### PR TITLE
fix: stabilize replay rendering and debug large sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ vite.config.js.timestamp-*
 
 # Test coverage
 coverage/
+
+# Local debug artifacts
+.vitest-targeted-output.txt

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "build:debug": "vite build --mode debug",
     "preview": "vite preview",
+    "app": "npm run build && node ./bin/agentviz.js",
+    "app:debug": "npm run build:debug && node ./bin/agentviz.js",
     "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/src/__tests__/sessionLibrary.test.js
+++ b/src/__tests__/sessionLibrary.test.js
@@ -24,6 +24,35 @@ function createMemoryStorage() {
   };
 }
 
+function createQuotaStorage(maxContentEntries) {
+  var storage = {};
+
+  function countContentEntries() {
+    return Object.keys(storage).filter(function (key) {
+      return key.indexOf("agentviz:session-content:v1:") === 0;
+    }).length;
+  }
+
+  return {
+    getItem: function (key) { return Object.prototype.hasOwnProperty.call(storage, key) ? storage[key] : null; },
+    setItem: function (key, value) {
+      var nextValue = String(value);
+      var isContentKey = key.indexOf("agentviz:session-content:v1:") === 0;
+      var isNewKey = !Object.prototype.hasOwnProperty.call(storage, key);
+
+      if (isContentKey && isNewKey && countContentEntries() >= maxContentEntries) {
+        var error = new Error("Quota exceeded");
+        error.name = "QuotaExceededError";
+        throw error;
+      }
+
+      storage[key] = nextValue;
+    },
+    removeItem: function (key) { delete storage[key]; },
+    clear: function () { storage = {}; },
+  };
+}
+
 describe("session library persistence", function () {
   it("stores metadata summaries and raw content for imported copilot sessions", function () {
     var parsed = parseSessionText(COPILOT_FIXTURE);
@@ -58,5 +87,24 @@ describe("session library persistence", function () {
     expect(entries[0].format).toBe("claude-code");
     expect(entries[0].autonomyMetrics.interventionCount).toBe(1);
     expect(entries[0].errorCount).toBeGreaterThan(0);
+  });
+
+  it("evicts older cached content when storage quota is exceeded", function () {
+    var parsed = parseSessionText(COPILOT_FIXTURE);
+    var storage = createQuotaStorage(1);
+    var alternateFixture = COPILOT_FIXTURE + "\n";
+    var secondResult = {
+      events: parsed.result.events,
+      turns: parsed.result.turns,
+      metadata: Object.assign({}, parsed.result.metadata, { sessionId: String(parsed.result.metadata.sessionId || "session") + "-2" }),
+    };
+
+    var first = persistSessionSnapshot("session-a.jsonl", parsed.result, COPILOT_FIXTURE, storage);
+    var second = persistSessionSnapshot("session-b.jsonl", secondResult, alternateFixture, storage);
+
+    expect(first.entry.hasContent).toBe(true);
+    expect(second.entry.hasContent).toBe(true);
+    expect(loadStoredSessionContent(first.entry.id, storage)).toBe("");
+    expect(loadStoredSessionContent(second.entry.id, storage)).toBe(alternateFixture);
   });
 });

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -205,6 +205,20 @@ export default function ReplayView({ currentTime, eventEntries, turnStartMap, se
     return getReplayWindow(layout.items, scrollTop, viewportHeight, REPLAY_WINDOW_OVERSCAN);
   }, [layout.items, scrollTop, viewportHeight]);
 
+  var windowMeasurementKey = useMemo(function () {
+    if (!windowedItems.length) return "";
+    return windowedItems.map(function (item) { return item.entry.index; }).join(",");
+  }, [windowedItems]);
+
+  var eventEntriesResetKey = useMemo(function () {
+    if (!eventEntries.length) return "empty";
+    return [
+      eventEntries.length,
+      eventEntries[0].index,
+      eventEntries[eventEntries.length - 1].index,
+    ].join(":");
+  }, [eventEntries]);
+
   useEffect(function () {
     if (containerRef.current && visibleEntries.length > prevCount.current && shouldFollowRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight;
@@ -230,9 +244,11 @@ export default function ReplayView({ currentTime, eventEntries, turnStartMap, se
   useEffect(function () {
     itemRefs.current = {};
     setMeasuredHeights({});
-  }, [eventEntries]);
+  }, [eventEntriesResetKey]);
 
   useLayoutEffect(function () {
+    if (!windowMeasurementKey) return;
+
     setMeasuredHeights(function (prev) {
       var next = prev;
       var changed = false;
@@ -252,7 +268,7 @@ export default function ReplayView({ currentTime, eventEntries, turnStartMap, se
 
       return changed ? next : prev;
     });
-  });
+  }, [viewportHeight, windowMeasurementKey]);
 
   function handleScroll(e) {
     var nextTop = e.currentTarget.scrollTop;

--- a/src/lib/sessionLibrary.js
+++ b/src/lib/sessionLibrary.js
@@ -98,6 +98,17 @@ function getSessionContentKey(id) {
   return SESSION_CONTENT_PREFIX + id;
 }
 
+function removeStoredSessionContent(id, storage) {
+  var target = getStorage(storage);
+  if (!target || !id) return;
+
+  try {
+    target.removeItem(getSessionContentKey(id));
+  } catch (error) {
+    console.warn("Could not remove stored session content", error);
+  }
+}
+
 export function loadStoredSessionContent(id, storage) {
   var target = getStorage(storage);
   if (!target || !id) return "";
@@ -110,7 +121,7 @@ export function loadStoredSessionContent(id, storage) {
   }
 }
 
-function storeSessionContent(id, rawText, storage) {
+function storeSessionContent(id, rawText, storage, existingEntries) {
   var target = getStorage(storage);
   if (!target || !id || !rawText) return false;
 
@@ -118,9 +129,36 @@ function storeSessionContent(id, rawText, storage) {
     target.setItem(getSessionContentKey(id), rawText);
     return true;
   } catch (error) {
-    console.warn("Could not persist session content", error);
-    return false;
+    if (!(error && error.name === "QuotaExceededError")) {
+      console.warn("Could not persist session content", error);
+      return false;
+    }
   }
+
+  var evictableEntries = Array.isArray(existingEntries)
+    ? existingEntries
+      .filter(function (entry) { return entry && entry.id && entry.id !== id && entry.hasContent; })
+      .sort(function (left, right) {
+        return String(left.updatedAt || left.importedAt || "").localeCompare(String(right.updatedAt || right.importedAt || ""));
+      })
+    : [];
+
+  for (var index = 0; index < evictableEntries.length; index += 1) {
+    removeStoredSessionContent(evictableEntries[index].id, target);
+
+    try {
+      target.setItem(getSessionContentKey(id), rawText);
+      return true;
+    } catch (retryError) {
+      if (!(retryError && retryError.name === "QuotaExceededError")) {
+        console.warn("Could not persist session content", retryError);
+        return false;
+      }
+    }
+  }
+
+  console.warn("Could not persist session content because storage quota was exceeded", { id: id });
+  return false;
 }
 
 export function buildSessionLibraryEntry(fileName, result, rawText, previousEntry) {
@@ -175,7 +213,7 @@ export function persistSessionSnapshot(fileName, result, rawText, storage) {
 
   var previousEntry = existingIndex >= 0 ? existingEntries[existingIndex] : null;
   var entry = buildSessionLibraryEntry(fileName, result, rawText, previousEntry);
-  entry.hasContent = storeSessionContent(entry.id, rawText, target);
+  entry.hasContent = storeSessionContent(entry.id, rawText, target, existingEntries);
 
   var nextEntries = existingEntries.slice();
   if (existingIndex >= 0) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,7 @@ import App from './App.jsx'
 class RootErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { hasError: false, error: null, resetKey: 0 };
+    this.state = { hasError: false, error: null, componentStack: "", resetKey: 0 };
     this.handleReset = this.handleReset.bind(this);
   }
 
@@ -14,12 +14,22 @@ class RootErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, info) {
+    var componentStack = info && info.componentStack ? info.componentStack : "";
+    if (typeof window !== "undefined") {
+      window.__AGENTVIZ_LAST_CRASH__ = {
+        message: error && error.message ? error.message : String(error),
+        stack: error && error.stack ? error.stack : "",
+        componentStack: componentStack,
+        timestamp: new Date().toISOString(),
+      };
+    }
     console.error("[AgentViz crash]", error, info && info.componentStack);
+    this.setState({ componentStack: componentStack });
   }
 
   handleReset() {
     this.setState(function (prev) {
-      return { hasError: false, error: null, resetKey: (prev.resetKey || 0) + 1 };
+      return { hasError: false, error: null, componentStack: "", resetKey: (prev.resetKey || 0) + 1 };
     });
   }
 
@@ -41,6 +51,22 @@ class RootErrorBoundary extends React.Component {
             overflowX: "auto", whiteSpace: "pre-wrap", wordBreak: "break-word",
           }
         }, msg),
+        !!(this.state.error && this.state.error.stack) && React.createElement("pre", {
+          style: {
+            background: "#0f141a", border: "1px solid #30363d", borderRadius: 8,
+            padding: "12px 16px", fontSize: 12, color: "#8b949e", maxWidth: 680,
+            overflowX: "auto", whiteSpace: "pre-wrap", wordBreak: "break-word",
+            margin: 0,
+          }
+        }, this.state.error.stack),
+        !!this.state.componentStack && React.createElement("pre", {
+          style: {
+            background: "#0f141a", border: "1px solid #30363d", borderRadius: 8,
+            padding: "12px 16px", fontSize: 12, color: "#8b949e", maxWidth: 680,
+            overflowX: "auto", whiteSpace: "pre-wrap", wordBreak: "break-word",
+            margin: 0,
+          }
+        }, this.state.componentStack),
         React.createElement("button", {
           onClick: this.handleReset,
           style: {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,10 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    port: 3000,
-    open: true,
-  },
+export default defineConfig(function ({ mode }) {
+  var isDebugBuild = mode === 'debug'
+
+  return {
+    plugins: [react()],
+    server: {
+      port: 3000,
+      open: true,
+    },
+    build: {
+      minify: isDebugBuild ? false : 'esbuild',
+      sourcemap: isDebugBuild,
+    },
+  }
 })


### PR DESCRIPTION
## Summary

This PR fixes an intermittent replay crash that was surfacing as React error 185 in the production bundle, improves session content persistence when localStorage is full, and adds a debug app path for easier browser-side diagnosis.

## What changed

### Replay render-loop fix

The replay crash was coming from ReplayView remeasuring visible rows inside a layout effect too aggressively. Under some session and selection states, that could repeatedly feed new measurement state back into layout and trigger a maximum update depth failure.

This change:
- scopes replay row measurement updates to a stable visible-window key instead of rerunning on every fresh windowedItems identity
- resets measured heights only when the effective event-entry window changes, rather than on incidental rerenders
- keeps the existing virtualized replay behavior while removing the render-loop path

### Session storage quota handling

Large imported sessions could exceed the browser localStorage quota when persisting raw session content, which produced noisy QuotaExceededError warnings and left persistence behavior brittle.

This change:
- retries raw-session persistence after evicting older cached session-content entries
- keeps metadata persistence intact even when content storage is tight
- logs a quota-specific warning only if storage still cannot succeed after eviction
- adds regression coverage for the quota-eviction behavior

### Debug build and crash diagnostics

External browser debugging was difficult because npm run app serves the production dist bundle, which minifies React errors.

This change adds:
- npm run build:debug for an unminified, sourcemapped debug build
- npm run app:debug to serve that debug build through the existing CLI entrypoint
- richer root crash diagnostics via window.__AGENTVIZ_LAST_CRASH__
- stack and component-stack rendering in the root crash fallback UI

### Ignore generated local artifact

This PR adds .vitest-targeted-output.txt to .gitignore so local captured test output does not show up as repo noise.

## Files included

- .gitignore
- package.json
- src/__tests__/sessionLibrary.test.js
- src/components/ReplayView.jsx
- src/lib/sessionLibrary.js
- src/main.jsx
- vite.config.js

## Verification

Focused tests run:

```bash
npx vitest run src/__tests__/sessionLibrary.test.js src/__tests__/session-ux.test.js src/__tests__/appRegression.test.jsx src/__tests__/mvpFlow.test.jsx
```

Result: 14/14 tests passed.

## Excluded artifacts

These were intentionally left out of the commit:
- agentviz-server.log
- .vitest-targeted-output.txt