### PR TITLE
Implement theme-aware UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Reload VS Code after adding the config. In Copilot Chat, use **Agent mode** and 
 ### What happens when you invoke it
 
 `launch_agentviz` will:
+
 1. Auto-detect the most recently active session file (checks `~/.claude/projects/` and `~/.copilot/session-state/`)
 2. Start a local HTTP server on a free port
 3. Open the browser with live streaming enabled
@@ -176,6 +177,7 @@ Horizontal bar chart showing tool call counts for both sessions on the same axis
 Click **Export** in any header to download a single self-contained `.html` file. Share it with anyone -- no server required. Opening it reproduces the full session or comparison view exactly as you see it.
 
 Export is available in two places:
+
 - **Single session header** -- exports the current session
 - **Comparison header** -- exports both sessions and the full comparison view
 
@@ -340,7 +342,7 @@ src/
     aiCoachAgent.js      # AI Coach powered by @github/copilot-sdk (gpt-4o)
     qaClassifier.js      # Session Q&A instant answer engine (9 patterns + model context)
     qaAgent.js           # Q&A agent powered by @github/copilot-sdk for model fallback
-    theme.js             # Design tokens (true black base, blue/purple/green accents)
+    theme.js             # Design tokens (dark/light/system mode-aware palette)
     constants.js         # Sample events for demo mode
     replayLayout.js      # Virtualized windowing for large sessions
     commandPalette.js    # Precomputed fuzzy search index
@@ -426,7 +428,7 @@ npm run typecheck       # Type-check with tsc --noEmit
 
 ### Design System
 
-True black base (`#000000`) with blue, purple, and green accents. Vivid semantic colors: green for success, muted red for warning, bright red for error. All colors are defined as design tokens in `src/lib/theme.js`. JetBrains Mono throughout. No CSS framework; all styles are inline.
+True black base (`#000000`) with blue, purple, and green accents in dark mode, plus a matching light palette and a `Light / Dark / System` toggle in the top bar. Vivid semantic colors: green for success, muted red for warning, bright red for error. All colors are defined as design tokens in `src/lib/theme.js`. JetBrains Mono throughout. No CSS framework; all styles are inline.
 
 ### Configuration
 

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -24,6 +24,7 @@ The interface should feel fast, focused, and information-dense without ever feel
 ## 1. Color System
 
 All colors live in `src/lib/theme.js`. Components should reference `theme.*` tokens.
+The token names stay the same across modes, but the resolved values now follow the active `light`, `dark`, or `system` preference.
 
 **Known exceptions:** `LiveIndicator.jsx` hardcodes `#34d399` (teal green) and
 `CompareView.jsx` hardcodes `#a78bfa` (purple) for the Session B accent.
@@ -32,69 +33,71 @@ These are legacy exceptions -- new code should use theme tokens.
 
 ### Backgrounds
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.bg.base` | `#000000` | Page background, true black |
-| `theme.bg.surface` | `#0f0f16` | Cards, panels, raised surfaces |
-| `theme.bg.raised` | `#1a1a24` | Selected items, active states |
-| `theme.bg.overlay` | `rgba(0,0,0,0.7)` | Overlay backdrop |
-| `theme.bg.hover` | `#20202e` | Hover feedback |
-| `theme.bg.active` | `#26263a` | Active/pressed feedback |
+These values describe the active palette. The token names stay the same across modes, but the resolved values follow the current `light`, `dark`, or `system` preference.
+
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.bg.base` | `#000000` | `#f6f7fb` | Page background |
+| `theme.bg.surface` | `#0f0f16` | `#ffffff` | Cards, panels, raised surfaces |
+| `theme.bg.raised` | `#1a1a24` | `#eef1f7` | Selected items, active states |
+| `theme.bg.overlay` | `rgba(0,0,0,0.7)` | `rgba(17, 24, 39, 0.48)` | Overlay backdrop |
+| `theme.bg.hover` | `#20202e` | `#e5e9f2` | Hover feedback |
+| `theme.bg.active` | `#26263a` | `#d8deea` | Active/pressed feedback |
 
 ### Text
 
 Five-level hierarchy. Use the minimum contrast level that communicates the information.
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.text.primary` | `#f0f0f2` | Body text, values, important content |
-| `theme.text.secondary` | `#a1a1a8` | Labels, metadata, descriptions |
-| `theme.text.muted` | `#717178` | Disabled text, tertiary info |
-| `theme.text.dim` | `#585860` | Section headers (uppercase), subtle labels |
-| `theme.text.ghost` | `#454548` | Placeholders, gutter numbers, near-invisible |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.text.primary` | `#f0f0f2` | `#141824` | Body text, values, important content |
+| `theme.text.secondary` | `#a1a1a8` | `#4f5669` | Labels, metadata, descriptions |
+| `theme.text.muted` | `#717178` | `#70788d` | Disabled text, tertiary info |
+| `theme.text.dim` | `#585860` | `#8a90a2` | Section headers (uppercase), subtle labels |
+| `theme.text.ghost` | `#454548` | `#b0b6c8` | Placeholders, gutter numbers, near-invisible |
 
 ### Accent
 
 One color. Used for: selection, focus rings, primary actions, active tab indicators.
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.accent.primary` | `#6475e8` | Links, focus, selected, CTA |
-| `theme.accent.hover` | `#7585f0` | Hover state of accent elements |
-| `theme.accent.muted` | `#6475e820` | Subtle accent background (13% opacity) |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.accent.primary` | `#6475e8` | `#6475e8` | Links, focus, selected, CTA |
+| `theme.accent.hover` | `#7585f0` | `#5467e6` | Hover state of accent elements |
+| `theme.accent.muted` | `#6475e820` | `#6475e818` | Subtle accent background |
 
 ### Semantic
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.semantic.success` | `#10d97a` | Positive outcomes, output track, "done" |
-| `theme.semantic.warning` | `#d14d4d` | Caution, modified files |
-| `theme.semantic.error` | `#ef4444` | Errors, failures |
-| `theme.semantic.errorBg` | `#ef444415` | Error row/card background |
-| `theme.semantic.errorBorder` | `#ef444430` | Error container border |
-| `theme.semantic.errorText` | `#f87171` | Error text (lighter for readability) |
-| `theme.semantic.info` | `#6475e8` | Informational (same as accent) |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.semantic.success` | `#10d97a` | `#0ea86b` | Positive outcomes, output track, "done" |
+| `theme.semantic.warning` | `#d14d4d` | `#b45309` | Caution, modified files |
+| `theme.semantic.error` | `#ef4444` | `#d32f2f` | Errors, failures |
+| `theme.semantic.errorBg` | `#ef444415` | `#d32f2f14` | Error row/card background |
+| `theme.semantic.errorBorder` | `#ef444430` | `#d32f2f2a` | Error container border |
+| `theme.semantic.errorText` | `#f87171` | `#c53030` | Error text (lighter for readability) |
+| `theme.semantic.info` | `#6475e8` | `#6475e8` | Informational (same as accent) |
 
 ### Agent Colors
 
 Subtle. The content matters, not who said it.
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.agent.user` | `#8b8b99` | User messages |
-| `theme.agent.assistant` | `#6475e8` | Assistant messages |
-| `theme.agent.system` | `#a78bfa` | System messages |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.agent.user` | `#8b8b99` | `#70788d` | User messages |
+| `theme.agent.assistant` | `#6475e8` | `#6475e8` | Assistant messages |
+| `theme.agent.system` | `#a78bfa` | `#8b5cf6` | System messages |
 
 ### Track Colors
 
 Balanced luminance so no track visually dominates another.
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.track.reasoning` | `#94a3b8` | Thinking/reasoning events |
-| `theme.track.tool_call` | `#3b9eff` | Tool invocations |
-| `theme.track.context` | `#a78bfa` | Context loading |
-| `theme.track.output` | `#10d97a` | Output/results |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.track.reasoning` | `#94a3b8` | `#64748b` | Thinking/reasoning events |
+| `theme.track.tool_call` | `#3b9eff` | `#2563eb` | Tool invocations |
+| `theme.track.context` | `#a78bfa` | `#8b5cf6` | Context loading |
+| `theme.track.output` | `#10d97a` | `#0ea86b` | Output/results |
 
 ### Data Visualization Scales
 
@@ -187,6 +190,7 @@ and the view-switcher tab buttons in `AppHeader`. Using it elsewhere is a violat
 ### Typography Patterns
 
 **Section headers** -- uppercase, letter-spaced, dim. Two variants exist:
+
 ```jsx
 // Standard (view headers, page-level labels)
 {
@@ -208,6 +212,7 @@ and the view-switcher tab buttons in `AppHeader`. Using it elsewhere is a violat
 ```
 
 **Brand wordmark** -- UI font, tight tracking, accent dot:
+
 ```jsx
 {
   fontSize: theme.fontSize.lg,
@@ -220,6 +225,7 @@ and the view-switcher tab buttons in `AppHeader`. Using it elsewhere is a violat
 ```
 
 **Metric values** -- large, bold, colored:
+
 ```jsx
 {
   fontSize: 22,
@@ -229,6 +235,7 @@ and the view-switcher tab buttons in `AppHeader`. Using it elsewhere is a violat
 ```
 
 **Code/data content** -- mono, pre-wrap:
+
 ```jsx
 {
   fontFamily: theme.font.mono,
@@ -301,31 +308,35 @@ Depth is created through **thin borders**, not shadows. Shadows are used sparing
 
 ### Border Colors
 
-| Token | Hex | Use |
-|-------|-----|-----|
-| `theme.border.subtle` | `#1a1a24` | Nearly invisible dividers, diff gutters |
-| `theme.border.default` | `#232333` | Standard separators, card borders |
-| `theme.border.strong` | `#2e2e42` | Emphasized dividers, drag handles |
-| `theme.border.focus` | `#6475e8` | Focus rings (same as accent) |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.border.subtle` | `#1a1a24` | `#e4e8f0` | Nearly invisible dividers, diff gutters |
+| `theme.border.default` | `#232333` | `#d8deea` | Standard separators, card borders |
+| `theme.border.strong` | `#2e2e42` | `#c2cad8` | Emphasized dividers, drag handles |
+| `theme.border.focus` | `#6475e8` | `#6475e8` | Focus rings (same as accent) |
 
 ### Border Patterns
 
 **Standard card/panel:**
+
 ```jsx
 border: "1px solid " + theme.border.default
 ```
 
 **Dashed drop zone:**
+
 ```jsx
 border: "2px dashed " + (isDragOver ? theme.accent.primary : theme.border.strong)
 ```
 
 **Colored left-accent (selection/error):**
+
 ```jsx
 borderLeft: isSelected ? "2px solid " + barColor : "2px solid transparent"
 ```
 
 **Section divider line:**
+
 ```jsx
 <div style={{ flex: 1, height: 1, background: theme.border.default }} />
 ```
@@ -345,12 +356,12 @@ borderLeft: isSelected ? "2px solid " + barColor : "2px solid transparent"
 
 Minimal. Used only for floating/elevated elements.
 
-| Token | Value | Use |
-|-------|-------|-----|
-| `theme.shadow.sm` | `0 1px 2px rgba(0,0,0,0.3)` | Subtle lift |
-| `theme.shadow.md` | `0 4px 12px rgba(0,0,0,0.25)` | Modals, command palette |
-| `theme.shadow.lg` | `0 12px 32px rgba(0,0,0,0.35)` | Large floating panels |
-| `theme.shadow.inset` | `inset 0 1px 2px rgba(0,0,0,0.2)` | Pressed/inset effect |
+| Token | Dark | Light | Use |
+| --- | --- | --- | --- |
+| `theme.shadow.sm` | `0 1px 2px rgba(0,0,0,0.3)` | `0 1px 2px rgba(17,24,39,0.08)` | Subtle lift |
+| `theme.shadow.md` | `0 4px 12px rgba(0,0,0,0.25)` | `0 4px 12px rgba(17,24,39,0.08)` | Modals, command palette |
+| `theme.shadow.lg` | `0 12px 32px rgba(0,0,0,0.35)` | `0 12px 32px rgba(17,24,39,0.10)` | Large floating panels |
+| `theme.shadow.inset` | `inset 0 1px 2px rgba(0,0,0,0.2)` | `inset 0 1px 2px rgba(17,24,39,0.06)` | Pressed/inset effect |
 
 **Rule:** Shadows appear only on floating elements (modals, tooltips, dropdowns).
 Cards and panels rely on borders, not shadows, for depth.
@@ -364,6 +375,7 @@ All icons come from **Lucide React** via the `Icon` component (`src/components/I
 ### Registry Rule
 
 Every icon used in the app must be:
+
 1. Imported from `lucide-react` at the top of `Icon.jsx`, AND
 2. Added to the `ICON_MAP` object in `Icon.jsx`.
 
@@ -423,6 +435,7 @@ Three CSS utility classes handle hover/active (defined in `index.html`):
 | `.av-search-wrap` | Focus-within: `border-color: var(--av-focus)` | -- | Boxed search wrappers (inbox, Q&A) |
 
 **Inline hover pattern** (when CSS class is insufficient):
+
 ```jsx
 background: isSelected ? theme.bg.raised : "transparent",
 transition: "background " + theme.transition.fast,
@@ -475,6 +488,7 @@ cursor: disabled ? "default" : "pointer",
 | `theme.transition.slow` | `300ms ease-out` | Layout transitions |
 
 **Rules:**
+
 - `ease-out` only. Never `ease-in` or `linear` for UI transitions (exception: playhead uses `linear`).
 - No decorative motion. Every animation must confirm a user action or communicate state.
 - Prefer transitions on `background`, `border-color`, `color`, `opacity`, `transform`.
@@ -518,6 +532,7 @@ in a conditional.
 
 The app shell uses `ShellFrame` at the top level. Individual views (ReplayView, TracksView, etc.)
 are rendered as children -- they are not each independently wrapped in `ShellFrame`.
+
 ```jsx
 {
   width: "100%",
@@ -534,6 +549,7 @@ are rendered as children -- they are not each independently wrapped in `ShellFra
 ### Resizable Split Panels
 
 `ResizablePanel` provides drag-to-resize splits:
+
 - Default split: `72% / 28%` (main content / sidebar inspector).
 - Minimum panel size: `120px` (configurable via `minPx`).
 - Drag handle: `6px` wide, `2px` visible indicator line, `24px` long.
@@ -543,6 +559,7 @@ are rendered as children -- they are not each independently wrapped in `ShellFra
 ### Sidebar Inspector
 
 Found in ReplayView, WaterfallView, GraphView, and StatsView. All panels follow a normalized standard:
+
 - Container: `padding: theme.space.lg` (12px), `gap: theme.space.lg` (12px), `display: "flex"`, `flexDirection: "column"`, `overflowY: "auto"`, `height: "100%"`.
 - Section headers: `fontSize: theme.fontSize.xs` (10px), `color: theme.text.dim`, `textTransform: "uppercase"`, `letterSpacing: 1`, `marginBottom: theme.space.md` (8px).
 - Body/stat rows: `fontSize: theme.fontSize.sm` (11px), label `color: theme.text.muted`, value `color: theme.text.primary`.
@@ -554,6 +571,7 @@ Found in ReplayView, WaterfallView, GraphView, and StatsView. All panels follow 
 ### Grid Layout
 
 Used for metric cards:
+
 ```jsx
 display: "grid",
 gridTemplateColumns: "1fr 1fr 1fr",
@@ -583,12 +601,14 @@ For card grids where each card represents a navigable item (sessions, experiment
 ```
 
 **States:**
+
 - Default: `border: 1px solid theme.border.default`, `background: theme.bg.surface`
 - Hover: `border-color: theme.border.strong`, `background: theme.bg.hover`
 - Use the `.av-interactive` class or inline `transition: theme.transition.fast`
 
 **Left-edge accent bar (optional):**
 Use a `::before`-style absolute-positioned div for color-coded status:
+
 ```jsx
 <div style={{
   position: "absolute",
@@ -602,6 +622,7 @@ Use a `::before`-style absolute-positioned div for color-coded status:
 ```
 
 **Card content layout:**
+
 - Header row: flex with `justifyContent: space-between` for title + timestamp
 - Metrics row: flex with `gap: 12` for inline stat chips
 - Summary: single line, truncated with `textOverflow: ellipsis`
@@ -613,6 +634,7 @@ override the button default. This ensures keyboard accessibility.
 **Two-tier rendering:**
 When a card may have full data or partial data (e.g., parsed vs discovered-only sessions),
 dim the partial cards:
+
 - Full data: normal rendering
 - Partial data: `opacity: 0.7` on the metrics row, show "Not yet analyzed" in `theme.text.dim`
 
@@ -626,6 +648,7 @@ dim the partial cards:
 **Toolbar containers with dropdowns must NOT use `overflow: hidden`.**
 Applying `overflow: hidden` to a toolbar or header row clips any absolutely-positioned
 dropdowns, menus, or tooltips that extend outside its bounds. Instead:
+
 - Set `position: relative` on the container to establish a stacking context.
 - Set `zIndex: theme.z.active` (2) on the container so it layers above scroll content.
 - Set `zIndex: theme.z.tooltip` (10) on the dropdown itself.
@@ -639,6 +662,7 @@ dropdowns, menus, or tooltips that extend outside its bounds. Instead:
 Three overlay patterns exist:
 
 **Command Palette** -- centered near top, blurred backdrop:
+
 ```jsx
 {
   position: "fixed",
@@ -650,6 +674,7 @@ Three overlay patterns exist:
 ```
 
 **Dialog Modal** (ShortcutsModal) -- centered, heavier backdrop, no blur:
+
 ```jsx
 {
   position: "fixed",
@@ -660,6 +685,7 @@ Three overlay patterns exist:
 ```
 
 **Landing Overlay** (drag-drop) -- near-opaque:
+
 ```jsx
 {
   background: alpha(theme.bg.base, 0.92),
@@ -667,6 +693,7 @@ Three overlay patterns exist:
 ```
 
 **Slide-over Drawer** (QADrawer) -- anchored to right edge, full height:
+
 ```jsx
 {
   position: "fixed",
@@ -682,6 +709,7 @@ Three overlay patterns exist:
   overflow: "hidden",
 }
 ```
+
 Drawers use flex column layout with a scrollable middle area (`flex: 1; minHeight: 0; overflowY: auto`) and a fixed input area at bottom. Dismiss via close button, Escape key, or a footer "Disable" link.
 
 All overlays dismiss on backdrop click via `e.stopPropagation()` on the inner container.
@@ -740,6 +768,7 @@ to theme tokens over time but are not blocking issues.
 ```
 
 **Rules:**
+
 - `pointerEvents: "none"` -- tooltips must never block clicks.
 - Show on `onMouseEnter`, hide on `onMouseLeave`.
 - Position above the element by default (`bottom: calc(100% + 8px)`).
@@ -808,6 +837,7 @@ New code should target the pattern above.
 Two variants exist:
 
 **ErrorBoundary** (catch-all):
+
 ```jsx
 {
   background: theme.bg.surface,
@@ -819,6 +849,7 @@ Two variants exist:
 ```
 
 **Error cards/rows** (inline in lists):
+
 ```jsx
 {
   background: theme.semantic.errorBg,
@@ -840,6 +871,7 @@ Two variants exist:
 Two loading patterns exist:
 
 **Primary loading screen** (AppLoadingState) -- border spinner:
+
 ```jsx
 <div style={{
   width: 20,
@@ -852,6 +884,7 @@ Two loading patterns exist:
 ```
 
 **Inline loading** (DebriefView) -- rotating Unicode star:
+
 ```jsx
 <span style={{
   animation: "spin 1.2s linear infinite",

--- a/index.html
+++ b/index.html
@@ -1,76 +1,217 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>AGENTVIZ</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <style>
-      :root {
-        --av-bg-hover: #20202e;
-        --av-bg-active: #26263a;
-        --av-focus: #6475e8;
-        --av-border: #2c2c30;
-        --av-border-strong: #3a3a3f;
-      }
 
-      * { margin: 0; padding: 0; box-sizing: border-box; }
-      body {
-        background: #000000;
-        overflow: hidden;
-        font-family: 'JetBrains Mono', monospace;
-      }
-      ::-webkit-scrollbar { width: 6px; height: 6px; }
-      ::-webkit-scrollbar-track { background: transparent; }
-      ::-webkit-scrollbar-thumb { background: #3a3a3f; border-radius: 3px; }
-      ::-webkit-scrollbar-thumb:hover { background: #45454b; }
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>AGENTVIZ</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+    rel="stylesheet" />
+  <script>
+    (function () {
+      var storageKey = "agentviz:theme-mode";
+      var clearedKey = "agentviz:theme-mode-cleared";
+      var preference = "dark";
 
-      *:focus-visible { outline: 2px solid var(--av-focus); outline-offset: 2px; }
-      *:focus:not(:focus-visible) { outline: none; }
-
-      /* Interactive button base class */
-      .av-btn {
-        cursor: pointer;
-        transition: background 80ms ease-out, border-color 80ms ease-out, color 80ms ease-out;
-      }
-      .av-btn:hover { background: var(--av-bg-hover); }
-      .av-btn:active { background: var(--av-bg-active); }
-
-      /* Interactive row/card hover class */
-      .av-interactive {
-        transition: background 80ms ease-out;
-      }
-      .av-interactive:hover { background: var(--av-bg-hover); }
-
-      /* Search input focus styling */
-      .av-search:focus { border-color: var(--av-focus) !important; outline: none !important; }
-      .av-search-wrap:focus-within { border-color: var(--av-focus) !important; }
-
-      @keyframes fadeIn {
-        from { opacity: 0; }
-        to { opacity: 1; }
-      }
-      @keyframes spin {
-        from { transform: rotate(0deg); }
-        to { transform: rotate(360deg); }
-      }
-      @keyframes pulse {
-        0%, 100% { opacity: 1; }
-        50% { opacity: 0.3; }
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        *, *::before, *::after {
-          animation-duration: 0.01ms !important;
-          transition-duration: 0.01ms !important;
+      try {
+        if (localStorage.getItem(clearedKey) !== "1") {
+          localStorage.removeItem(storageKey);
+          localStorage.setItem(clearedKey, "1");
         }
+      } catch (error) {
+        preference = "dark";
       }
-    </style>
-  </head>
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.jsx"></script>
-  </body>
+
+      var isLight = window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches;
+      var resolved = preference === "light" || preference === "dark" ? preference : (isLight ? "light" : "dark");
+      var tokens = resolved === "light" ? {
+        bgBase: "#f6f7fb",
+        bgSurface: "#ffffff",
+        bgHover: "#e5e9f2",
+        bgActive: "#d8deea",
+        focus: "#6475e8",
+        border: "#d8deea",
+        borderStrong: "#c2cad8",
+        textPrimary: "#141824",
+        textSecondary: "#4f5669",
+      } : {
+        bgBase: "#000000",
+        bgSurface: "#0f0f16",
+        bgHover: "#20202e",
+        bgActive: "#26263a",
+        focus: "#6475e8",
+        border: "#232333",
+        borderStrong: "#2e2e42",
+        textPrimary: "#f0f0f2",
+        textSecondary: "#a1a1a8",
+      };
+
+      var root = document.documentElement;
+      root.dataset.theme = resolved;
+      root.dataset.themePreference = preference;
+      root.style.colorScheme = resolved;
+      root.style.setProperty("--av-bg-base", tokens.bgBase);
+      root.style.setProperty("--av-bg-surface", tokens.bgSurface);
+      root.style.setProperty("--av-bg-hover", tokens.bgHover);
+      root.style.setProperty("--av-bg-active", tokens.bgActive);
+      root.style.setProperty("--av-focus", tokens.focus);
+      root.style.setProperty("--av-border", tokens.border);
+      root.style.setProperty("--av-border-strong", tokens.borderStrong);
+      root.style.setProperty("--av-text-primary", tokens.textPrimary);
+      root.style.setProperty("--av-text-secondary", tokens.textSecondary);
+    }());
+  </script>
+  <style>
+    :root {
+      --av-bg-base: #000000;
+      --av-bg-surface: #0f0f16;
+      --av-bg-hover: #20202e;
+      --av-bg-active: #26263a;
+      --av-focus: #6475e8;
+      --av-border: #232333;
+      --av-border-strong: #2e2e42;
+      --av-text-primary: #f0f0f2;
+      --av-text-secondary: #a1a1a8;
+    }
+
+    :root[data-theme="light"] {
+      --av-bg-base: #f6f7fb;
+      --av-bg-surface: #ffffff;
+      --av-bg-hover: #e5e9f2;
+      --av-bg-active: #d8deea;
+      --av-focus: #6475e8;
+      --av-border: #d8deea;
+      --av-border-strong: #c2cad8;
+      --av-text-primary: #141824;
+      --av-text-secondary: #4f5669;
+    }
+
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      background: var(--av-bg-base);
+      color: var(--av-text-primary);
+      overflow: hidden;
+      font-family: 'JetBrains Mono', monospace;
+    }
+
+    html {
+      background: var(--av-bg-base);
+    }
+
+    ::-webkit-scrollbar {
+      width: 6px;
+      height: 6px;
+    }
+
+    ::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    ::-webkit-scrollbar-thumb {
+      background: var(--av-border-strong);
+      border-radius: 3px;
+    }
+
+    ::-webkit-scrollbar-thumb:hover {
+      background: var(--av-text-secondary);
+    }
+
+    *:focus-visible {
+      outline: 2px solid var(--av-focus);
+      outline-offset: 2px;
+    }
+
+    *:focus:not(:focus-visible) {
+      outline: none;
+    }
+
+    /* Interactive button base class */
+    .av-btn {
+      cursor: pointer;
+      transition: background 80ms ease-out, border-color 80ms ease-out, color 80ms ease-out;
+    }
+
+    .av-btn:hover {
+      background: var(--av-bg-hover);
+    }
+
+    .av-btn:active {
+      background: var(--av-bg-active);
+    }
+
+    /* Interactive row/card hover class */
+    .av-interactive {
+      transition: background 80ms ease-out;
+    }
+
+    .av-interactive:hover {
+      background: var(--av-bg-hover);
+    }
+
+    /* Search input focus styling */
+    .av-search:focus {
+      border-color: var(--av-focus) !important;
+      outline: none !important;
+    }
+
+    .av-search-wrap:focus-within {
+      border-color: var(--av-focus) !important;
+    }
+
+    @keyframes fadeIn {
+      from {
+        opacity: 0;
+      }
+
+      to {
+        opacity: 1;
+      }
+    }
+
+    @keyframes spin {
+      from {
+        transform: rotate(0deg);
+      }
+
+      to {
+        transform: rotate(360deg);
+      }
+    }
+
+    @keyframes pulse {
+
+      0%,
+      100% {
+        opacity: 1;
+      }
+
+      50% {
+        opacity: 0.3;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+
+      *,
+      *::before,
+      *::after {
+        animation-duration: 0.01ms !important;
+        transition-duration: 0.01ms !important;
+      }
+    }
+  </style>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.jsx"></script>
+</body>
+
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "^0.2.0",
@@ -120,6 +120,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -472,6 +473,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -520,6 +522,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1904,6 +1907,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2331,6 +2335,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2578,6 +2583,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.8.tgz",
       "integrity": "sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3057,6 +3063,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3169,6 +3176,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -3690,6 +3698,7 @@
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -3965,6 +3974,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useMemo, useCallback, useEffect } from "react";
-import { theme } from "./lib/theme.js";
+import { theme, getResolvedThemeMode, getThemeTokensForMode, setSystemThemePreference, setThemePreference } from "./lib/theme.js";
 import { exportSingleSession, exportComparison } from "./lib/exportHtml.js";
 import usePersistentState from "./hooks/usePersistentState.js";
 import useSessionLoader from "./hooks/useSessionLoader.js";
@@ -115,8 +115,13 @@ function renderActiveView(activeView, props) {
 
 export default function App() {
   var [view, setView] = usePersistentState("agentviz:view", "replay");
+  var [themeModePreference, setThemeModePreference] = usePersistentState("agentviz:theme-mode", "dark");
   var [libraryEntries, setLibraryEntries] = useState(function () {
     return readSessionLibrary();
+  });
+  var [systemThemeMode, setSystemThemeMode] = useState(function () {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return "dark";
+    return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
   });
   var [showPalette, setShowPalette] = useState(false);
   var [showShortcuts, setShowShortcuts] = useState(false);
@@ -206,6 +211,56 @@ export default function App() {
     onLines: session.appendLines,
   });
 
+  useEffect(function () {
+    if (typeof window === "undefined" || typeof window.matchMedia !== "function") return;
+
+    var mediaQuery = window.matchMedia("(prefers-color-scheme: light)");
+
+    function handleChange(event) {
+      setSystemThemeMode(event.matches ? "light" : "dark");
+    }
+
+    setSystemThemeMode(mediaQuery.matches ? "light" : "dark");
+
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", handleChange);
+      return function () {
+        mediaQuery.removeEventListener("change", handleChange);
+      };
+    }
+
+    mediaQuery.addListener(handleChange);
+    return function () {
+      mediaQuery.removeListener(handleChange);
+    };
+  }, []);
+
+  setThemePreference(themeModePreference);
+  setSystemThemePreference(systemThemeMode);
+
+  var resolvedThemeMode = getResolvedThemeMode(themeModePreference, systemThemeMode);
+
+  useEffect(function () {
+    if (typeof document === "undefined") return;
+
+    var tokens = getThemeTokensForMode(themeModePreference, systemThemeMode);
+
+    document.documentElement.dataset.theme = resolvedThemeMode;
+    document.documentElement.dataset.themePreference = themeModePreference;
+    document.documentElement.style.colorScheme = resolvedThemeMode;
+    document.documentElement.style.setProperty("--av-bg-base", tokens.bg.base);
+    document.documentElement.style.setProperty("--av-bg-surface", tokens.bg.surface);
+    document.documentElement.style.setProperty("--av-bg-hover", tokens.bg.hover);
+    document.documentElement.style.setProperty("--av-bg-active", tokens.bg.active);
+    document.documentElement.style.setProperty("--av-focus", tokens.border.focus);
+    document.documentElement.style.setProperty("--av-border", tokens.border.default);
+    document.documentElement.style.setProperty("--av-border-strong", tokens.border.strong);
+    document.documentElement.style.setProperty("--av-text-primary", tokens.text.primary);
+    document.documentElement.style.setProperty("--av-text-secondary", tokens.text.secondary);
+    document.body.style.background = tokens.bg.base;
+    document.body.style.color = tokens.text.primary;
+  }, [themeModePreference, systemThemeMode, resolvedThemeMode]);
+
   var autonomyMetrics = useMemo(function () {
     return buildAutonomyMetrics(session.events, session.turns, session.metadata);
   }, [session.events, session.turns, session.metadata]);
@@ -246,14 +301,14 @@ export default function App() {
     }
 
     if (entry.isDiscovered && entry.discoveredPath) {
-      discovered.fetchSessionContent(entry.discoveredPath).then(afterLoad).catch(function () {});
+      discovered.fetchSessionContent(entry.discoveredPath).then(afterLoad).catch(function () { });
       return;
     }
 
     var rawText = loadStoredSessionContent(entry.id);
     if (rawText) { afterLoad(rawText); return; }
     if (entry.discoveredPath) {
-      discovered.fetchSessionContent(entry.discoveredPath).then(afterLoad).catch(function () {});
+      discovered.fetchSessionContent(entry.discoveredPath).then(afterLoad).catch(function () { });
       return;
     }
   }, [handleFile, setView, setLibraryEntries, discovered.fetchSessionContent]);
@@ -363,6 +418,8 @@ export default function App() {
         session={session}
         activeView={activeView}
         setView={setView}
+        currentThemeMode={themeModePreference}
+        onSetThemeMode={setThemeModePreference}
         autonomyMetrics={autonomyMetrics}
         debrief={debrief}
         showPalette={showPalette}
@@ -395,6 +452,7 @@ function AppSessionView({
   showFilters, setShowFilters, showQA, setShowQA, qaFlag,
   searchInputRef, filtersRef, reset, allSessions, openStoredSession,
   handleExportSession, sessionExport, setCompareLanding,
+  currentThemeMode, onSetThemeMode,
 }) {
   var pb = usePlaybackContext();
 
@@ -481,6 +539,8 @@ function AppSessionView({
         activeView={activeView}
         views={APP_VIEWS}
         onSetView={setView}
+        currentThemeMode={currentThemeMode}
+        onSetThemeMode={onSetThemeMode}
         onReset={reset}
         search={pb.search}
         searchInputRef={searchInputRef}

--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -31,6 +31,10 @@ import {
   ArrowRight,
   Send,
   Sparkles,
+  SunMedium,
+  Moon,
+  Monitor,
+  Check,
 } from "lucide-react";
 
 var ICON_MAP = {
@@ -66,6 +70,10 @@ var ICON_MAP = {
   "arrow-right": ArrowRight,
   send: Send,
   sparkles: Sparkles,
+  sun: SunMedium,
+  moon: Moon,
+  monitor: Monitor,
+  check: Check,
 };
 
 export default function Icon({ name, size, strokeWidth, style, className }) {

--- a/src/components/app/AppHeader.jsx
+++ b/src/components/app/AppHeader.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { TRACK_TYPES, alpha, theme } from "../../lib/theme.js";
+import { TRACK_TYPES, THEME_MODES, alpha, theme } from "../../lib/theme.js";
 import LiveIndicator from "../LiveIndicator.jsx";
 import Icon from "../Icon.jsx";
 import BrandWordmark from "../ui/BrandWordmark.jsx";
@@ -27,6 +27,8 @@ export default function AppHeader({
   onToggleTrackFilter,
   speed,
   onCycleSpeed,
+  currentThemeMode,
+  onSetThemeMode,
   onStartCompare,
   hasRawText,
   onExportSession,
@@ -37,11 +39,13 @@ export default function AppHeader({
   currentFile,
 }) {
   var [showRecent, setShowRecent] = useState(false);
+  var [showThemeMenu, setShowThemeMenu] = useState(false);
 
   var showSearch = activeView === "replay" || activeView === "tracks" || activeView === "waterfall";
   var showFiltersBtn = activeView === "replay" || activeView === "tracks" || activeView === "waterfall";
   var showSpeed = activeView === "replay" || activeView === "tracks" || activeView === "waterfall";
   var showErrorNav = activeView === "replay";
+  var currentTheme = THEME_MODES.find(function (item) { return item.id === currentThemeMode; }) || THEME_MODES[0];
 
   return (
     <div style={{
@@ -293,6 +297,76 @@ export default function AppHeader({
             {speed}x
           </ToolbarButton>
         )}
+
+        <div style={{ position: "relative" }}>
+          <ToolbarButton
+            onClick={function () { setShowThemeMenu(function (value) { return !value; }); }}
+            title={"Theme: " + currentTheme.label + " (click to change)"}
+            aria-label="Theme selector"
+            style={{
+              background: showThemeMenu ? alpha(theme.accent.primary, 0.08) : "transparent",
+              border: "1px solid " + (showThemeMenu ? theme.accent.primary : theme.border.default),
+              color: showThemeMenu ? theme.accent.primary : theme.text.muted,
+              padding: "2px 6px",
+              minWidth: 28,
+              justifyContent: "center",
+            }}
+          >
+            <Icon name={currentTheme.icon} size={12} />
+          </ToolbarButton>
+          {showThemeMenu && (
+            <div style={{
+              position: "absolute",
+              top: "calc(100% + 6px)",
+              right: 0,
+              background: theme.bg.surface,
+              border: "1px solid " + theme.border.strong,
+              borderRadius: theme.radius.lg,
+              padding: 6,
+              zIndex: theme.z.tooltip,
+              boxShadow: theme.shadow.md,
+              minWidth: 152,
+            }}>
+              {THEME_MODES.map(function (item) {
+                var isSelected = item.id === currentThemeMode;
+                return (
+                  <button
+                    key={item.id}
+                    className="av-interactive"
+                    onClick={function () {
+                      onSetThemeMode(item.id);
+                      setShowThemeMenu(false);
+                    }}
+                    style={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 8,
+                      padding: "6px 10px",
+                      borderRadius: theme.radius.md,
+                      width: "100%",
+                      background: "transparent",
+                      border: "none",
+                      cursor: "pointer",
+                      textAlign: "left",
+                    }}
+                  >
+                    <span style={{ display: "inline-flex", alignItems: "center", justifyContent: "center", width: 16 }}>
+                      <Icon name={item.icon} size={12} style={{ color: isSelected ? theme.accent.primary : theme.text.secondary }} />
+                    </span>
+                    <span style={{
+                      flex: 1,
+                      fontSize: theme.fontSize.xs,
+                      fontFamily: theme.font.mono,
+                      color: theme.text.primary,
+                    }}>
+                      {item.label}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
 
         <ToolbarButton onClick={onStartCompare} title="Compare with another session" aria-label="Compare with another session" style={{ padding: "2px 6px" }}>
           <Icon name="arrow-up-down" size={12} />

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -1,78 +1,14 @@
 /**
  * AGENTVIZ Design Tokens
  *
- * Dark palette, blue/purple/grey accents. Color means something.
+ * Mode-aware palette with dark, light, and system preferences.
  * Inspired by Linear, Raycast, Vercel -- tools that feel quiet and fast.
  */
 
-export const theme = {
-  // ── Backgrounds ──
-  // True black base, cool dark grays
-  bg: {
-    base: "#000000",
-    surface: "#0f0f16",
-    raised: "#1a1a24",
-    overlay: "rgba(0, 0, 0, 0.7)",
-    hover: "#20202e",
-    active: "#26263a",
-  },
+var THEME_STORAGE_KEY = "agentviz:theme-mode";
+var THEME_STORAGE_CLEARED_KEY = "agentviz:theme-mode-cleared";
 
-  // ── Borders ──
-  // Depth through thin lines, not shadows
-  border: {
-    subtle: "#1a1a24",
-    default: "#232333",
-    strong: "#2e2e42",
-    focus: "#6475e8",
-  },
-
-  // ── Text ──
-  // Clear hierarchy, no lavender tint
-  text: {
-    primary: "#f0f0f2",
-    secondary: "#a1a1a8",
-    muted: "#717178",
-    dim: "#585860",
-    ghost: "#454548",
-  },
-
-  // ── Accent ──
-  // One color. Used for: selection, focus, primary actions.
-  accent: {
-    primary: "#6475e8",
-    hover: "#7585f0",
-    muted: "#6475e820",
-  },
-
-  // ── Semantic ──
-  semantic: {
-    success: "#10d97a",
-    warning: "#d14d4d",
-    error: "#ef4444",
-    errorBg: "#ef444415",
-    errorBorder: "#ef444430",
-    errorText: "#f87171",
-    info: "#6475e8",
-  },
-
-  // ── Agent colors ──
-  // Subtle. The content matters, not who said it.
-  agent: {
-    user: "#8b8b99",
-    assistant: "#6475e8",
-    system: "#a78bfa",
-  },
-
-  // ── Track colors ──
-  // Balanced luminance so no track dominates
-  track: {
-    reasoning: "#94a3b8",
-    tool_call: "#3b9eff",
-    context: "#a78bfa",
-    output: "#10d97a",
-  },
-
-  // ── Typography ──
+var SHARED_THEME = {
   font: {
     mono: "'JetBrains Mono', monospace",
     ui: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif",
@@ -87,9 +23,6 @@ export const theme = {
     xxl: 24,
     hero: 32,
   },
-
-  // ── Spacing ──
-  // 4px grid
   space: {
     xs: 2,
     sm: 4,
@@ -101,8 +34,6 @@ export const theme = {
     huge: 40,
     giant: 56,
   },
-
-  // ── Radii ──
   radius: {
     sm: 4,
     md: 6,
@@ -111,31 +42,12 @@ export const theme = {
     xxl: 12,
     full: 9999,
   },
-
-  // ── Shadows ──
-  // Minimal. No glows.
-  shadow: {
-    sm: "0 1px 2px rgba(0,0,0,0.3)",
-    md: "0 4px 12px rgba(0,0,0,0.25)",
-    lg: "0 12px 32px rgba(0,0,0,0.35)",
-    inset: "inset 0 1px 2px rgba(0,0,0,0.2)",
-  },
-
-  // ── Focus ──
-  focus: {
-    ring: "0 0 0 2px #6475e8",
-  },
-
-  // ── Animation ──
-  // Snappy, ease-out only. No decorative motion.
   transition: {
     fast: "80ms ease-out",
     base: "150ms ease-out",
     smooth: "200ms ease-out",
     slow: "300ms ease-out",
   },
-
-  // ── Z-index layers ──
   z: {
     base: 1,
     active: 2,
@@ -144,17 +56,270 @@ export const theme = {
     overlay: 50,
     modal: 100,
   },
+  focus: {
+    ring: "0 0 0 2px #6475e8",
+  },
 };
 
-// ── Track metadata ──
+var DARK_THEME = {
+  bg: {
+    base: "#000000",
+    surface: "#0f0f16",
+    raised: "#1a1a24",
+    overlay: "rgba(0, 0, 0, 0.7)",
+    hover: "#20202e",
+    active: "#26263a",
+  },
+  border: {
+    subtle: "#1a1a24",
+    default: "#232333",
+    strong: "#2e2e42",
+    focus: "#6475e8",
+  },
+  text: {
+    primary: "#f0f0f2",
+    secondary: "#a1a1a8",
+    muted: "#717178",
+    dim: "#585860",
+    ghost: "#454548",
+  },
+  accent: {
+    primary: "#6475e8",
+    hover: "#7585f0",
+    muted: "#6475e820",
+  },
+  semantic: {
+    success: "#10d97a",
+    warning: "#d14d4d",
+    error: "#ef4444",
+    errorBg: "#ef444415",
+    errorBorder: "#ef444430",
+    errorText: "#f87171",
+    info: "#6475e8",
+  },
+  agent: {
+    user: "#8b8b99",
+    assistant: "#6475e8",
+    system: "#a78bfa",
+  },
+  track: {
+    reasoning: "#94a3b8",
+    tool_call: "#3b9eff",
+    context: "#a78bfa",
+    output: "#10d97a",
+  },
+  shadow: {
+    sm: "0 1px 2px rgba(0,0,0,0.3)",
+    md: "0 4px 12px rgba(0,0,0,0.25)",
+    lg: "0 12px 32px rgba(0,0,0,0.35)",
+    inset: "inset 0 1px 2px rgba(0,0,0,0.2)",
+  },
+};
+
+var LIGHT_THEME = {
+  bg: {
+    base: "#f6f7fb",
+    surface: "#ffffff",
+    raised: "#eef1f7",
+    overlay: "rgba(17, 24, 39, 0.48)",
+    hover: "#e5e9f2",
+    active: "#d8deea",
+  },
+  border: {
+    subtle: "#e4e8f0",
+    default: "#d8deea",
+    strong: "#c2cad8",
+    focus: "#6475e8",
+  },
+  text: {
+    primary: "#141824",
+    secondary: "#4f5669",
+    muted: "#70788d",
+    dim: "#8a90a2",
+    ghost: "#b0b6c8",
+  },
+  accent: {
+    primary: "#6475e8",
+    hover: "#5467e6",
+    muted: "#6475e818",
+  },
+  semantic: {
+    success: "#0ea86b",
+    warning: "#b45309",
+    error: "#d32f2f",
+    errorBg: "#d32f2f14",
+    errorBorder: "#d32f2f2a",
+    errorText: "#c53030",
+    info: "#6475e8",
+  },
+  agent: {
+    user: "#70788d",
+    assistant: "#6475e8",
+    system: "#8b5cf6",
+  },
+  track: {
+    reasoning: "#64748b",
+    tool_call: "#2563eb",
+    context: "#8b5cf6",
+    output: "#0ea86b",
+  },
+  shadow: {
+    sm: "0 1px 2px rgba(17,24,39,0.08)",
+    md: "0 4px 12px rgba(17,24,39,0.08)",
+    lg: "0 12px 32px rgba(17,24,39,0.10)",
+    inset: "inset 0 1px 2px rgba(17,24,39,0.06)",
+  },
+};
+
+var themePreference = "dark";
+var systemThemePreference = "dark";
+
+function clearStoredThemePreference() {
+  if (typeof window === "undefined") return;
+  try {
+    if (window.localStorage.getItem(THEME_STORAGE_CLEARED_KEY) === "1") return;
+    window.localStorage.removeItem(THEME_STORAGE_KEY);
+    window.localStorage.setItem(THEME_STORAGE_CLEARED_KEY, "1");
+  } catch (error) {
+    // Ignore storage access failures during bootstrap.
+  }
+}
+
+function normalizeThemePreference(mode) {
+  return mode === "light" || mode === "dark" ? mode : "system";
+}
+
+function normalizeResolvedMode(mode) {
+  return mode === "light" ? "light" : "dark";
+}
+
+function readStoredThemePreference() {
+  if (typeof window === "undefined") return themePreference;
+  try {
+    var raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (!raw) return themePreference;
+
+    try {
+      return normalizeThemePreference(JSON.parse(raw));
+    } catch (parseError) {
+      return normalizeThemePreference(raw);
+    }
+  } catch (error) {
+    return themePreference;
+  }
+}
+
+function readSystemThemePreference() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return systemThemePreference;
+  return window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark";
+}
+
+function resolveThemeMode(mode, systemMode) {
+  var preference = normalizeThemePreference(typeof mode === "undefined" ? themePreference : mode);
+  var resolvedSystemMode = normalizeResolvedMode(typeof systemMode === "undefined" ? systemThemePreference : systemMode);
+  return preference === "system" ? resolvedSystemMode : preference;
+}
+
+function getThemeTokens(mode, systemMode) {
+  return resolveThemeMode(mode, systemMode) === "light"
+    ? Object.assign({}, SHARED_THEME, LIGHT_THEME)
+    : Object.assign({}, SHARED_THEME, DARK_THEME);
+}
+
+export function setThemePreference(mode) {
+  themePreference = normalizeThemePreference(mode);
+}
+
+export function getThemePreference() {
+  return themePreference;
+}
+
+export function setSystemThemePreference(mode) {
+  systemThemePreference = normalizeResolvedMode(mode);
+}
+
+export function getSystemThemePreference() {
+  return systemThemePreference;
+}
+
+export function getResolvedThemeMode(mode, systemMode) {
+  return resolveThemeMode(mode, systemMode);
+}
+
+export function getThemeTokensForMode(mode, systemMode) {
+  return getThemeTokens(mode, systemMode);
+}
+
+export const THEME_MODES = [
+  { id: "system", label: "System", icon: "monitor" },
+  { id: "light", label: "Light", icon: "sun" },
+  { id: "dark", label: "Dark", icon: "moon" },
+];
+
+function defineThemeSection(target, key) {
+  Object.defineProperty(target, key, {
+    enumerable: true,
+    get: function () {
+      return getThemeTokens()[key];
+    },
+  });
+}
+
+export var theme = {};
+defineThemeSection(theme, "bg");
+defineThemeSection(theme, "border");
+defineThemeSection(theme, "text");
+defineThemeSection(theme, "accent");
+defineThemeSection(theme, "semantic");
+defineThemeSection(theme, "agent");
+defineThemeSection(theme, "track");
+defineThemeSection(theme, "shadow");
+theme.font = SHARED_THEME.font;
+theme.fontSize = SHARED_THEME.fontSize;
+theme.space = SHARED_THEME.space;
+theme.radius = SHARED_THEME.radius;
+theme.focus = SHARED_THEME.focus;
+theme.transition = SHARED_THEME.transition;
+theme.z = SHARED_THEME.z;
+Object.defineProperty(theme, "mode", {
+  enumerable: true,
+  get: function () {
+    return resolveThemeMode();
+  },
+});
+
+function createDynamicColorMap(keys) {
+  var result = {};
+  keys.forEach(function (key) {
+    Object.defineProperty(result, key, {
+      enumerable: true,
+      get: function () {
+        return getThemeTokens().agent[key];
+      },
+    });
+  });
+  return result;
+}
+
+export const AGENT_COLORS = createDynamicColorMap(["user", "assistant", "system"]);
+
+function createTrackInfo(key, label, icon) {
+  var result = { label: label, icon: icon };
+  Object.defineProperty(result, "color", {
+    enumerable: true,
+    get: function () {
+      return getThemeTokens().track[key];
+    },
+  });
+  return result;
+}
+
 export const TRACK_TYPES = {
-  reasoning: { label: "Reasoning", color: theme.track.reasoning, icon: "reasoning" },
-  tool_call: { label: "Tool Calls", color: theme.track.tool_call, icon: "tool_call" },
-  context: { label: "Context", color: theme.track.context, icon: "context" },
-  output: { label: "Output", color: theme.track.output, icon: "output" },
+  reasoning: createTrackInfo("reasoning", "Reasoning", "reasoning"),
+  tool_call: createTrackInfo("tool_call", "Tool Calls", "tool_call"),
+  context: createTrackInfo("context", "Context", "context"),
+  output: createTrackInfo("output", "Output", "output"),
 };
-
-export const AGENT_COLORS = theme.agent;
 
 // ── Opacity helper ──
 export function alpha(hex, opacity) {
@@ -165,3 +330,7 @@ export function alpha(hex, opacity) {
   var b = parseInt(h.substring(4, 6), 16);
   return "rgba(" + r + "," + g + "," + b + "," + opacity + ")";
 }
+
+clearStoredThemePreference();
+setThemePreference(readStoredThemePreference());
+setSystemThemePreference(readSystemThemePreference());


### PR DESCRIPTION
For some, dark theme is hard to read and having the option to switch to a diff theme is helpful for a11y.

This change adds theming (retaining dark as default), and adds System/Light/Dark with a simple icon switcher in the toolbar area using standard visuals in web apps for this type of switching functionality.
<img width="317" height="237" alt="image" src="https://github.com/user-attachments/assets/02abed22-ee64-44e9-8abe-c94894cffdc4" />

Light theme on a session:
<img width="2484" height="1416" alt="image" src="https://github.com/user-attachments/assets/69819419-c86b-471f-ba76-886b0b269bfd" />

- Added theme mode switching functionality with light, dark, and system preferences.
- Enhanced CSS variables for dynamic theming based on user preference.
- Updated App component to manage theme state and apply styles accordingly.
- Introduced new icons for theme selection in the AppHeader component.