### PR TITLE
fix: add routes/ to npm files field

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bin",
     "mcp",
     "dist",
+    "routes",
     "server.js",
     "config.js",
     "src/lib",


### PR DESCRIPTION
## Problem

Running `npx agentviz` fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../node_modules/agentviz/routes/sessions.js'
imported from .../node_modules/agentviz/server.js
```

## Root Cause

`server.js` imports from `./routes/sessions.js`, `./routes/ai.js`, and `./routes/config.js`, but the `routes/` directory is not listed in the `files` field of `package.json`. This causes the entire `routes/` directory to be excluded from the published npm tarball.

## Fix

Add `"routes"` to the `files` array in `package.json`.