### PR TITLE
Add tool execution waterfall view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,11 +28,13 @@ src/
     session.js         # Pure helpers: getSessionTotal, buildFilteredEventEntries, buildTurnStartMap
     replayLayout.js    # Estimated layout + binary search windowing for virtualized replay
     commandPalette.js  # Precomputed search index with scoring and per-type caps
+    waterfall.js       # Waterfall view helpers: item building, stats, layout, windowing
   components/
     FileUploader.jsx   # Drag-and-drop file input with error handling
     Timeline.jsx       # Scrubable playback bar with event markers, turn boundaries
     ReplayView.jsx     # Windowed event stream + resizable inspector sidebar
     TracksView.jsx     # DAW-style multi-track lanes with solo/mute
+    WaterfallView.jsx  # Tool execution waterfall with nesting, inspector sidebar
     StatsView.jsx      # Aggregate metrics, tool ranking, turn summary
     SessionHero.jsx    # Summary card shown after file load (sparkline, format badge, metrics)
     CommandPalette.jsx # Cmd+K fuzzy search overlay (events, turns, views)
@@ -66,7 +68,7 @@ Agent types: user, assistant, system
 ## Dev commands
 - `npm run dev` - Start dev server on port 3000
 - `npm run build` - Production build to dist/
-- `npm test` - Run 86 tests (40 Claude parser + 41 Copilot parser + 5 UX helpers) via Vitest
+- `npm test` - Run 109 tests (40 Claude parser + 41 Copilot parser + 5 UX helpers + 23 waterfall) via Vitest
 - `npm run test:watch` - Watch mode for tests
 
 ## Conventions

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,12 +11,14 @@ import Timeline from "./components/Timeline.jsx";
 import ReplayView from "./components/ReplayView.jsx";
 import TracksView from "./components/TracksView.jsx";
 import StatsView from "./components/StatsView.jsx";
+import WaterfallView from "./components/WaterfallView.jsx";
 import SessionHero from "./components/SessionHero.jsx";
 import CommandPalette from "./components/CommandPalette.jsx";
 
 var VIEWS = [
   { id: "replay", label: "Replay", icon: "\u25B6" },
   { id: "tracks", label: "Tracks", icon: "\u2261" },
+  { id: "waterfall", label: "Waterfall", icon: "\u2507" },
   { id: "stats", label: "Stats", icon: "\u25FB" },
 ];
 
@@ -623,6 +625,16 @@ export default function App() {
             eventEntries={filteredEventEntries}
             totalTime={session.total}
             turns={session.turns}
+          />
+        )}
+        {activeView === "waterfall" && (
+          <WaterfallView
+            currentTime={playback.time}
+            eventEntries={filteredEventEntries}
+            totalTime={session.total}
+            turns={session.turns}
+            metadata={session.metadata}
+            onSeek={playback.seek}
           />
         )}
         {activeView === "stats" && (

--- a/src/__tests__/waterfall.test.js
+++ b/src/__tests__/waterfall.test.js
@@ -1,0 +1,318 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildWaterfallItems,
+  getWaterfallStats,
+  buildWaterfallLayout,
+  getWaterfallWindow,
+  getToolColor,
+  WATERFALL_ROW_HEIGHT,
+  WATERFALL_ROW_GAP,
+} from "../lib/waterfall.js";
+
+// Helpers to create test events
+function makeEvent(overrides) {
+  return Object.assign({
+    t: 0,
+    agent: "assistant",
+    track: "tool_call",
+    text: "test tool",
+    duration: 1,
+    intensity: 0.6,
+    raw: {},
+    turnIndex: 0,
+    isError: false,
+    toolName: "bash",
+    toolInput: {},
+  }, overrides);
+}
+
+function makeNonToolEvent(overrides) {
+  return Object.assign({
+    t: 0,
+    agent: "assistant",
+    track: "reasoning",
+    text: "thinking...",
+    duration: 0.5,
+    intensity: 0.5,
+    raw: {},
+    turnIndex: 0,
+    isError: false,
+  }, overrides);
+}
+
+// ── buildWaterfallItems ──
+
+describe("buildWaterfallItems", function () {
+  it("returns empty array for empty events", function () {
+    expect(buildWaterfallItems([])).toEqual([]);
+    expect(buildWaterfallItems(null)).toEqual([]);
+    expect(buildWaterfallItems(undefined)).toEqual([]);
+  });
+
+  it("filters only tool_call events", function () {
+    var events = [
+      makeNonToolEvent({ t: 0 }),
+      makeEvent({ t: 1, toolName: "bash" }),
+      makeNonToolEvent({ t: 2, track: "output" }),
+      makeEvent({ t: 3, toolName: "grep" }),
+      makeNonToolEvent({ t: 4, track: "context" }),
+    ];
+
+    var items = buildWaterfallItems(events);
+    expect(items.length).toBe(2);
+    expect(items[0].event.toolName).toBe("bash");
+    expect(items[1].event.toolName).toBe("grep");
+  });
+
+  it("preserves original index from events array", function () {
+    var events = [
+      makeNonToolEvent({ t: 0 }),
+      makeNonToolEvent({ t: 0.5 }),
+      makeEvent({ t: 1, toolName: "bash" }),
+      makeNonToolEvent({ t: 1.5 }),
+      makeEvent({ t: 2, toolName: "grep" }),
+    ];
+
+    var items = buildWaterfallItems(events);
+    expect(items[0].originalIndex).toBe(2);
+    expect(items[1].originalIndex).toBe(4);
+  });
+
+  it("computes depth=0 for flat tool calls (no parentToolCallId)", function () {
+    var events = [
+      makeEvent({ t: 0, toolName: "bash" }),
+      makeEvent({ t: 1, toolName: "grep" }),
+      makeEvent({ t: 2, toolName: "view" }),
+    ];
+
+    var items = buildWaterfallItems(events);
+    expect(items.every(function (item) { return item.depth === 0; })).toBe(true);
+  });
+
+  it("computes correct nesting depth from parentToolCallId chains", function () {
+    var events = [
+      makeEvent({
+        t: 0,
+        toolName: "task",
+        raw: { data: { toolCallId: "tc-1" } },
+      }),
+      makeEvent({
+        t: 0.5,
+        toolName: "bash",
+        parentToolCallId: "tc-1",
+        raw: { data: { toolCallId: "tc-2", parentToolCallId: "tc-1" } },
+      }),
+      makeEvent({
+        t: 1,
+        toolName: "grep",
+        parentToolCallId: "tc-2",
+        raw: { data: { toolCallId: "tc-3", parentToolCallId: "tc-2" } },
+      }),
+    ];
+
+    var items = buildWaterfallItems(events);
+    expect(items[0].depth).toBe(0);
+    expect(items[1].depth).toBe(1);
+    expect(items[2].depth).toBe(2);
+  });
+
+  it("returns items sorted by start time", function () {
+    var events = [
+      makeEvent({ t: 3, toolName: "c" }),
+      makeEvent({ t: 1, toolName: "a" }),
+      makeEvent({ t: 2, toolName: "b" }),
+    ];
+
+    var items = buildWaterfallItems(events);
+    expect(items[0].event.toolName).toBe("a");
+    expect(items[1].event.toolName).toBe("b");
+    expect(items[2].event.toolName).toBe("c");
+  });
+
+  it("handles events with no raw data gracefully", function () {
+    var events = [
+      makeEvent({ t: 0, toolName: "bash", raw: null }),
+      makeEvent({ t: 1, toolName: "grep", raw: {} }),
+    ];
+
+    var items = buildWaterfallItems(events);
+    expect(items.length).toBe(2);
+    expect(items[0].depth).toBe(0);
+    expect(items[1].depth).toBe(0);
+  });
+});
+
+// ── getWaterfallStats ──
+
+describe("getWaterfallStats", function () {
+  it("returns zeros for empty items", function () {
+    var stats = getWaterfallStats([]);
+    expect(stats.totalCalls).toBe(0);
+    expect(stats.maxConcurrency).toBe(0);
+    expect(stats.maxDepth).toBe(0);
+    expect(stats.longestTool).toBe(null);
+  });
+
+  it("computes correct totals", function () {
+    var items = [
+      { event: makeEvent({ t: 0, duration: 2, toolName: "bash" }), depth: 0 },
+      { event: makeEvent({ t: 1, duration: 3, toolName: "grep" }), depth: 0 },
+      { event: makeEvent({ t: 5, duration: 1, toolName: "bash" }), depth: 0 },
+    ];
+
+    var stats = getWaterfallStats(items);
+    expect(stats.totalCalls).toBe(3);
+    expect(stats.longestTool).toBe("grep");
+    expect(stats.toolFrequency.bash).toBe(2);
+    expect(stats.toolFrequency.grep).toBe(1);
+  });
+
+  it("computes max concurrency correctly", function () {
+    // Three overlapping calls: [0-2], [0.5-1.5], [1-3]
+    var items = [
+      { event: makeEvent({ t: 0, duration: 2 }), depth: 0 },
+      { event: makeEvent({ t: 0.5, duration: 1 }), depth: 0 },
+      { event: makeEvent({ t: 1, duration: 2 }), depth: 0 },
+    ];
+
+    var stats = getWaterfallStats(items);
+    expect(stats.maxConcurrency).toBe(3);
+  });
+
+  it("computes max concurrency of 1 for sequential calls", function () {
+    var items = [
+      { event: makeEvent({ t: 0, duration: 1 }), depth: 0 },
+      { event: makeEvent({ t: 2, duration: 1 }), depth: 0 },
+      { event: makeEvent({ t: 4, duration: 1 }), depth: 0 },
+    ];
+
+    var stats = getWaterfallStats(items);
+    expect(stats.maxConcurrency).toBe(1);
+  });
+
+  it("reports max depth", function () {
+    var items = [
+      { event: makeEvent({ t: 0 }), depth: 0 },
+      { event: makeEvent({ t: 1 }), depth: 1 },
+      { event: makeEvent({ t: 2 }), depth: 3 },
+    ];
+
+    var stats = getWaterfallStats(items);
+    expect(stats.maxDepth).toBe(3);
+  });
+});
+
+// ── buildWaterfallLayout ──
+
+describe("buildWaterfallLayout", function () {
+  it("returns empty layout for empty items", function () {
+    var layout = buildWaterfallLayout([]);
+    expect(layout.layoutItems).toEqual([]);
+    expect(layout.totalHeight).toBe(0);
+  });
+
+  it("positions items sequentially with correct heights", function () {
+    var items = [
+      { event: makeEvent({ t: 0 }), depth: 0, originalIndex: 0 },
+      { event: makeEvent({ t: 1 }), depth: 0, originalIndex: 1 },
+      { event: makeEvent({ t: 2 }), depth: 0, originalIndex: 2 },
+    ];
+
+    var layout = buildWaterfallLayout(items);
+    expect(layout.layoutItems.length).toBe(3);
+    expect(layout.layoutItems[0].top).toBe(0);
+    expect(layout.layoutItems[0].height).toBe(WATERFALL_ROW_HEIGHT);
+    expect(layout.layoutItems[1].top).toBe(WATERFALL_ROW_HEIGHT + WATERFALL_ROW_GAP);
+    expect(layout.layoutItems[2].top).toBe(2 * (WATERFALL_ROW_HEIGHT + WATERFALL_ROW_GAP));
+  });
+
+  it("computes total height correctly", function () {
+    var items = [
+      { event: makeEvent({ t: 0 }), depth: 0, originalIndex: 0 },
+      { event: makeEvent({ t: 1 }), depth: 0, originalIndex: 1 },
+    ];
+
+    var layout = buildWaterfallLayout(items);
+    var expected = 2 * WATERFALL_ROW_HEIGHT + 2 * WATERFALL_ROW_GAP;
+    expect(layout.totalHeight).toBe(expected);
+  });
+});
+
+// ── getWaterfallWindow ──
+
+describe("getWaterfallWindow", function () {
+  function makeLayoutItems(count) {
+    var items = [];
+    var top = 0;
+    for (var i = 0; i < count; i++) {
+      items.push({
+        item: { event: makeEvent({ t: i }), depth: 0, originalIndex: i },
+        top: top,
+        height: WATERFALL_ROW_HEIGHT,
+      });
+      top += WATERFALL_ROW_HEIGHT + WATERFALL_ROW_GAP;
+    }
+    return items;
+  }
+
+  it("returns empty for empty items", function () {
+    expect(getWaterfallWindow([], 0, 500)).toEqual([]);
+    expect(getWaterfallWindow(null, 0, 500)).toEqual([]);
+  });
+
+  it("returns all items when they fit in viewport", function () {
+    var items = makeLayoutItems(5);
+    var result = getWaterfallWindow(items, 0, 2000, 0);
+    expect(result.length).toBe(5);
+  });
+
+  it("returns correct windowed slice for scroll position", function () {
+    var items = makeLayoutItems(100);
+    // Each row is 32+2=34px, so 10 items = 340px
+    // Scroll to 340px (past first 10 items), viewport 170px (5 items), no overscan
+    var result = getWaterfallWindow(items, 340, 170, 0);
+    expect(result.length).toBeGreaterThanOrEqual(5);
+    expect(result[0].item.originalIndex).toBe(10);
+  });
+
+  it("includes overscan items", function () {
+    var items = makeLayoutItems(100);
+    var rowSize = WATERFALL_ROW_HEIGHT + WATERFALL_ROW_GAP;
+    // Scroll to row 50, viewport 5 rows, overscan 3 rows
+    var result = getWaterfallWindow(items, 50 * rowSize, 5 * rowSize, 3 * rowSize);
+    // Should include items before and after the visible range
+    expect(result[0].item.originalIndex).toBeLessThanOrEqual(47);
+    expect(result[result.length - 1].item.originalIndex).toBeGreaterThanOrEqual(55);
+  });
+});
+
+// ── getToolColor ──
+
+describe("getToolColor", function () {
+  it("returns a string color for any tool name", function () {
+    expect(typeof getToolColor("bash")).toBe("string");
+    expect(getToolColor("bash").startsWith("#")).toBe(true);
+  });
+
+  it("returns consistent color for same tool name", function () {
+    expect(getToolColor("grep")).toBe(getToolColor("grep"));
+  });
+
+  it("returns different colors for different tool names (usually)", function () {
+    // Not guaranteed for all pairs, but very likely for these
+    var colors = new Set([
+      getToolColor("bash"),
+      getToolColor("grep"),
+      getToolColor("view"),
+      getToolColor("edit"),
+      getToolColor("create"),
+    ]);
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
+  it("handles null/undefined/empty gracefully", function () {
+    expect(typeof getToolColor(null)).toBe("string");
+    expect(typeof getToolColor(undefined)).toBe("string");
+    expect(typeof getToolColor("")).toBe("string");
+  });
+});

--- a/src/components/WaterfallView.jsx
+++ b/src/components/WaterfallView.jsx
@@ -1,0 +1,571 @@
+import { useState, useRef, useMemo, useCallback, useEffect } from "react";
+import { theme, alpha } from "../lib/theme.js";
+import {
+  buildWaterfallItems,
+  getWaterfallStats,
+  buildWaterfallLayout,
+  getWaterfallWindow,
+  getToolColor,
+  WATERFALL_ROW_HEIGHT,
+} from "../lib/waterfall.js";
+import ResizablePanel from "./ResizablePanel.jsx";
+import SyntaxHighlight from "./SyntaxHighlight.jsx";
+
+var OVERSCAN_PX = 400;
+var INDENT_PX = 20;
+var LABEL_WIDTH = 180;
+var MIN_BAR_WIDTH_PX = 4;
+var TIME_AXIS_HEIGHT = 28;
+
+function formatDuration(seconds) {
+  if (seconds < 0.01) return "<10ms";
+  if (seconds < 1) return (seconds * 1000).toFixed(0) + "ms";
+  if (seconds < 60) return seconds.toFixed(1) + "s";
+  return (seconds / 60).toFixed(1) + "m";
+}
+
+function formatTime(seconds) {
+  if (seconds < 60) return seconds.toFixed(1) + "s";
+  var m = Math.floor(seconds / 60);
+  var s = (seconds % 60).toFixed(0);
+  return m + ":" + (s < 10 ? "0" : "") + s;
+}
+
+function TimeAxis({ totalTime, chartWidth }) {
+  if (totalTime <= 0 || chartWidth <= 0) return null;
+
+  // Compute tick interval: aim for ticks every ~80-120px
+  var rawInterval = (totalTime / chartWidth) * 100;
+  var niceIntervals = [0.1, 0.25, 0.5, 1, 2, 5, 10, 15, 30, 60, 120, 300, 600];
+  var interval = niceIntervals[0];
+  for (var i = 0; i < niceIntervals.length; i++) {
+    if (niceIntervals[i] >= rawInterval) {
+      interval = niceIntervals[i];
+      break;
+    }
+  }
+
+  var ticks = [];
+  for (var t = 0; t <= totalTime; t += interval) {
+    ticks.push(t);
+  }
+
+  return (
+    <div style={{
+      height: TIME_AXIS_HEIGHT,
+      position: "relative",
+      borderBottom: "1px solid " + theme.border.default,
+      flexShrink: 0,
+    }}>
+      {ticks.map(function (tick) {
+        var left = (tick / totalTime) * 100;
+        return (
+          <div key={tick} style={{
+            position: "absolute",
+            left: left + "%",
+            top: 0,
+            bottom: 0,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+          }}>
+            <div style={{
+              width: 1,
+              flex: 1,
+              background: theme.border.subtle,
+            }} />
+            <span style={{
+              fontSize: theme.fontSize.xs,
+              color: theme.text.dim,
+              padding: "0 2px",
+              whiteSpace: "nowrap",
+            }}>
+              {formatTime(tick)}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function WaterfallInspector({ selectedItem, stats }) {
+  var selected = selectedItem ? selectedItem.event : null;
+
+  return (
+    <div style={{
+      height: "100%",
+      overflow: "auto",
+      background: theme.bg.surface,
+      padding: theme.space.lg,
+      display: "flex",
+      flexDirection: "column",
+      gap: theme.space.lg,
+    }}>
+      {/* Stats section */}
+      <div>
+        <div style={{
+          fontSize: theme.fontSize.xs,
+          color: theme.text.dim,
+          textTransform: "uppercase",
+          letterSpacing: 1,
+          marginBottom: theme.space.md,
+        }}>
+          Waterfall Stats
+        </div>
+        <div style={{ display: "flex", flexDirection: "column", gap: theme.space.sm }}>
+          {[
+            ["Total calls", stats.totalCalls],
+            ["Max concurrency", stats.maxConcurrency],
+            ["Max depth", stats.maxDepth],
+            ["Longest tool", stats.longestTool || "n/a"],
+          ].map(function (pair) {
+            return (
+              <div key={pair[0]} style={{
+                display: "flex",
+                justifyContent: "space-between",
+                fontSize: theme.fontSize.sm,
+              }}>
+                <span style={{ color: theme.text.muted }}>{pair[0]}</span>
+                <span style={{ color: theme.text.primary }}>{pair[1]}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Tool frequency ranking */}
+      {stats.totalCalls > 0 && (
+        <div>
+          <div style={{
+            fontSize: theme.fontSize.xs,
+            color: theme.text.dim,
+            textTransform: "uppercase",
+            letterSpacing: 1,
+            marginBottom: theme.space.md,
+          }}>
+            Tool Frequency
+          </div>
+          <div style={{ display: "flex", flexDirection: "column", gap: theme.space.xs }}>
+            {Object.entries(stats.toolFrequency)
+              .sort(function (a, b) { return b[1] - a[1]; })
+              .slice(0, 15)
+              .map(function (entry) {
+                var name = entry[0];
+                var count = entry[1];
+                var pct = stats.totalCalls > 0 ? (count / stats.totalCalls) * 100 : 0;
+                var color = getToolColor(name);
+
+                return (
+                  <div key={name} style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: theme.space.sm,
+                    fontSize: theme.fontSize.sm,
+                  }}>
+                    <div style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: color,
+                      flexShrink: 0,
+                    }} />
+                    <span style={{
+                      color: theme.text.secondary,
+                      flex: 1,
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      whiteSpace: "nowrap",
+                    }}>
+                      {name}
+                    </span>
+                    <span style={{ color: theme.text.dim, flexShrink: 0 }}>
+                      {count}
+                    </span>
+                    <div style={{
+                      width: 40,
+                      height: 3,
+                      background: theme.bg.raised,
+                      borderRadius: 2,
+                      flexShrink: 0,
+                      overflow: "hidden",
+                    }}>
+                      <div style={{
+                        width: pct + "%",
+                        height: "100%",
+                        background: color,
+                        borderRadius: 2,
+                      }} />
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      )}
+
+      {/* Selected tool details */}
+      {selected && (
+        <div>
+          <div style={{
+            fontSize: theme.fontSize.xs,
+            color: theme.text.dim,
+            textTransform: "uppercase",
+            letterSpacing: 1,
+            marginBottom: theme.space.md,
+          }}>
+            Selected Tool
+          </div>
+          <div style={{
+            background: theme.bg.raised,
+            borderRadius: theme.radius.lg,
+            padding: theme.space.lg,
+            border: "1px solid " + theme.border.default,
+          }}>
+            <div style={{
+              fontSize: theme.fontSize.md,
+              color: getToolColor(selected.toolName),
+              fontWeight: 600,
+              marginBottom: theme.space.md,
+            }}>
+              {selected.toolName || "Unknown Tool"}
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: theme.space.sm }}>
+              {[
+                ["Time", formatTime(selected.t)],
+                ["Duration", formatDuration(selected.duration)],
+                ["Turn", selected.turnIndex !== undefined ? selected.turnIndex + 1 : "n/a"],
+                ["Agent", selected.agent],
+                selected.model ? ["Model", selected.model] : null,
+                selectedItem && selectedItem.depth > 0 ? ["Depth", selectedItem.depth] : null,
+                selected.isError ? ["Status", "ERROR"] : null,
+              ].filter(Boolean).map(function (pair) {
+                var isError = pair[0] === "Status";
+                return (
+                  <div key={pair[0]} style={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    fontSize: theme.fontSize.sm,
+                  }}>
+                    <span style={{ color: theme.text.muted }}>{pair[0]}</span>
+                    <span style={{ color: isError ? theme.error : theme.text.primary }}>{pair[1]}</span>
+                  </div>
+                );
+              })}
+            </div>
+
+            {selected.toolInput && (
+              <div style={{ marginTop: theme.space.lg }}>
+                <div style={{
+                  fontSize: theme.fontSize.xs,
+                  color: theme.text.dim,
+                  marginBottom: theme.space.sm,
+                }}>
+                  Input
+                </div>
+                <SyntaxHighlight
+                  text={typeof selected.toolInput === "string"
+                    ? selected.toolInput
+                    : JSON.stringify(selected.toolInput, null, 2)}
+                  maxLines={30}
+                />
+              </div>
+            )}
+
+            {selected.raw && selected.raw.data && (
+              <div style={{ marginTop: theme.space.lg }}>
+                <div style={{
+                  fontSize: theme.fontSize.xs,
+                  color: theme.text.dim,
+                  marginBottom: theme.space.sm,
+                }}>
+                  Raw
+                </div>
+                <SyntaxHighlight
+                  text={JSON.stringify(selected.raw.data, null, 2)}
+                  maxLines={20}
+                />
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!selected && stats.totalCalls > 0 && (
+        <div style={{
+          fontSize: theme.fontSize.sm,
+          color: theme.text.dim,
+          fontStyle: "italic",
+          marginTop: theme.space.md,
+        }}>
+          Click a tool bar to inspect details
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function WaterfallView({ currentTime, eventEntries, totalTime, turns, metadata, onSeek }) {
+  var [selectedIdx, setSelectedIdx] = useState(null);
+  var [hoveredIdx, setHoveredIdx] = useState(null);
+  var scrollRef = useRef(null);
+  var chartRef = useRef(null);
+  var [scrollTop, setScrollTop] = useState(0);
+  var [viewportHeight, setViewportHeight] = useState(600);
+
+  // Extract all events from entries
+  var allEvents = useMemo(function () {
+    return eventEntries.map(function (entry) { return entry.event; });
+  }, [eventEntries]);
+
+  var items = useMemo(function () {
+    return buildWaterfallItems(allEvents);
+  }, [allEvents]);
+
+  var stats = useMemo(function () {
+    return getWaterfallStats(items);
+  }, [items]);
+
+  var layout = useMemo(function () {
+    return buildWaterfallLayout(items);
+  }, [items]);
+
+  var visibleItems = useMemo(function () {
+    return getWaterfallWindow(layout.layoutItems, scrollTop, viewportHeight, OVERSCAN_PX);
+  }, [layout.layoutItems, scrollTop, viewportHeight]);
+
+  var selectedItem = useMemo(function () {
+    if (selectedIdx === null || !items[selectedIdx]) return null;
+    return items[selectedIdx];
+  }, [selectedIdx, items]);
+
+  var handleScroll = useCallback(function () {
+    if (scrollRef.current) {
+      setScrollTop(scrollRef.current.scrollTop);
+    }
+  }, []);
+
+  useEffect(function () {
+    if (!scrollRef.current) return;
+    var observer = new ResizeObserver(function (entries) {
+      if (entries[0]) {
+        setViewportHeight(entries[0].contentRect.height);
+      }
+    });
+    observer.observe(scrollRef.current);
+    return function () { observer.disconnect(); };
+  }, []);
+
+  var playPct = totalTime > 0 ? (currentTime / totalTime) * 100 : 0;
+
+  if (items.length === 0) {
+    return (
+      <div style={{
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        color: theme.text.dim,
+        fontSize: theme.fontSize.md,
+        fontStyle: "italic",
+      }}>
+        No tool calls to display
+      </div>
+    );
+  }
+
+  return (
+    <ResizablePanel
+      initialSplit={0.72}
+      minPx={200}
+      direction="horizontal"
+      storageKey="agentviz:waterfall-panel-split"
+    >
+      {/* Left panel: waterfall chart */}
+      <div style={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        background: theme.bg.base,
+        borderRadius: theme.radius.lg,
+        border: "1px solid " + theme.border.default,
+        overflow: "hidden",
+      }}>
+        <TimeAxis
+          totalTime={totalTime}
+          chartWidth={800}
+        />
+
+        <div
+          ref={scrollRef}
+          onScroll={handleScroll}
+          style={{
+            flex: 1,
+            overflow: "auto",
+            position: "relative",
+          }}
+        >
+          <div style={{
+            height: layout.totalHeight,
+            position: "relative",
+            minHeight: "100%",
+          }}>
+            {/* Turn boundary vertical lines */}
+            {turns && turns.map(function (turn, ti) {
+              if (ti === 0) return null;
+              var left = totalTime > 0 ? (turn.startTime / totalTime) * 100 : 0;
+              return (
+                <div key={"tb-" + ti} style={{
+                  position: "absolute",
+                  left: "calc(" + LABEL_WIDTH + "px + " + left + "% * (100% - " + LABEL_WIDTH + "px) / 100)",
+                  top: 0,
+                  bottom: 0,
+                  width: 1,
+                  background: theme.border.subtle,
+                  zIndex: 0,
+                  pointerEvents: "none",
+                }} />
+              );
+            })}
+
+            {/* Playhead */}
+            <div style={{
+              position: "absolute",
+              left: "calc(" + LABEL_WIDTH + "px + " + playPct + "% * (100% - " + LABEL_WIDTH + "px) / 100)",
+              top: 0,
+              bottom: 0,
+              width: 2,
+              background: theme.accent.cyan,
+              boxShadow: "0 0 6px " + theme.accent.cyan,
+              zIndex: theme.z.playhead,
+              transition: "left 0.08s linear",
+              pointerEvents: "none",
+            }} />
+
+            {/* Waterfall rows */}
+            {visibleItems.map(function (layoutItem, vi) {
+              var item = layoutItem.item;
+              var ev = item.event;
+              var idx = items.indexOf(item);
+              var isSelected = selectedIdx === idx;
+              var isHovered = hoveredIdx === idx;
+              var isActive = currentTime >= ev.t && currentTime <= ev.t + ev.duration;
+              var barColor = ev.isError ? theme.error : getToolColor(ev.toolName);
+              var indent = item.depth * INDENT_PX;
+
+              var barLeft = totalTime > 0 ? (ev.t / totalTime) * 100 : 0;
+              var barWidth = totalTime > 0 ? (ev.duration / totalTime) * 100 : 0;
+
+              return (
+                <div
+                  key={item.originalIndex}
+                  onClick={function () { setSelectedIdx(isSelected ? null : idx); }}
+                  onMouseEnter={function () { setHoveredIdx(idx); }}
+                  onMouseLeave={function () { setHoveredIdx(null); }}
+                  style={{
+                    position: "absolute",
+                    top: layoutItem.top,
+                    left: 0,
+                    right: 0,
+                    height: WATERFALL_ROW_HEIGHT,
+                    display: "flex",
+                    alignItems: "center",
+                    cursor: "pointer",
+                    background: isSelected
+                      ? alpha(barColor, 0.08)
+                      : isHovered
+                        ? theme.bg.hover
+                        : "transparent",
+                    borderLeft: isSelected ? "2px solid " + barColor : "2px solid transparent",
+                    transition: "background " + theme.transition.fast,
+                  }}
+                >
+                  {/* Tool name label */}
+                  <div style={{
+                    width: LABEL_WIDTH,
+                    flexShrink: 0,
+                    paddingLeft: theme.space.md + indent,
+                    paddingRight: theme.space.sm,
+                    display: "flex",
+                    alignItems: "center",
+                    gap: theme.space.sm,
+                    overflow: "hidden",
+                    borderRight: "1px solid " + theme.border.subtle,
+                  }}>
+                    <div style={{
+                      width: 6,
+                      height: 6,
+                      borderRadius: "50%",
+                      background: barColor,
+                      flexShrink: 0,
+                    }} />
+                    <span style={{
+                      fontSize: theme.fontSize.sm,
+                      color: ev.isError ? theme.errorText : theme.text.secondary,
+                      whiteSpace: "nowrap",
+                      overflow: "hidden",
+                      textOverflow: "ellipsis",
+                      fontWeight: isSelected ? 600 : 400,
+                    }}>
+                      {ev.toolName || "tool"}
+                    </span>
+                  </div>
+
+                  {/* Bar area */}
+                  <div ref={vi === 0 ? chartRef : undefined} style={{
+                    flex: 1,
+                    position: "relative",
+                    height: "100%",
+                  }}>
+                    <div style={{
+                      position: "absolute",
+                      left: barLeft + "%",
+                      width: "max(" + MIN_BAR_WIDTH_PX + "px, " + barWidth + "%)",
+                      top: 4,
+                      bottom: 4,
+                      borderRadius: theme.radius.sm,
+                      background: "linear-gradient(90deg, " + alpha(barColor, 0.7) + ", " + alpha(barColor, 0.45) + ")",
+                      border: "1px solid " + (isActive || isSelected
+                        ? barColor
+                        : alpha(barColor, 0.3)),
+                      boxShadow: isActive
+                        ? "0 0 8px " + alpha(barColor, 0.3)
+                        : isSelected
+                          ? "0 0 6px " + alpha(barColor, 0.2)
+                          : "none",
+                      display: "flex",
+                      alignItems: "center",
+                      padding: "0 4px",
+                      overflow: "hidden",
+                      transition: "border-color " + theme.transition.fast + ", box-shadow " + theme.transition.fast,
+                    }}>
+                      {ev.isError && (
+                        <span style={{ fontSize: 8, marginRight: 2, color: theme.error }}>{"\u25CF"}</span>
+                      )}
+                      <span style={{
+                        fontSize: theme.fontSize.xs,
+                        color: theme.text.primary,
+                        whiteSpace: "nowrap",
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        opacity: 0.85,
+                      }}>
+                        {formatDuration(ev.duration)}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* Right panel: inspector */}
+      <WaterfallInspector
+        selectedItem={selectedItem}
+        stats={stats}
+      />
+    </ResizablePanel>
+  );
+}

--- a/src/lib/waterfall.js
+++ b/src/lib/waterfall.js
@@ -1,0 +1,246 @@
+/**
+ * Waterfall view data helpers.
+ *
+ * Transforms normalized events into a flat list of tool-call items
+ * with nesting depth (from parentToolCallId), plus summary stats
+ * and binary-search windowing for virtualized rendering.
+ */
+
+var WATERFALL_ROW_HEIGHT = 32;
+var WATERFALL_ROW_GAP = 2;
+
+// Stable color palette for tool names (rotates through theme accents)
+var TOOL_PALETTE = [
+  "#f59e0b", // amber
+  "#22d3ee", // cyan
+  "#a78bfa", // purple
+  "#34d399", // green
+  "#60a5fa", // blue
+  "#f472b6", // pink
+  "#fb923c", // orange
+  "#818cf8", // indigo
+  "#fbbf24", // yellow
+  "#2dd4bf", // teal
+];
+
+function hashToolName(name) {
+  if (!name) return 0;
+  var h = 0;
+  for (var i = 0; i < name.length; i++) {
+    h = ((h << 5) - h + name.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+export function getToolColor(toolName) {
+  return TOOL_PALETTE[hashToolName(toolName) % TOOL_PALETTE.length];
+}
+
+/**
+ * Build waterfall items from normalized events.
+ * Filters to track === "tool_call", computes nesting depth from
+ * parentToolCallId chains, and returns items sorted by start time.
+ *
+ * Each item: { event, originalIndex, depth, parentToolCallId }
+ */
+export function buildWaterfallItems(events) {
+  if (!events || events.length === 0) return [];
+
+  // First pass: collect all tool_call events with their original index
+  var toolEvents = [];
+  for (var i = 0; i < events.length; i++) {
+    if (events[i].track === "tool_call") {
+      toolEvents.push({ event: events[i], originalIndex: i });
+    }
+  }
+
+  if (toolEvents.length === 0) return [];
+
+  // Build a lookup from toolCallId to its parent for depth computation.
+  // toolCallId lives in raw.data.toolCallId for Copilot CLI events.
+  var parentMap = {};
+  var idToItem = {};
+
+  for (var j = 0; j < toolEvents.length; j++) {
+    var ev = toolEvents[j].event;
+    var raw = ev.raw;
+    var toolCallId = raw && raw.data ? raw.data.toolCallId : null;
+    var parentId = ev.parentToolCallId || null;
+
+    if (toolCallId) {
+      idToItem[toolCallId] = toolEvents[j];
+      if (parentId) {
+        parentMap[toolCallId] = parentId;
+      }
+    }
+  }
+
+  // Compute depth by walking parent chain
+  var depthCache = {};
+  function getDepth(toolCallId) {
+    if (!toolCallId) return 0;
+    if (depthCache[toolCallId] !== undefined) return depthCache[toolCallId];
+
+    var parent = parentMap[toolCallId];
+    if (!parent || !idToItem[parent]) {
+      depthCache[toolCallId] = 0;
+      return 0;
+    }
+    // Guard against cycles
+    depthCache[toolCallId] = 0;
+    depthCache[toolCallId] = getDepth(parent) + 1;
+    return depthCache[toolCallId];
+  }
+
+  // Build final items
+  var items = [];
+  for (var k = 0; k < toolEvents.length; k++) {
+    var te = toolEvents[k];
+    var r = te.event.raw;
+    var tcId = r && r.data ? r.data.toolCallId : null;
+    var depth = tcId ? getDepth(tcId) : 0;
+
+    items.push({
+      event: te.event,
+      originalIndex: te.originalIndex,
+      depth: depth,
+      parentToolCallId: te.event.parentToolCallId || null,
+    });
+  }
+
+  // Sort by start time (should already be sorted, but be safe)
+  items.sort(function (a, b) { return a.event.t - b.event.t; });
+
+  return items;
+}
+
+/**
+ * Compute summary stats for waterfall items.
+ */
+export function getWaterfallStats(items) {
+  if (!items || items.length === 0) {
+    return {
+      totalCalls: 0,
+      maxConcurrency: 0,
+      maxDepth: 0,
+      longestTool: null,
+      toolFrequency: {},
+    };
+  }
+
+  var maxDepth = 0;
+  var longestDuration = 0;
+  var longestTool = null;
+  var toolFrequency = {};
+
+  // Build timeline events for concurrency calculation
+  var timeline = [];
+
+  for (var i = 0; i < items.length; i++) {
+    var item = items[i];
+    var ev = item.event;
+
+    if (item.depth > maxDepth) maxDepth = item.depth;
+
+    if (ev.duration > longestDuration) {
+      longestDuration = ev.duration;
+      longestTool = ev.toolName || "unknown";
+    }
+
+    var name = ev.toolName || "unknown";
+    toolFrequency[name] = (toolFrequency[name] || 0) + 1;
+
+    timeline.push({ time: ev.t, delta: 1 });
+    timeline.push({ time: ev.t + ev.duration, delta: -1 });
+  }
+
+  // Sort timeline events and sweep for max concurrency
+  timeline.sort(function (a, b) {
+    return a.time !== b.time ? a.time - b.time : a.delta - b.delta;
+  });
+
+  var concurrent = 0;
+  var maxConcurrency = 0;
+  for (var j = 0; j < timeline.length; j++) {
+    concurrent += timeline[j].delta;
+    if (concurrent > maxConcurrency) maxConcurrency = concurrent;
+  }
+
+  return {
+    totalCalls: items.length,
+    maxConcurrency: maxConcurrency,
+    maxDepth: maxDepth,
+    longestTool: longestTool,
+    toolFrequency: toolFrequency,
+  };
+}
+
+/**
+ * Build layout positions for waterfall items (for virtualized rendering).
+ * Returns { layoutItems, totalHeight } where each layoutItem has { item, top, height }.
+ */
+export function buildWaterfallLayout(items) {
+  if (!items || items.length === 0) return { layoutItems: [], totalHeight: 0 };
+
+  var top = 0;
+  var layoutItems = [];
+
+  for (var i = 0; i < items.length; i++) {
+    layoutItems.push({
+      item: items[i],
+      top: top,
+      height: WATERFALL_ROW_HEIGHT,
+    });
+    top += WATERFALL_ROW_HEIGHT + WATERFALL_ROW_GAP;
+  }
+
+  return { layoutItems: layoutItems, totalHeight: top };
+}
+
+/**
+ * Binary search windowing for waterfall layout items.
+ * Returns only items visible within scrollTop..scrollTop+viewportHeight + overscan.
+ */
+export function getWaterfallWindow(layoutItems, scrollTop, viewportHeight, overscanPx) {
+  if (!layoutItems || layoutItems.length === 0) return [];
+  if (overscanPx === undefined || overscanPx === null) overscanPx = 200;
+
+  var targetTop = Math.max(0, scrollTop - overscanPx);
+  var targetBottom = scrollTop + viewportHeight + overscanPx;
+
+  // Binary search for first visible item
+  var low = 0;
+  var high = layoutItems.length - 1;
+  var startIdx = layoutItems.length;
+
+  while (low <= high) {
+    var mid = Math.floor((low + high) / 2);
+    if (layoutItems[mid].top + layoutItems[mid].height >= targetTop) {
+      startIdx = mid;
+      high = mid - 1;
+    } else {
+      low = mid + 1;
+    }
+  }
+
+  // Binary search for last visible item
+  low = startIdx;
+  high = layoutItems.length - 1;
+  var endIdx = -1;
+
+  while (low <= high) {
+    var mid2 = Math.floor((low + high) / 2);
+    if (layoutItems[mid2].top <= targetBottom) {
+      endIdx = mid2;
+      low = mid2 + 1;
+    } else {
+      high = mid2 - 1;
+    }
+  }
+
+  if (startIdx >= layoutItems.length || endIdx < startIdx) return [];
+
+  return layoutItems.slice(startIdx, endIdx + 1);
+}
+
+export { WATERFALL_ROW_HEIGHT, WATERFALL_ROW_GAP };


### PR DESCRIPTION
## Motivation

AgentViz can show session events as a replay stream or DAW-style tracks, but there's no way to see the temporal relationships between tool calls -- which ran in parallel, how long each took, or how sub-agent tools nest inside parent calls. A waterfall view makes these patterns immediately visible.

## Approach

Adds a new **Waterfall** tab (between Tracks and Stats) that renders every tool call as a horizontal bar on a shared time axis, with a detail inspector sidebar.

**Data layer** (`src/lib/waterfall.js`):
- `buildWaterfallItems` filters to `track === "tool_call"` events and computes nesting depth by walking `parentToolCallId` chains (Copilot CLI format). Claude Code sessions render flat (depth 0) since they lack parent/child info.
- `getWaterfallStats` computes summary metrics including max concurrency (via timeline sweep), max nesting depth, longest tool, and frequency ranking.
- `buildWaterfallLayout` + `getWaterfallWindow` provide the same binary-search virtualized windowing pattern used by ReplayView, keeping large sessions performant.

**View component** (`src/components/WaterfallView.jsx`):
- Left panel: time axis header, tool name labels with depth indentation, percentage-positioned bars colored by tool name (hashed to a 10-color accent palette), playhead + turn boundary lines
- Right panel (ResizablePanel): waterfall stats, tool frequency ranking with mini bar charts, and a click-to-inspect detail card with tool input/raw JSON via SyntaxHighlight
- Empty state when session has no tool calls

**Integration** (`src/App.jsx`):
- Registered in the VIEWS array with icon `┇`
- Receives same props as other views plus `onSeek` for time axis interaction

## Testing

23 new unit tests covering:
- Item filtering (only tool_call events), original index preservation
- Depth computation for flat and nested parent/child chains
- Time sorting, null/missing raw data edge cases
- Stats: totals, concurrency detection, sequential vs overlapping calls
- Layout positioning and total height calculation
- Binary search windowing with and without overscan

All 109 tests pass. Production build clean.