### PR TITLE
Fix empty replay view for Copilot CLI sessions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useMemo } from "react";
+import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { theme, TRACK_TYPES, alpha } from "./lib/theme.js";
 import { buildFilteredEventEntries, buildTurnStartMap } from "./lib/session.js";
 import usePersistentState from "./hooks/usePersistentState.js";
@@ -46,6 +46,13 @@ export default function App() {
   }, [session.turns]);
 
   var search = useSearch(filteredEventEntries);
+
+  // Auto-seek to first event when a new session loads so content is immediately visible
+  useEffect(function () {
+    if (session.firstEventTime > 0) {
+      playback.seek(session.firstEventTime);
+    }
+  }, [session.firstEventTime]);
 
   var activeView = VIEWS.some(function (item) { return item.id === view; }) ? view : "replay";
 

--- a/src/hooks/useSessionLoader.js
+++ b/src/hooks/useSessionLoader.js
@@ -8,6 +8,7 @@ export default function useSessionLoader() {
   var [turns, setTurns] = useState([]);
   var [metadata, setMetadata] = useState(null);
   var [total, setTotal] = useState(0);
+  var [firstEventTime, setFirstEventTime] = useState(0);
   var [file, setFile] = useState("");
   var [error, setError] = useState(null);
   var [loading, setLoading] = useState(false);
@@ -18,6 +19,7 @@ export default function useSessionLoader() {
     setTurns(result.turns);
     setMetadata(result.metadata);
     setTotal(getSessionTotal(result.events));
+    setFirstEventTime(result.events.length > 0 ? result.events[0].t : 0);
     setFile(name);
     setError(null);
     setShowHero(true);
@@ -55,6 +57,7 @@ export default function useSessionLoader() {
     setTurns([]);
     setMetadata(null);
     setTotal(0);
+    setFirstEventTime(0);
     setFile("");
     setError(null);
     setLoading(false);
@@ -70,6 +73,7 @@ export default function useSessionLoader() {
     turns: turns,
     metadata: metadata,
     total: total,
+    firstEventTime: firstEventTime,
     file: file,
     error: error,
     loading: loading,


### PR DESCRIPTION
## Problem

Loading a Copilot CLI session file shows the correct event count in the header (e.g. "55 events / 34 tools / 12 turns") but the Replay view renders completely empty with no events visible.

This happens because Copilot CLI sessions have a gap between the `session.start` timestamp (t=0) and the first `user.message` (e.g. t=26s). Since playback always initialized at `time=0`, the ReplayView filter (`event.t <= currentTime`) excluded every event.

## Approach

Rather than changing the filter logic or the parser's timestamp calculation, the fix auto-seeks playback to the first event's timestamp when a new session loads:

- **`useSessionLoader.js`** — tracks `firstEventTime` from parsed events and exposes it alongside other session state
- **`App.jsx`** — a `useEffect` watches `firstEventTime` and calls `playback.seek()` so events are immediately visible after load

This keeps the timeline accurate (the session truly does start at t=0) while ensuring the user sees content right away.

## Testing

All 109 existing tests pass. Build succeeds.