### PR TITLE
feat: browse local sessions from landing page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,8 @@ bin/
   agentviz.js          # CLI entry point: finds free port, starts server, opens browser
 mcp/
   server.js            # MCP server: launch_agentviz and close_agentviz tools
-server.js              # HTTP server: serves dist/ SPA + SSE /api/stream file tail
+server.js              # HTTP server: serves dist/ SPA + SSE /api/stream file tail + /api/sessions listing
+sessionSources.js      # Shared session discovery: known source dirs, listing, path validation
 ```
 
 ## Key data types

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -21,72 +21,15 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { createServer } from "../server.js";
+import { findLatestSessionFile } from "../sessionSources.js";
 import fs from "fs";
 import path from "path";
 import net from "net";
-import os from "os";
 import { exec } from "child_process";
 import { fileURLToPath } from "url";
 
 var __dirname = path.dirname(fileURLToPath(import.meta.url));
 var distDir = path.resolve(__dirname, "../dist");
-
-// Known session directories and how to find .jsonl files within them.
-var SESSION_SOURCES = [
-  {
-    // Claude Code: ~/.claude/projects/<project-dir>/<uuid>.jsonl
-    root: path.join(os.homedir(), ".claude", "projects"),
-    find: function (root) {
-      var results = [];
-      try {
-        for (var proj of fs.readdirSync(root)) {
-          var projPath = path.join(root, proj);
-          try { if (!fs.statSync(projPath).isDirectory()) continue; } catch (e) { continue; }
-          try {
-            for (var f of fs.readdirSync(projPath)) {
-              if (f.endsWith(".jsonl")) results.push(path.join(projPath, f));
-            }
-          } catch (e) {}
-        }
-      } catch (e) {}
-      return results;
-    },
-  },
-  {
-    // Copilot CLI: ~/.copilot/session-state/<uuid>/events.jsonl
-    root: path.join(os.homedir(), ".copilot", "session-state"),
-    find: function (root) {
-      var results = [];
-      try {
-        for (var sess of fs.readdirSync(root)) {
-          var candidate = path.join(root, sess, "events.jsonl");
-          if (fs.existsSync(candidate)) results.push(candidate);
-        }
-      } catch (e) {}
-      return results;
-    },
-  },
-];
-
-// Find the most recently modified session file across all known sources.
-function findLatestSessionFile() {
-  var best = null;
-  var bestMtime = 0;
-
-  for (var i = 0; i < SESSION_SOURCES.length; i++) {
-    var source = SESSION_SOURCES[i];
-    if (!fs.existsSync(source.root)) continue;
-    var files = source.find(source.root);
-    for (var j = 0; j < files.length; j++) {
-      try {
-        var mtime = fs.statSync(files[j]).mtimeMs;
-        if (mtime > bestMtime) { bestMtime = mtime; best = files[j]; }
-      } catch (e) {}
-    }
-  }
-
-  return best;
-}
 
 function findFreePort(preferred, cb) {
   var server = net.createServer();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1182,9 +1182,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1199,9 +1196,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1216,9 +1210,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1233,9 +1224,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1250,9 +1238,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,9 +1252,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1284,9 +1266,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1301,9 +1280,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,9 +1294,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1335,9 +1308,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1352,9 +1322,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1369,9 +1336,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1386,9 +1350,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "app": "npm run build && node bin/agentviz.js",
     "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/server.js
+++ b/server.js
@@ -1,8 +1,9 @@
 /**
  * AgentViz local server.
  * Serves dist/ as a static SPA and provides:
- *   GET /api/file   -- returns the watched session file as text
+ *   GET /api/file   -- returns the watched session file as text, or a known session via ?path=
  *   GET /api/meta   -- returns { filename } JSON
+ *   GET /api/sessions -- returns recent local sessions from known source directories
  *   GET /api/stream -- SSE endpoint, pushes new JSONL lines as the file grows
  */
 
@@ -10,6 +11,7 @@ import http from "http";
 import fs from "fs";
 import path from "path";
 import url from "url";
+import { isKnownSessionPath, listKnownSessionFiles } from "./sessionSources.js";
 
 var MIME = {
   ".html": "text/html; charset=utf-8",
@@ -68,6 +70,14 @@ export function createServer({ sessionFile, distDir }) {
   var watcher = null;
   var watcherClosed = false;
   var pollInterval = null;
+
+  function normalizeRequestedSessionPath(inputPath) {
+    if (!inputPath || typeof inputPath !== "string") return null;
+    var resolved = path.resolve(inputPath);
+    if (!resolved.endsWith(".jsonl")) return null;
+    if (!isKnownSessionPath(resolved)) return null;
+    return resolved;
+  }
 
   function broadcastNewLines() {
     if (!sessionFile || clients.size === 0) return;
@@ -139,15 +149,49 @@ export function createServer({ sessionFile, distDir }) {
     res.setHeader("Access-Control-Allow-Origin", "*");
 
     if (pathname === "/api/file") {
-      if (!sessionFile) { res.writeHead(404); res.end("No session file"); return; }
+      var requestedPath = normalizeRequestedSessionPath(parsed.query && parsed.query.path);
+      var targetFile = requestedPath || sessionFile;
+
+      if (parsed.query && parsed.query.path && !requestedPath) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "invalid_session_path" }));
+        return;
+      }
+
+      if (!targetFile) { res.writeHead(404); res.end("No session file"); return; }
+
       try {
-        var text = fs.readFileSync(sessionFile, "utf8");
+        var text = fs.readFileSync(targetFile, "utf8");
         res.writeHead(200, { "Content-Type": "text/plain; charset=utf-8" });
         res.end(text);
       } catch (e) {
         res.writeHead(500);
         res.end(e.message);
       }
+      return;
+    }
+
+    if (pathname === "/api/sessions") {
+      var limit = Number(parsed.query && parsed.query.limit);
+      var sessions = listKnownSessionFiles(limit)
+        .map(function (entry) {
+          return {
+            path: entry.path,
+            name: entry.name,
+            sourceKind: entry.sourceKind,
+            sourceLabel: entry.sourceLabel,
+            mtimeMs: entry.mtimeMs,
+            mtimeIso: new Date(entry.mtimeMs).toISOString(),
+            sizeBytes: entry.sizeBytes,
+            eventCount: entry.eventCount,
+          };
+        });
+
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        sessions: sessions,
+        selectedPath: sessionFile || null,
+      }));
       return;
     }
 

--- a/sessionSources.js
+++ b/sessionSources.js
@@ -1,0 +1,154 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+// Count complete JSONL lines without reading the entire file into a string.
+// Streams 64KB chunks and counts newline-terminated non-empty lines.
+function countCompleteJsonlEvents(filePath) {
+  var fd;
+  try {
+    fd = fs.openSync(filePath, "r");
+    var buf = Buffer.alloc(65536);
+    var count = 0;
+    var hasContent = false; // tracks whether current line has non-whitespace
+    var bytesRead;
+
+    while ((bytesRead = fs.readSync(fd, buf, 0, buf.length)) > 0) {
+      for (var i = 0; i < bytesRead; i++) {
+        var ch = buf[i];
+        if (ch === 10) { // \n
+          if (hasContent) count++;
+          hasContent = false;
+        } else if (ch === 13) { // \r -- skip
+          // do nothing
+        } else if (!hasContent && (ch === 32 || ch === 9)) { // space/tab
+          // still whitespace-only
+        } else {
+          hasContent = true;
+        }
+      }
+    }
+    // Only count the trailing content if it ends with a newline (complete record).
+    // hasContent without a trailing newline means an in-progress write.
+    fs.closeSync(fd);
+    return count;
+  } catch (e) {
+    if (fd !== undefined) try { fs.closeSync(fd); } catch (_) {}
+    return null;
+  }
+}
+
+function findClaudeCodeSessions(root) {
+  var results = [];
+
+  try {
+    var projects = fs.readdirSync(root);
+    for (var i = 0; i < projects.length; i++) {
+      var projectPath = path.join(root, projects[i]);
+      try {
+        if (!fs.statSync(projectPath).isDirectory()) continue;
+      } catch (e) {
+        continue;
+      }
+
+      try {
+        var files = fs.readdirSync(projectPath);
+        for (var j = 0; j < files.length; j++) {
+          if (!files[j].endsWith(".jsonl")) continue;
+          results.push(path.join(projectPath, files[j]));
+        }
+      } catch (e) {}
+    }
+  } catch (e) {}
+
+  return results;
+}
+
+function findCopilotCliSessions(root) {
+  var results = [];
+
+  try {
+    var sessions = fs.readdirSync(root);
+    for (var i = 0; i < sessions.length; i++) {
+      var candidate = path.join(root, sessions[i], "events.jsonl");
+      if (fs.existsSync(candidate)) results.push(candidate);
+    }
+  } catch (e) {}
+
+  return results;
+}
+
+export function getSessionSources() {
+  return [
+    {
+      kind: "claude",
+      label: "Claude Code",
+      root: path.join(os.homedir(), ".claude", "projects"),
+      find: findClaudeCodeSessions,
+    },
+    {
+      kind: "copilot",
+      label: "Copilot CLI",
+      root: path.join(os.homedir(), ".copilot", "session-state"),
+      find: findCopilotCliSessions,
+    },
+  ];
+}
+
+export function listKnownSessionFiles(limit) {
+  var max = Number.isFinite(limit) ? Math.max(1, Math.floor(limit)) : 20;
+  var entries = [];
+  var seen = new Set();
+  var sources = getSessionSources();
+
+  for (var i = 0; i < sources.length; i++) {
+    var source = sources[i];
+    if (!fs.existsSync(source.root)) continue;
+
+    var files = source.find(source.root);
+    for (var j = 0; j < files.length; j++) {
+      var filePath = path.resolve(files[j]);
+      if (seen.has(filePath)) continue;
+
+      try {
+        var stat = fs.statSync(filePath);
+        if (!stat.isFile()) continue;
+        seen.add(filePath);
+        entries.push({
+          path: filePath,
+          name: path.basename(filePath),
+          mtimeMs: stat.mtimeMs,
+          sizeBytes: stat.size,
+          eventCount: countCompleteJsonlEvents(filePath),
+          sourceKind: source.kind,
+          sourceLabel: source.label,
+        });
+      } catch (e) {}
+    }
+  }
+
+  entries.sort(function (a, b) {
+    return b.mtimeMs - a.mtimeMs;
+  });
+
+  return entries.slice(0, max);
+}
+
+export function findLatestSessionFile() {
+  var entries = listKnownSessionFiles(1);
+  return entries.length > 0 ? entries[0].path : null;
+}
+
+export function isKnownSessionPath(targetPath) {
+  if (!targetPath) return false;
+  var normalizedTarget = path.resolve(targetPath);
+  var sources = getSessionSources();
+
+  for (var i = 0; i < sources.length; i++) {
+    var root = path.resolve(sources[i].root);
+    var rel = path.relative(root, normalizedTarget);
+    if (!rel || (!rel.startsWith("..") && !path.isAbsolute(rel))) return true;
+  }
+
+  return false;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -175,6 +175,11 @@ export default function App() {
     session.handleFile(text, name);
   }, [resetVisualizerState, session.handleFile]);
 
+  var loadRecentSession = useCallback(function (sessionPath) {
+    resetVisualizerState();
+    session.loadServerFile(sessionPath);
+  }, [resetVisualizerState, session.loadServerFile]);
+
   var loadSample = useCallback(function () {
     resetVisualizerState();
     session.loadSample();
@@ -305,6 +310,7 @@ export default function App() {
       <AppLandingState
         error={session.error}
         onLoad={handleFile}
+        onLoadRecent={loadRecentSession}
         onLoadSample={loadSample}
         onStartCompare={function () { setCompareLanding(true); }}
       />

--- a/src/__tests__/appRegression.test.jsx
+++ b/src/__tests__/appRegression.test.jsx
@@ -39,13 +39,19 @@ function createTextResponse(payload) {
 }
 
 function createInactiveFetch() {
-  return vi.fn(async function () {
+  return vi.fn(async function (url) {
+    if (String(url).includes("/api/sessions")) {
+      return createJsonResponse({ sessions: [] });
+    }
     return { ok: false };
   });
 }
 
 function createBootstrapFetch(filename, text, live) {
   return vi.fn(async function (url) {
+    if (String(url).includes("/api/sessions")) {
+      return createJsonResponse({ sessions: [] });
+    }
     if (String(url).includes("/api/meta")) {
       return createJsonResponse({ filename: filename, live: live });
     }
@@ -62,6 +68,32 @@ function createLiveFetch(filename, text) {
 
 function createExportBootstrapFetch(filename, text) {
   return createBootstrapFetch(filename, text, false);
+}
+
+function createRecentSessionsFetch(sessionPath, text) {
+  return vi.fn(async function (url) {
+    if (String(url).includes("/api/sessions")) {
+      return createJsonResponse({
+        sessions: [{
+          path: sessionPath,
+          name: "recent.jsonl",
+          sourceKind: "copilot",
+          sourceLabel: "Copilot CLI",
+          mtimeMs: 1,
+          mtimeIso: "1970-01-01T00:00:00.001Z",
+          eventCount: 42,
+          sizeBytes: 8192,
+        }],
+      });
+    }
+    if (String(url).includes("/api/meta")) {
+      return createJsonResponse({ filename: null, live: false });
+    }
+    if (String(url).includes("/api/file?path=")) {
+      return createTextResponse(text);
+    }
+    throw new Error("Unexpected fetch: " + url);
+  });
 }
 
 function click(node) {
@@ -259,6 +291,26 @@ describe("App browser regressions", function () {
 
     expect(findByText(app.container, "Drop a session file here")).toBeFalsy();
     expect(fetchMock).toHaveBeenCalledWith("/api/file");
+
+    await app.unmount();
+  });
+
+  it("loads a recent local session from landing", async function () {
+    var app = await renderApp(createRecentSessionsFetch("/tmp/recent.jsonl", FIXTURE_TEXT));
+
+    await click(findClickableText(app.container, "browse local sessions"));
+
+    await waitFor(function () {
+      return findByText(app.container, "Recent local sessions");
+    }, "expected recent sessions heading");
+
+    await click(findClickableText(app.container, "recent.jsonl"));
+
+    await waitFor(function () {
+      return !findByText(app.container, "Drop a session file here");
+    }, "expected selected recent session to load");
+
+    expect(findByText(app.container, "Drop a session file here")).toBeFalsy();
 
     await app.unmount();
   });

--- a/src/components/app/AppLandingState.jsx
+++ b/src/components/app/AppLandingState.jsx
@@ -1,10 +1,93 @@
-import { theme } from "../../lib/theme.js";
+import { useCallback, useEffect, useState } from "react";
+import { theme, alpha } from "../../lib/theme.js";
 import FileUploader from "../FileUploader.jsx";
 import Icon from "../Icon.jsx";
 import BrandWordmark from "../ui/BrandWordmark.jsx";
 import ShellFrame from "../ui/ShellFrame.jsx";
 
-export default function AppLandingState({ error, onLoad, onLoadSample, onStartCompare }) {
+var SOURCE_COLORS = {
+  claude: theme.agent.assistant,
+  copilot: theme.track.context,
+};
+
+function formatRecentTime(item) {
+  var value = item && (item.mtimeMs || item.mtimeIso);
+  if (!value) return "time unknown";
+  var ts = new Date(value);
+  if (Number.isNaN(ts.getTime())) return "time unknown";
+  return ts.toLocaleString();
+}
+
+function getPathContext(item) {
+  if (!item || !item.path) return "";
+  var parts = String(item.path).split(/[\\/]/).filter(Boolean);
+  if (parts.length <= 2) return item.path;
+  return parts.slice(-3).join("/");
+}
+
+function formatCount(value, label) {
+  if (!Number.isFinite(value)) return "unknown " + label;
+  var n = Math.max(0, Math.floor(value));
+  return n.toLocaleString() + " " + label;
+}
+
+function formatSize(bytes) {
+  if (!Number.isFinite(bytes)) return "unknown size";
+  var size = Math.max(0, bytes);
+  if (size < 1024) return size + " B";
+  var kb = size / 1024;
+  if (kb < 1024) return kb.toFixed(1) + " KB";
+  var mb = kb / 1024;
+  return mb.toFixed(1) + " MB";
+}
+
+export default function AppLandingState({ error, onLoad, onLoadRecent, onLoadSample, onStartCompare }) {
+  var [recent, setRecent] = useState([]);
+  var [isLoadingRecent, setIsLoadingRecent] = useState(false);
+  var [recentError, setRecentError] = useState(null);
+  var [showRecentModal, setShowRecentModal] = useState(false);
+
+  var loadRecentSessions = useCallback(function () {
+    setIsLoadingRecent(true);
+    setRecentError(null);
+
+    fetch("/api/sessions?limit=20")
+      .then(function (r) {
+        if (!r.ok) throw new Error("failed");
+        return r.json();
+      })
+      .then(function (payload) {
+        var sessions = payload && Array.isArray(payload.sessions) ? payload.sessions : [];
+        setRecent(sessions);
+        setIsLoadingRecent(false);
+      })
+      .catch(function () {
+        setRecent([]);
+        setIsLoadingRecent(false);
+        setRecentError("Could not fetch local sessions. Start the app with node bin/agentviz.js.");
+      });
+  }, []);
+
+  useEffect(function () {
+    if (!showRecentModal) return;
+    loadRecentSessions();
+  }, [showRecentModal, loadRecentSessions]);
+
+  useEffect(function () {
+    if (!showRecentModal) return;
+
+    function onKeyDown(e) {
+      if (e.key === "Escape") setShowRecentModal(false);
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return function () {
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [showRecentModal]);
+
+
+
   return (
     <ShellFrame
       style={{
@@ -44,6 +127,20 @@ export default function AppLandingState({ error, onLoad, onLoadSample, onStartCo
         </span>
         <span style={{ color: theme.text.ghost, fontSize: theme.fontSize.sm }}>or</span>
         <span
+          onClick={function () { setShowRecentModal(true); }}
+          style={{
+            color: theme.text.muted,
+            cursor: "pointer",
+            fontSize: theme.fontSize.sm,
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+          }}
+        >
+          <Icon name="file-plus" size={12} /> browse local sessions
+        </span>
+        <span style={{ color: theme.text.ghost, fontSize: theme.fontSize.sm }}>or</span>
+        <span
           onClick={onStartCompare}
           style={{
             color: theme.accent.primary,
@@ -57,6 +154,148 @@ export default function AppLandingState({ error, onLoad, onLoadSample, onStartCo
           <Icon name="arrow-up-down" size={12} /> compare two sessions
         </span>
       </div>
+
+      {showRecentModal && (
+        <div
+          onClick={function () { setShowRecentModal(false); }}
+          style={{
+            position: "fixed",
+            inset: 0,
+            background: theme.bg.overlay,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            zIndex: theme.z.modal,
+            padding: 24,
+          }}
+        >
+          <div
+            onClick={function (e) { e.stopPropagation(); }}
+            style={{
+              width: "min(920px, 100%)",
+              maxHeight: "min(80vh, 760px)",
+              background: theme.bg.raised,
+              border: "1px solid " + theme.border.strong,
+              borderRadius: theme.radius.xxl,
+              display: "flex",
+              flexDirection: "column",
+              overflow: "hidden",
+              boxShadow: theme.shadow.lg,
+            }}
+          >
+            <div style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "14px 16px",
+              borderBottom: "1px solid " + theme.border.default,
+              background: theme.bg.surface,
+            }}>
+              <div>
+                <div style={{ fontSize: theme.fontSize.lg, color: theme.text.primary, fontWeight: 600 }}>
+                  Recent local sessions
+                </div>
+                <div style={{ fontSize: theme.fontSize.sm, color: theme.text.dim, marginTop: 4 }}>
+                  Claude Code and Copilot CLI files from known local session folders
+                </div>
+              </div>
+              <button
+                onClick={function () { setShowRecentModal(false); }}
+                style={{
+                  background: "transparent",
+                  color: theme.text.muted,
+                  border: "1px solid " + theme.border.default,
+                  borderRadius: theme.radius.lg,
+                  cursor: "pointer",
+                  padding: "7px 10px",
+                  display: "flex",
+                  alignItems: "center",
+                }}
+              >
+                <Icon name="close" size={14} />
+              </button>
+            </div>
+
+            <div style={{ padding: 12, overflowY: "auto", minHeight: 260 }}>
+              {isLoadingRecent && (
+                <div style={{ fontSize: theme.fontSize.sm, color: theme.text.dim, padding: 10 }}>
+                  Scanning local session directories...
+                </div>
+              )}
+
+              {!isLoadingRecent && recentError && (
+                <div style={{
+                  background: theme.semantic.errorBg,
+                  border: "1px solid " + theme.semantic.error,
+                  borderRadius: theme.radius.lg,
+                  padding: "10px 12px",
+                  color: theme.semantic.errorText,
+                  fontSize: theme.fontSize.sm,
+                }}>
+                  {recentError}
+                </div>
+              )}
+
+              {!isLoadingRecent && !recentError && recent.length === 0 && (
+                <div style={{ fontSize: theme.fontSize.sm, color: theme.text.dim, padding: 10 }}>
+                  No known local sessions were found yet.
+                </div>
+              )}
+
+              {!isLoadingRecent && !recentError && recent.length > 0 && (
+                <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                  {recent.map(function (item, idx) {
+                    return (
+                      <button
+                        key={item.path + "-" + idx}
+                        onClick={function () {
+                          setShowRecentModal(false);
+                          onLoadRecent(item.path);
+                        }}
+                        style={{
+                          width: "100%",
+                          border: "1px solid " + theme.border.default,
+                          borderRadius: theme.radius.lg,
+                          background: theme.bg.surface,
+                          color: theme.text.primary,
+                          textAlign: "left",
+                          cursor: "pointer",
+                          padding: "11px 12px",
+                          fontFamily: theme.font.mono,
+                        }}
+                      >
+                        <div style={{ display: "flex", justifyContent: "space-between", gap: 12, alignItems: "center" }}>
+                          <span style={{ fontSize: theme.fontSize.md, fontWeight: 600 }}>{item.name}</span>
+                          <span style={{
+                            fontSize: theme.fontSize.xs,
+                            color: SOURCE_COLORS[item.sourceKind] || theme.text.secondary,
+                            border: "1px solid " + alpha(SOURCE_COLORS[item.sourceKind] || theme.border.subtle, 0.25),
+                            borderRadius: theme.radius.full,
+                            padding: "2px 8px",
+                            flexShrink: 0,
+                            background: alpha(SOURCE_COLORS[item.sourceKind] || theme.bg.base, 0.08),
+                          }}>
+                            {item.sourceLabel || item.sourceKind}
+                          </span>
+                        </div>
+                        <div style={{ marginTop: 7, fontSize: theme.fontSize.xs, color: theme.text.secondary }}>
+                          Modified: {formatRecentTime(item)}
+                        </div>
+                        <div style={{ marginTop: 5, fontSize: theme.fontSize.sm, color: theme.text.secondary }}>
+                          {formatCount(item.eventCount, "events")} | {formatSize(item.sizeBytes)}
+                        </div>
+                        <div style={{ marginTop: 5, fontSize: theme.fontSize.sm, color: theme.text.muted }}>
+                          {getPathContext(item)}
+                        </div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
     </ShellFrame>
   );
 }

--- a/src/hooks/useSessionLoader.js
+++ b/src/hooks/useSessionLoader.js
@@ -131,6 +131,49 @@ export default function useSessionLoader(options) {
     setShowHero(false);
   }, []);
 
+  var loadServerFile = useCallback(function (sessionPath) {
+    if (!sessionPath) return;
+
+    requestIdRef.current += 1;
+    var requestId = requestIdRef.current;
+
+    if (parseTimeoutRef.current) {
+      clearTimeout(parseTimeoutRef.current);
+      parseTimeoutRef.current = null;
+    }
+
+    setError(null);
+    setLoading(true);
+    setIsLive(false);
+    liveRequestIdRef.current = 0;
+
+    fetch("/api/file?path=" + encodeURIComponent(sessionPath))
+      .then(function (r) { return r.ok ? r.text() : null; })
+      .then(function (text) {
+        if (!text || requestId !== requestIdRef.current) {
+          if (requestId === requestIdRef.current) setLoading(false);
+          return;
+        }
+
+        rawTextRef.current = text;
+        var name = sessionPath.split(/[\\/]/).pop() || sessionPath;
+        var parsed = parseSessionText(text);
+
+        setLoading(false);
+        if (!parsed.result) {
+          setError(parsed.error || "Could not parse selected session.");
+          return;
+        }
+
+        applySession(parsed.result, name);
+      })
+      .catch(function () {
+        if (requestId !== requestIdRef.current) return;
+        setLoading(false);
+        setError("Could not load selected session from local server.");
+      });
+  }, [applySession]);
+
   // When served by the CLI (server.js), /api/meta tells us the filename
   // and /api/file provides the initial content. Bootstrap from there.
   useEffect(function () {
@@ -193,6 +236,7 @@ export default function useSessionLoader(options) {
     loadSample: loadSample,
     resetSession: resetSession,
     dismissHero: dismissHero,
+    loadServerFile: loadServerFile,
     getRawText: function () { return rawTextRef.current; },
   };
 }


### PR DESCRIPTION
## Browse Local Sessions

Adds a **browse local sessions** option to the landing page that discovers and lists Claude Code and Copilot CLI session files from known local directories.

### What changed

- **Shared session discovery** (sessionSources.js): new module with streaming JSONL event counter, known source enumeration, path validation. Used by both the HTTP server and MCP server.
- **Server API**: new \/api/sessions\ endpoint returns session metadata (path, source kind, event count, file size, modified time). Extended \/api/file?path=\ for loading specific sessions with path validation.
- **MCP refactor**: \mcp/server.js\ now imports from shared \sessionSources.js\ instead of inline discovery logic.
- **Landing page modal**: click *browse local sessions* to open a modal overlay showing recent sessions with source-colored badges (Claude/Copilot), event counts, file sizes, timestamps, and path context. Click any card to load it.
- **npm script**: added \
pm run app\ (build + launch server) for one-command startup.
- **Tests**: new regression test for the browse flow; all 219 tests passing.

### Screenshots

> *Screenshots will be added as a comment below*

### Files changed (10 files, +549 / -104)

| File | Change |
|------|--------|
| \sessionSources.js\ | New shared session discovery module |
| \server.js\ | Added /api/sessions endpoint, /api/file?path= |
| \mcp/server.js\ | Refactored to use shared sessionSources |
| \src/components/app/AppLandingState.jsx\ | Modal overlay with session cards |
| \src/hooks/useSessionLoader.js\ | Added loadServerFile method |
| \src/App.jsx\ | Wired loadRecentSession callback |
| \src/__tests__/appRegression.test.jsx\ | Added browse flow test |
| \src/lib/theme.js\ | No changes (reference only) |
| \package.json\ | Added \pp\ script |
| \CLAUDE.md\ | Updated architecture docs |


<img width="1600" height="900" alt="browse-landing" src="https://github.com/user-attachments/assets/cf3e3ca0-6746-4b55-9313-3f0ca25686eb" />
<img width="1600" height="900" alt="browse-loaded" src="https://github.com/user-attachments/assets/c5eba607-61e3-4f33-a3a6-887f8edd4b47" />
<img width="1600" height="900" alt="browse-modal" src="https://github.com/user-attachments/assets/ffbe8d4b-604c-444e-a64a-99c79ddb07bf" />
