### PR TITLE
chore: exclude ag and its log variations from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ coverage/
 
 # Local debug artifacts
 .vitest-targeted-output.txt
+
+# AGENTVIZ runtime artifacts
+agentviz-server.log
+ag.log
+ag-*.log
+ag.*.log
+*.ag.log


### PR DESCRIPTION
## Summary

I noticed `agentviz-server.log` after running a few of the files on a local clone. To avoid us from ever accidentally committing these, this PR adds `.gitignore` patterns targeting these:

- `agentviz-server.log` -- main server log
- `ag.log`, `ag-*.log`, `ag.*.log`, `*.ag.log` -- shorthand/variant log names

These files are generated at runtime by the backend (`bin/agentviz.js`) and should _not_ be tracked.