### PR TITLE
Fix replay view to show all events on session load

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -47,12 +47,12 @@ export default function App() {
 
   var search = useSearch(filteredEventEntries);
 
-  // Auto-seek to first event when a new session loads so content is immediately visible
+  // Auto-seek to end of session when loaded so all events are immediately visible
   useEffect(function () {
-    if (session.firstEventTime > 0) {
-      playback.seek(session.firstEventTime);
+    if (session.total > 0) {
+      playback.seek(session.total);
     }
-  }, [session.firstEventTime]);
+  }, [session.total]);
 
   var activeView = VIEWS.some(function (item) { return item.id === view; }) ? view : "replay";
 


### PR DESCRIPTION
## Problem

PR #3 attempted to fix the empty Replay view for Copilot CLI sessions by auto-seeking to `firstEventTime` (~26s). However, this only revealed **1 event** since ReplayView filters events by `event.t <= currentTime` -- seeking to the first event's timestamp only includes that single event.

## Fix

Seek to `session.total` (end of session) instead of `firstEventTime`, so all events are immediately visible when a session loads. This matches the expected behavior: load a file, see all events.

Verified with:
- **Copilot CLI test file** (55 events, 26,519s duration) -- all events visible
- **Demo session** (13 events, 25s duration) -- all events visible
- All 109 tests pass, build succeeds