### PR TITLE
Compress timeline display for sessions with large idle gaps

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useMemo, useEffect } from "react";
 import { theme, TRACK_TYPES, alpha } from "./lib/theme.js";
-import { buildFilteredEventEntries, buildTurnStartMap } from "./lib/session.js";
+import { buildFilteredEventEntries, buildTurnStartMap, buildTimeMap } from "./lib/session.js";
 import usePersistentState from "./hooks/usePersistentState.js";
 import useSessionLoader from "./hooks/useSessionLoader.js";
 import usePlayback from "./hooks/usePlayback.js";
@@ -44,6 +44,10 @@ export default function App() {
   var turnStartMap = useMemo(function () {
     return buildTurnStartMap(session.turns);
   }, [session.turns]);
+
+  var timeMap = useMemo(function () {
+    return buildTimeMap(session.events);
+  }, [session.events]);
 
   var search = useSearch(filteredEventEntries);
 
@@ -305,6 +309,7 @@ export default function App() {
           metadata={session.metadata}
           events={session.events}
           totalTime={session.total}
+          timeMap={timeMap}
           onDive={session.dismissHero}
         />
       </div>
@@ -605,6 +610,7 @@ export default function App() {
         <Timeline
           currentTime={playback.time}
           totalTime={session.total}
+          timeMap={timeMap}
           onSeek={playback.seek}
           isPlaying={playback.playing}
           onPlayPause={playback.playPause}

--- a/src/components/SessionHero.jsx
+++ b/src/components/SessionHero.jsx
@@ -4,13 +4,14 @@ import { theme, TRACK_TYPES, alpha } from "../lib/theme.js";
  * SessionHero - Beautiful summary card shown after loading a session.
  * Displays key metrics with a mini activity sparkline.
  */
-export default function SessionHero({ metadata, events, totalTime, onDive }) {
+export default function SessionHero({ metadata, events, totalTime, timeMap, onDive }) {
   // Build mini sparkline data (30 bins)
   var bins = 30;
   var sparkData = new Array(bins).fill(0);
   if (events && totalTime > 0) {
     for (var i = 0; i < events.length; i++) {
-      var bin = Math.min(bins - 1, Math.floor((events[i].t / totalTime) * bins));
+      var pos = timeMap ? timeMap.toPosition(events[i].t) : events[i].t / totalTime;
+      var bin = Math.min(bins - 1, Math.floor(pos * bins));
       sparkData[bin] += events[i].intensity || 0.5;
     }
   }

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -1,16 +1,16 @@
 import { useRef, useMemo } from "react";
 import { theme, TRACK_TYPES } from "../lib/theme.js";
 
-export default function Timeline({ currentTime, totalTime, onSeek, isPlaying, onPlayPause, eventEntries, turns, matchSet }) {
+export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPlaying, onPlayPause, eventEntries, turns, matchSet }) {
   var barRef = useRef(null);
 
   function handleClick(e) {
     var rect = barRef.current.getBoundingClientRect();
     var pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
-    onSeek(pct * totalTime);
+    onSeek(timeMap ? timeMap.toTime(pct) : pct * totalTime);
   }
 
-  var pct = totalTime > 0 ? (currentTime / totalTime) * 100 : 0;
+  var pct = timeMap ? timeMap.toPosition(currentTime) * 100 : (totalTime > 0 ? (currentTime / totalTime) * 100 : 0);
 
   var counts = useMemo(function () {
     var nextCounts = {};
@@ -87,7 +87,7 @@ export default function Timeline({ currentTime, totalTime, onSeek, isPlaying, on
       >
         {turns && turns.map(function (turn, i) {
           if (i === 0) return null;
-          var left = totalTime > 0 ? (turn.startTime / totalTime) * 100 : 0;
+          var left = timeMap ? timeMap.toPosition(turn.startTime) * 100 : (totalTime > 0 ? (turn.startTime / totalTime) * 100 : 0);
           return (
             <div key={"turn-" + i} style={{
               position: "absolute",
@@ -103,8 +103,8 @@ export default function Timeline({ currentTime, totalTime, onSeek, isPlaying, on
         })}
         {eventEntries.map(function (entry) {
           var ev = entry.event;
-          var left = totalTime > 0 ? (ev.t / totalTime) * 100 : 0;
-          var width = Math.max(0.3, totalTime > 0 ? (ev.duration / totalTime) * 100 : 1);
+          var left = timeMap ? timeMap.toPosition(ev.t) * 100 : (totalTime > 0 ? (ev.t / totalTime) * 100 : 0);
+          var width = Math.max(0.3, timeMap ? (timeMap.toPosition(ev.t + ev.duration) - timeMap.toPosition(ev.t)) * 100 : (totalTime > 0 ? (ev.duration / totalTime) * 100 : 1));
           var info = TRACK_TYPES[ev.track];
           var color = ev.isError ? theme.error : (info ? info.color : theme.text.muted);
           var isMatch = matchSet && matchSet.has(entry.index);

--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -34,3 +34,109 @@ export function buildTurnStartMap(turns) {
 
   return map;
 }
+
+/**
+ * Build a time map that compresses large idle gaps for display purposes.
+ * Playback stays in real time; this only affects visual positioning in
+ * Timeline and SessionHero sparkline.
+ *
+ * Returns { toPosition(t), toTime(pos), displayTotal, hasCompression }.
+ */
+export function buildTimeMap(events) {
+  var sessionTotal = getSessionTotal(events);
+
+  function identity() {
+    return {
+      toPosition: function (t) { return sessionTotal > 0 ? Math.max(0, Math.min(1, t / sessionTotal)) : 0; },
+      toTime: function (pos) { return pos * sessionTotal; },
+      displayTotal: sessionTotal,
+      hasCompression: false,
+    };
+  }
+
+  if (!events || events.length === 0 || sessionTotal <= 0) {
+    return identity();
+  }
+
+  // Collect sorted unique event times, anchored at 0 and sessionTotal
+  var raw = [0];
+  for (var i = 0; i < events.length; i++) raw.push(events[i].t);
+  raw.push(sessionTotal);
+  raw.sort(function (a, b) { return a - b; });
+
+  var unique = [raw[0]];
+  for (var i = 1; i < raw.length; i++) {
+    if (raw[i] > unique[unique.length - 1]) unique.push(raw[i]);
+  }
+
+  if (unique.length <= 2) return identity();
+
+  // Compute inter-event gaps
+  var gaps = [];
+  for (var i = 1; i < unique.length; i++) {
+    gaps.push(unique[i] - unique[i - 1]);
+  }
+
+  var sorted = gaps.slice().sort(function (a, b) { return a - b; });
+  var median = sorted[Math.floor(sorted.length / 2)];
+  var maxGap = sorted[sorted.length - 1];
+  var threshold = Math.max(60, median * 10);
+
+  if (maxGap <= threshold) return identity();
+
+  // Build compressed breakpoints: [realTime, displayTime]
+  var compressedSize = Math.max(5, Math.min(30, median * 3));
+  var bp = [[unique[0], 0]];
+  var dt = 0;
+
+  for (var i = 1; i < unique.length; i++) {
+    var gap = unique[i] - unique[i - 1];
+    dt += gap > threshold ? compressedSize : gap;
+    bp.push([unique[i], dt]);
+  }
+
+  var displayTotal = dt;
+
+  function findSegment(arr, val, field) {
+    var lo = 0;
+    var hi = arr.length - 1;
+    while (lo < hi - 1) {
+      var mid = (lo + hi) >> 1;
+      if (arr[mid][field] <= val) lo = mid;
+      else hi = mid;
+    }
+    return lo;
+  }
+
+  function toPosition(t) {
+    if (displayTotal <= 0) return 0;
+    if (t <= bp[0][0]) return 0;
+    if (t >= bp[bp.length - 1][0]) return 1;
+
+    var lo = findSegment(bp, t, 0);
+    var hi = lo + 1;
+    var realLen = bp[hi][0] - bp[lo][0];
+    var frac = realLen > 0 ? (t - bp[lo][0]) / realLen : 0;
+    var dispVal = bp[lo][1] + frac * (bp[hi][1] - bp[lo][1]);
+    return Math.max(0, Math.min(1, dispVal / displayTotal));
+  }
+
+  function toTime(pos) {
+    var target = pos * displayTotal;
+    if (target <= 0) return 0;
+    if (target >= displayTotal) return sessionTotal;
+
+    var lo = findSegment(bp, target, 1);
+    var hi = lo + 1;
+    var dispLen = bp[hi][1] - bp[lo][1];
+    var frac = dispLen > 0 ? (target - bp[lo][1]) / dispLen : 0;
+    return bp[lo][0] + frac * (bp[hi][0] - bp[lo][0]);
+  }
+
+  return {
+    toPosition: toPosition,
+    toTime: toTime,
+    displayTotal: displayTotal,
+    hasCompression: true,
+  };
+}


### PR DESCRIPTION
## Problem

Sessions with long inactive periods (e.g. a 7-hour Copilot CLI session with two short bursts of activity) had all event markers crammed into a tiny sliver of the timeline bar and sparkline. The SessionHero sparkline showed one bar on the far left and one on the far right with nothing in between.

## Approach

Added a `buildTimeMap()` function in `session.js` that detects large idle gaps between event clusters and builds a compressed time mapping for display. The compression replaces gaps exceeding `max(60s, 10x median inter-event gap)` with a small fixed visual size, while preserving proportional spacing within active clusters.

The compressed mapping is used by:
- **Timeline** -- event markers, turn boundaries, playback cursor, and click-to-seek all use compressed positions
- **SessionHero** -- sparkline bins events using compressed time so activity fills the chart

Playback stays in real wall-clock time. Only visual positioning is compressed. Sessions without significant gaps use an identity mapping with zero overhead.

## Results

For the test Copilot CLI session (26,519s / 7h 21m with two ~15s bursts):
- Events now span 15%-99% of the display (was 0.1% and 99.9%)
- Sparkline fills 16/30 bins with data (was 2/30)
- Round-trip `toTime(toPosition(t))` is accurate

## Testing

All 109 existing tests pass. Build succeeds. Verified both the Copilot CLI test file and demo session render correctly.