### PR TITLE
Fix bugs, perf bottlenecks, and UI inconsistencies from code review

### DIFF
--- a/src/__tests__/copilotCliParser.test.js
+++ b/src/__tests__/copilotCliParser.test.js
@@ -398,7 +398,7 @@ describe("metadata", function () {
 
   it("identifies primary model", function () {
     expect(meta.primaryModel).toBe("claude-opus-4.6");
-    expect(meta.models).toContain("claude-opus-4.6");
+    expect(meta.models).toHaveProperty("claude-opus-4.6");
   });
 
   it("counts events and turns", function () {

--- a/src/components/SessionHero.jsx
+++ b/src/components/SessionHero.jsx
@@ -38,7 +38,7 @@ export default function SessionHero({ metadata, events, totalTime, timeMap, onDi
     stats.push({ label: "Errors", value: metadata.errorCount, color: theme.error });
   }
 
-  if (metadata.tokenUsage) {
+  if (metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0) {
     var total = metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens;
     stats.push({ label: "Tokens", value: total > 1000 ? (total / 1000).toFixed(1) + "k" : total, color: theme.accent.green });
   }

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -68,7 +68,7 @@ export default function StatsView({ events, totalTime, metadata, turns }) {
                 {metadata.primaryModel}
               </div>
             </div>
-            {metadata.tokenUsage && (
+            {metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0 && (
               <div style={{ borderLeft: "1px solid " + theme.border.default, paddingLeft: 20 }}>
                 <div style={{ fontSize: theme.fontSize.xs, color: theme.text.dim, textTransform: "uppercase", letterSpacing: 2, marginBottom: 4 }}>
                   Tokens

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -1,6 +1,8 @@
 import { useRef, useMemo } from "react";
 import { theme, TRACK_TYPES } from "../lib/theme.js";
 
+var TIMELINE_BINS = 200;
+
 export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPlaying, onPlayPause, eventEntries, turns, matchSet }) {
   var barRef = useRef(null);
 
@@ -101,27 +103,46 @@ export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPl
             }} />
           );
         })}
-        {eventEntries.map(function (entry) {
-          var ev = entry.event;
-          var left = timeMap ? timeMap.toPosition(ev.t) * 100 : (totalTime > 0 ? (ev.t / totalTime) * 100 : 0);
-          var width = Math.max(0.3, timeMap ? (timeMap.toPosition(ev.t + ev.duration) - timeMap.toPosition(ev.t)) * 100 : (totalTime > 0 ? (ev.duration / totalTime) * 100 : 1));
-          var info = TRACK_TYPES[ev.track];
-          var color = ev.isError ? theme.error : (info ? info.color : theme.text.muted);
-          var isMatch = matchSet && matchSet.has(entry.index);
-          return (
-            <div key={entry.index} style={{
-              position: "absolute",
-              left: left + "%",
-              width: width + "%",
-              top: 2,
-              bottom: 2,
-              background: color,
-              opacity: isMatch ? 0.9 : (ev.isError ? 0.7 : ev.intensity * 0.4),
-              borderRadius: 2,
-              boxShadow: isMatch ? "0 0 4px " + theme.accent.cyan : (ev.isError ? "0 0 4px " + theme.error : "none"),
-            }} />
-          );
-        })}
+        {/* Binned event markers for performance */}
+        {(function () {
+          var bins = [];
+          for (var b = 0; b < TIMELINE_BINS; b++) {
+            bins.push({ intensity: 0, isError: false, isMatch: false, color: null, count: 0 });
+          }
+          for (var i = 0; i < eventEntries.length; i++) {
+            var ev = eventEntries[i].event;
+            var pos = timeMap ? timeMap.toPosition(ev.t) : (totalTime > 0 ? ev.t / totalTime : 0);
+            var bin = Math.min(TIMELINE_BINS - 1, Math.max(0, Math.floor(pos * TIMELINE_BINS)));
+            var info = TRACK_TYPES[ev.track];
+            bins[bin].count++;
+            bins[bin].intensity = Math.max(bins[bin].intensity, ev.intensity || 0.3);
+            if (ev.isError) bins[bin].isError = true;
+            if (matchSet && matchSet.has(eventEntries[i].index)) bins[bin].isMatch = true;
+            if (!bins[bin].color && info) bins[bin].color = info.color;
+          }
+          var result = [];
+          for (var j = 0; j < TIMELINE_BINS; j++) {
+            if (bins[j].count === 0) continue;
+            var binData = bins[j];
+            var left = (j / TIMELINE_BINS) * 100;
+            var width = Math.max(0.3, 100 / TIMELINE_BINS);
+            var color = binData.isError ? theme.error : (binData.color || theme.text.muted);
+            result.push(
+              <div key={"bin-" + j} style={{
+                position: "absolute",
+                left: left + "%",
+                width: width + "%",
+                top: 2,
+                bottom: 2,
+                background: color,
+                opacity: binData.isMatch ? 0.9 : (binData.isError ? 0.7 : binData.intensity * 0.4),
+                borderRadius: 2,
+                boxShadow: binData.isMatch ? "0 0 4px " + theme.accent.cyan : (binData.isError ? "0 0 4px " + theme.error : "none"),
+              }} />
+            );
+          }
+          return result;
+        })()}
         <div style={{
           position: "absolute",
           left: pct + "%",

--- a/src/components/WaterfallView.jsx
+++ b/src/components/WaterfallView.jsx
@@ -440,10 +440,11 @@ export default function WaterfallView({ currentTime, eventEntries, totalTime, ti
             {turns && turns.map(function (turn, ti) {
               if (ti === 0) return null;
               var left = timeMap ? timeMap.toPosition(turn.startTime) * 100 : (totalTime > 0 ? (turn.startTime / totalTime) * 100 : 0);
+              var frac = left / 100;
               return (
                 <div key={"tb-" + ti} style={{
                   position: "absolute",
-                  left: "calc(" + LABEL_WIDTH + "px + " + left + "% * (100% - " + LABEL_WIDTH + "px) / 100)",
+                  left: "calc(" + LABEL_WIDTH + "px + (100% - " + LABEL_WIDTH + "px) * " + frac + ")",
                   top: 0,
                   bottom: 0,
                   width: 1,
@@ -457,7 +458,7 @@ export default function WaterfallView({ currentTime, eventEntries, totalTime, ti
             {/* Playhead */}
             <div style={{
               position: "absolute",
-              left: "calc(" + LABEL_WIDTH + "px + " + playPct + "% * (100% - " + LABEL_WIDTH + "px) / 100)",
+              left: "calc(" + LABEL_WIDTH + "px + (100% - " + LABEL_WIDTH + "px) * " + (playPct / 100) + ")",
               top: 0,
               bottom: 0,
               width: 2,

--- a/src/hooks/useKeyboardShortcuts.js
+++ b/src/hooks/useKeyboardShortcuts.js
@@ -52,7 +52,8 @@ export default function useKeyboardShortcuts(options) {
 
       if (e.key === "1") o.onSetView("replay");
       if (e.key === "2") o.onSetView("tracks");
-      if (e.key === "3") o.onSetView("stats");
+      if (e.key === "3") o.onSetView("waterfall");
+      if (e.key === "4") o.onSetView("stats");
 
       if (e.key === "e") {
         e.preventDefault();

--- a/src/hooks/usePersistentState.js
+++ b/src/hooks/usePersistentState.js
@@ -36,7 +36,15 @@ export default function usePersistentState(storageKey, initialValue) {
     }, PERSIST_DEBOUNCE_MS);
 
     return function () {
-      if (timerRef.current) clearTimeout(timerRef.current);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        // Flush synchronously on unmount so the last value is saved
+        try {
+          window.localStorage.setItem(storageKey, JSON.stringify(state));
+        } catch (error) {
+          // Ignore errors during unmount flush
+        }
+      }
     };
   }, [storageKey, state]);
 

--- a/src/hooks/useSessionLoader.js
+++ b/src/hooks/useSessionLoader.js
@@ -47,6 +47,7 @@ export default function useSessionLoader() {
     setTurns(SAMPLE_TURNS);
     setMetadata(SAMPLE_METADATA);
     setTotal(SAMPLE_TOTAL);
+    setFirstEventTime(SAMPLE_EVENTS.length > 0 ? SAMPLE_EVENTS[0].t : 0);
     setFile("demo-session.jsonl");
     setError(null);
     setShowHero(true);

--- a/src/lib/commandPalette.js
+++ b/src/lib/commandPalette.js
@@ -14,6 +14,7 @@ function buildViewItems() {
   return [
     { id: "view-replay", type: "view", label: "Replay View", icon: "\u25B6", viewId: "replay", searchText: "replay view timeline stream", priority: 40 },
     { id: "view-tracks", type: "view", label: "Tracks View", icon: "\u2261", viewId: "tracks", searchText: "tracks view lanes daw", priority: 40 },
+    { id: "view-waterfall", type: "view", label: "Waterfall View", icon: "\u2507", viewId: "waterfall", searchText: "waterfall view tools timeline execution", priority: 40 },
     { id: "view-stats", type: "view", label: "Stats View", icon: "\u25FB", viewId: "stats", searchText: "stats view metrics summary", priority: 40 },
   ];
 }

--- a/src/lib/copilotCliParser.js
+++ b/src/lib/copilotCliParser.js
@@ -444,10 +444,10 @@ function buildMetadata(records, events, turns, malformedLines) {
     }
   }
 
-  var modelNames = Object.keys(models);
-  var primaryModel = modelNames.sort(function (a, b) {
-    return (models[b] || 0) - (models[a] || 0);
-  })[0] || null;
+  var modelEntries = Object.entries(models).sort(function (a, b) {
+    return (b[1] || 0) - (a[1] || 0);
+  });
+  var primaryModel = modelEntries.length > 0 ? modelEntries[0][0] : null;
 
   var duration = events.length > 0
     ? events[events.length - 1].t + events[events.length - 1].duration
@@ -469,7 +469,7 @@ function buildMetadata(records, events, turns, malformedLines) {
     totalToolCalls: totalToolCalls,
     errorCount: errorCount,
     duration: duration,
-    models: modelNames,
+    models: models,
     primaryModel: primaryModel,
     tokenUsage: {
       inputTokens: totalInputTokens,


### PR DESCRIPTION
## Summary

Thorough code review identified 10 issues (4 bugs, 3 performance, 3 UI). PRs #6 and #7 had already fixed 2 of them (waterfall indexOf perf, timeMap consistency). This PR fixes the remaining 8.

## Critical Bugs
- **Copilot CLI StatsView broken**: `metadata.models` was returned as an array instead of object, causing "All Models" section to show `"0 (claude-sonnet-4)"` instead of `"claude-sonnet-4 (5)"`
- **WaterfallView turn lines and playhead invisible**: CSS `calc()` used `length * length` multiplication (`25% * (100% - 180px)`), which is dimensionally invalid and silently discarded by browsers. Restructured to `(100% - 180px) * 0.25`
- **Waterfall unreachable from Cmd+K**: `buildViewItems()` only listed 3 views
- **Keyboard shortcut gap**: Only keys 1-3 mapped; added 3=Waterfall, 4=Stats

## Performance
- **Timeline DOM explosion**: Rendered 1 `<div>` per event (1000+ nodes in a 28px bar). Now buckets into 200 bins
- **usePersistentState data loss**: 300ms debounce cleanup dropped the last write on fast unmount. Now flushes synchronously

## UI Consistency
- **"Tokens: 0" for Copilot CLI**: `tokenUsage` is never null for that parser, so check `total > 0` before displaying
- **`loadSample` missing `firstEventTime`**: Inconsistent with `handleFile` path

## Testing
- All 109 tests pass (updated 1 test assertion for the models type change)
- Production build succeeds