### PR TITLE
feat: add cache hit rate observability per turn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ src/
     sessionLibrary.js  # localStorage-backed session library with content persistence
     sessionParsing.ts  # Session parsing utilities and types
     sessionTypes.ts    # TypeScript type definitions for session data
+    cacheMetrics.ts    # Shared cache hit rate helpers
     autonomyMetrics.js # Human response time, idle gaps, intervention scoring
     projectConfig.js   # Project config surface detection (CLAUDE.md, .github/, etc.)
     aiCoachAgent.js    # AI Coach powered by @github/copilot-sdk (gpt-4o)

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Side-by-side metrics with delta badges:
 | Cost / PRUs | Green = A cheaper (delta suppressed for cross-agent comparisons since units differ) |
 | Input / Output tokens | Neutral |
 | Cache reads / writes | Neutral (shown only when cache data present) |
+| Cache hit rate | Neutral (shown only when cache data present) |
 | Premium requests (PRU) | Green = A uses fewer (shown only for Copilot sessions) |
 | Tool calls | Neutral |
 | Errors | Green = A has fewer |
@@ -232,7 +233,7 @@ Interactive directed graph of session turns with expandable tool-call structure.
 
 ### Stats View
 
-Aggregate metrics, event distribution bars, tools used ranking, and a per-turn summary. Includes token counts and estimated USD cost per turn for Claude models.
+Aggregate metrics, event distribution bars, tools used ranking, and a per-turn summary. Includes token counts, estimated USD cost per turn for Claude models, and per-turn cache hit rate (cache read / cache write / hit %) when prompt caching data is available.
 
 <div align="center">
 <img src="docs/screenshots/stats-view.png" alt="Stats View" width="800" />
@@ -377,6 +378,7 @@ src/
     sessionLibrary.js    # localStorage-backed session library with content persistence
     sessionParsing.ts    # Session parsing utilities and types
     sessionTypes.ts      # TypeScript type definitions for session data
+    cacheMetrics.ts      # Shared cache hit rate helpers
     autonomyMetrics.js   # Human response time, idle gaps, intervention scoring
     projectConfig.js     # Project config surface detection (CLAUDE.md, .github/, etc.)
     aiCoachAgent.js      # AI Coach powered by @github/copilot-sdk (gpt-4o)

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -593,6 +593,8 @@ The Graph view renders five distinct node types. All node text uses `theme.font.
 
 **Pre-fork and post-join tools:** Tools that execute before the fork or after the join are rendered as compound children of the host turn node, preserving parent-child edges via `parentToolCallId`.
 
+**Turn snippet priority:** real user message > cache metrics (for placeholder turns with `cacheRead > 0`) > tool call summary > first reasoning text > `"Turn {n}"`. Cache metric snippets use the format `{n} cache read / {n} cache write / cache hit rate {pct}%`.
+
 ### Grid Layout
 
 Used for metric cards:
@@ -1013,6 +1015,22 @@ Two loading patterns exist:
   - `<$0.01` for sub-cent
   - `$0.XXX` (3 decimals) for < $1
   - `$X.XX` (2 decimals) for >= $1
+
+### Cache Metrics
+
+Cache observability is shown when `cacheRead > 0` in token usage data.
+
+| Location | Format | Font | Style |
+|----------|--------|------|-------|
+| StatsView summary card | `{n} cache read / {n} cache write / {pct}% hit` | `theme.font.mono` | `fontSize: theme.fontSize.xs`, `color: theme.text.muted` |
+| StatsView per-turn row | `{n} cache read / {n} cache write / cache hit rate {pct}%` | `theme.font.mono` | `fontSize: theme.fontSize.xs`, `color: theme.text.muted` |
+| CompareView scorecard | `{pct}%` or `N/A` | `theme.font.mono` | Same as other scorecard rows, `lowerIsBetter: null` (neutral) |
+| GraphView turn snippet | `{n} cache read / {n} cache write / cache hit rate {pct}%` | Plain text | Only shown for placeholder turns (no real user message) |
+| Q&A cost answer | `- Cache write: {n}\n- Cache hit rate: {pct}%` | Markdown list | Appended to existing token usage lines |
+
+**Formula:** `cacheHitRate = cacheRead / ((inputTokens - cacheRead) + cacheWrite + cacheRead)`. Computed by `computeCacheHitRate()` in `src/lib/cacheMetrics.ts`. Returns `undefined` when denominator is zero.
+
+Percentages use `.toFixed(1)` (e.g. `85.3%`). Token counts use `.toLocaleString()` for thousands separators.
 
 ### Color Coding for Values
 

--- a/src/__tests__/cacheMetrics.test.js
+++ b/src/__tests__/cacheMetrics.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeCacheHitRate,
+  computeCacheHitRateDenomTokens,
+  computeEffectiveInputTokens,
+} from "../lib/cacheMetrics";
+
+describe("cacheMetrics", function () {
+  it("returns undefined when all token buckets are zero", function () {
+    expect(computeEffectiveInputTokens(0, 0)).toBe(0);
+    expect(computeCacheHitRateDenomTokens(0, 0, 0)).toBe(0);
+    expect(computeCacheHitRate(0, 0, 0)).toBeUndefined();
+  });
+
+  it("clamps negative cache write tokens out of the denominator", function () {
+    expect(computeEffectiveInputTokens(100, 20)).toBe(80);
+    expect(computeCacheHitRateDenomTokens(100, -50, 20)).toBe(100);
+    expect(computeCacheHitRate(100, -50, 20)).toBeCloseTo(0.2, 6);
+  });
+
+  it("handles large token counts with the shared cache hit rate formula", function () {
+    expect(computeEffectiveInputTokens(9000000, 4000000)).toBe(5000000);
+    expect(computeCacheHitRateDenomTokens(9000000, 1000000, 4000000)).toBe(10000000);
+    expect(computeCacheHitRate(9000000, 1000000, 4000000)).toBeCloseTo(0.4, 6);
+  });
+});

--- a/src/__tests__/copilotCliParser.test.js
+++ b/src/__tests__/copilotCliParser.test.js
@@ -390,10 +390,9 @@ describe("metadata", function () {
     expect(meta.codeChanges.filesModified).toContain("src/auth.js");
   });
 
-  it("computes token usage from modelMetrics", function () {
-    expect(meta.tokenUsage.inputTokens).toBe(5000);
-    expect(meta.tokenUsage.outputTokens).toBe(150);
-    expect(meta.tokenUsage.cacheRead).toBe(3000);
+  it("computes cache hit rate using copilot session semantics", function () {
+    expect(meta.tokenUsage.cacheHitRate).toBeCloseTo(3000 / ((5000 - 3000) + 0 + 3000), 6);
+    expect(meta.tokenUsage.denomTokens).toBe(5000);
   });
 
   it("uses null tokenUsage when no token counters are present", function () {
@@ -426,6 +425,8 @@ describe("metadata", function () {
     expect(meta.modelTokenUsage["claude-opus-4.6"].inputTokens).toBe(5000);
     expect(meta.modelTokenUsage["claude-opus-4.6"].outputTokens).toBe(150);
     expect(meta.modelTokenUsage["claude-opus-4.6"].cacheRead).toBe(3000);
+    expect(meta.modelTokenUsage["claude-opus-4.6"].cacheHitRate).toBeCloseTo(3000 / ((5000 - 3000) + 0 + 3000), 6);
+    expect(meta.modelTokenUsage["claude-opus-4.6"].denomTokens).toBe(5000);
   });
 
   it("returns null totalCost and modelTokenUsage when no shutdown data", function () {

--- a/src/__tests__/graphLayout.test.js
+++ b/src/__tests__/graphLayout.test.js
@@ -367,6 +367,14 @@ describe("buildTurnSnippet", function () {
     expect(buildTurnSnippet(turn, [])).toBe("Fix the login bug");
   });
 
+  it("keeps real user message ahead of cache metrics", function () {
+    var events = [
+      makeEvent(0, { track: "output", tokenUsage: { inputTokens: 1200, outputTokens: 300, cacheRead: 600, cacheWrite: 300 } }),
+    ];
+    var turn = makeTurn(0, [0], { userMessage: "Fix the login bug" });
+    expect(buildTurnSnippet(turn, events)).toBe("Fix the login bug");
+  });
+
   it("truncates long user messages", function () {
     var longMsg = "A".repeat(100);
     var turn = makeTurn(0, [], { userMessage: longMsg });

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -424,6 +424,7 @@ describe("parseClaudeCodeJSONL", function () {
       };
       var result = parseClaudeCodeJSONL(makeSession([USER_MSG, repeated1, repeated2, repeated3]));
       expect(result.metadata.tokenUsage.inputTokens).toBe(1000);
+      expect(result.metadata.tokenUsage.outputTokens).toBe(200);
       expect(result.metadata.tokenUsage.cacheRead).toBe(800);
       expect(result.metadata.tokenUsage.cacheWrite).toBe(0);
       expect(result.metadata.tokenUsage.cacheHitRate).toBeCloseTo(800 / ((1000 - 800) + 0 + 800), 6);

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -430,6 +430,13 @@ describe("parseClaudeCodeJSONL", function () {
       expect(result.metadata.tokenUsage.cacheHitRate).toBeCloseTo(800 / ((1000 - 800) + 0 + 800), 6);
     });
 
+    it("reports session duration", function () {
+      var result = parseClaudeCodeJSONL(makeSession([
+        USER_MSG, ASSISTANT_TEXT, ASSISTANT_TOOL_USE,
+      ]));
+      expect(result.metadata.duration).toBeGreaterThan(0);
+    });
+
   });
 
 

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -27,7 +27,7 @@ var ASSISTANT_TEXT = {
     content: [
       { type: "text", text: "Here is the Express.js project with TypeScript." },
     ],
-    usage: { input_tokens: 1200, output_tokens: 350 },
+    usage: { input_tokens: 1200, output_tokens: 350, cache_read_input_tokens: 600, cache_creation_input_tokens: 300 },
   },
 };
 
@@ -375,19 +375,60 @@ describe("parseClaudeCodeJSONL", function () {
       expect(result.metadata.primaryModel).toBe("claude-sonnet-4-20250514");
     });
 
-    it("aggregates token usage", function () {
+    it("aggregates cache buckets and cache hit rate", function () {
       var result = parseClaudeCodeJSONL(makeSession([ASSISTANT_TEXT]));
       if (result.metadata.tokenUsage) {
-        expect(result.metadata.tokenUsage.inputTokens).toBeGreaterThan(0);
+        expect(result.metadata.tokenUsage.cacheRead).toBe(600);
+        expect(result.metadata.tokenUsage.cacheWrite).toBe(300);
+        expect(result.metadata.tokenUsage.cacheHitRate).toBeCloseTo(600 / ((1200 - 600) + 300 + 600), 6);
+        expect(result.metadata.tokenUsage.denomTokens).toBe(1500);
       }
     });
 
-    it("reports session duration", function () {
-      var result = parseClaudeCodeJSONL(makeSession([
-        USER_MSG, ASSISTANT_TEXT, ASSISTANT_TOOL_USE,
-      ]));
-      expect(result.metadata.duration).toBeGreaterThan(0);
+    it("deduplicates usage across assistant records with the same message id", function () {
+      var repeated1 = {
+        type: "assistant",
+        timestamp: "2026-01-18T22:25:00.000Z",
+        message: {
+          id: "resp_same",
+          model: "claude-sonnet-4-20250514",
+          content: [
+            { type: "tool_use", id: "tool_a", name: "Read", input: { file_path: "/tmp/a" } },
+          ],
+          usage: { input_tokens: 1000, output_tokens: 0, cache_read_input_tokens: 800, cache_creation_input_tokens: 0 },
+        },
+      };
+      var repeated2 = {
+        type: "assistant",
+        timestamp: "2026-01-18T22:25:01.000Z",
+        message: {
+          id: "resp_same",
+          model: "claude-sonnet-4-20250514",
+          content: [
+            { type: "tool_use", id: "tool_b", name: "Grep", input: { pattern: "x" } },
+          ],
+          usage: { input_tokens: 1000, output_tokens: 0, cache_read_input_tokens: 800, cache_creation_input_tokens: 0 },
+        },
+      };
+      var repeated3 = {
+        type: "assistant",
+        timestamp: "2026-01-18T22:25:02.000Z",
+        message: {
+          id: "resp_same",
+          model: "claude-sonnet-4-20250514",
+          content: [
+            { type: "tool_use", id: "tool_c", name: "Bash", input: { command: "pwd" } },
+          ],
+          usage: { input_tokens: 1000, output_tokens: 200, cache_read_input_tokens: 800, cache_creation_input_tokens: 0 },
+        },
+      };
+      var result = parseClaudeCodeJSONL(makeSession([USER_MSG, repeated1, repeated2, repeated3]));
+      expect(result.metadata.tokenUsage.inputTokens).toBe(1000);
+      expect(result.metadata.tokenUsage.cacheRead).toBe(800);
+      expect(result.metadata.tokenUsage.cacheWrite).toBe(0);
+      expect(result.metadata.tokenUsage.cacheHitRate).toBeCloseTo(800 / ((1000 - 800) + 0 + 800), 6);
     });
+
   });
 
 

--- a/src/__tests__/qaClassifier.test.js
+++ b/src/__tests__/qaClassifier.test.js
@@ -25,7 +25,7 @@ function makeSession(overrides) {
     models: { "claude-sonnet-4": 3 },
     primaryModel: "claude-sonnet-4",
     format: "claude-code",
-    tokenUsage: { inputTokens: 5000, outputTokens: 2000, cacheRead: 1000 },
+    tokenUsage: { inputTokens: 5000, outputTokens: 2000, cacheRead: 1000, cacheWrite: 200, cacheHitRate: 1000 / ((5000) + 200 + 1000) },
   }, overrides.metadata || {});
   var autonomyMetrics = Object.assign({
     autonomyEfficiency: 0.72,
@@ -158,11 +158,10 @@ describe("classify: cost", function () {
     expect(r.answer).toContain("5,000");
   });
 
-  it("handles missing token data", function () {
-    var noTokens = makeSession({ metadata: { tokenUsage: null } });
-    var r = classify("how much did it cost?", noTokens);
+  it("includes cache hit rate when available", function () {
+    var r = classify("How much did this cost?", SESSION);
     expect(r.tier).toBe("instant");
-    expect(r.answer).toContain("No token usage");
+    expect(r.answer).toContain("Cache hit rate");
   });
 });
 

--- a/src/__tests__/qaClassifier.test.js
+++ b/src/__tests__/qaClassifier.test.js
@@ -25,7 +25,7 @@ function makeSession(overrides) {
     models: { "claude-sonnet-4": 3 },
     primaryModel: "claude-sonnet-4",
     format: "claude-code",
-    tokenUsage: { inputTokens: 5000, outputTokens: 2000, cacheRead: 1000, cacheWrite: 200, cacheHitRate: 1000 / ((5000) + 200 + 1000) },
+    tokenUsage: { inputTokens: 5000, outputTokens: 2000, cacheRead: 1000, cacheWrite: 200, cacheHitRate: 1000 / ((5000 - 1000) + 200 + 1000) },
   }, overrides.metadata || {});
   var autonomyMetrics = Object.assign({
     autonomyEfficiency: 0.72,
@@ -162,6 +162,13 @@ describe("classify: cost", function () {
     var r = classify("How much did this cost?", SESSION);
     expect(r.tier).toBe("instant");
     expect(r.answer).toContain("Cache hit rate");
+  });
+
+  it("handles missing token usage data", function () {
+    var noTokenUsage = makeSession({ metadata: { tokenUsage: null } });
+    var r = classify("How much did this cost?", noTokenUsage);
+    expect(r.tier).toBe("instant");
+    expect(r.answer).toContain("No token usage data available");
   });
 });
 

--- a/src/components/CompareView.jsx
+++ b/src/components/CompareView.jsx
@@ -15,6 +15,11 @@ function fmtMetric(n) {
   return n.toLocaleString();
 }
 
+function fmtPercent(n) {
+  if (n == null) return "N/A";
+  return (n * 100).toFixed(1) + "%";
+}
+
 function getFilesTouched(events) {
   var paths = new Set();
   if (!events) return 0;
@@ -59,6 +64,7 @@ export function buildMetrics(session) {
     outputTokens: hasTokenUsage ? (tu.outputTokens || 0) : null,
     cacheRead: hasTokenUsage ? (tu.cacheRead || 0) : null,
     cacheWrite: hasTokenUsage ? (tu.cacheWrite || 0) : null,
+    cacheHitRate: hasTokenUsage && tu.cacheHitRate != null ? tu.cacheHitRate : null,
     toolCalls: meta.totalToolCalls || 0,
     errors: meta.errorCount || 0,
     turns: meta.totalTurns || 0,
@@ -224,6 +230,9 @@ function Scorecard({ mA, mB, fileA, fileB, onOpenSessionA, onOpenSessionB }) {
       )}
       {cacheAvailable && (
         <Row label="Cache writes" valA={fmtMetric(mA.cacheWrite)} valB={fmtMetric(mB.cacheWrite)} a={mA.cacheWrite} b={mB.cacheWrite} lowerIsBetter={null} indent />
+      )}
+      {cacheAvailable && (
+        <Row label="Cache hit rate" valA={fmtPercent(mA.cacheHitRate)} valB={fmtPercent(mB.cacheHitRate)} a={mA.cacheHitRate} b={mB.cacheHitRate} lowerIsBetter={null} indent />
       )}
       {hasPRU && (
         <Row

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -2,6 +2,7 @@ import { theme, TRACK_TYPES, alpha } from "../lib/theme.js";
 import Icon from "./Icon.jsx";
 import { estimateCost, estimateMultiModelCost, formatCost, hasModelPricing } from "../lib/pricing.js";
 import { formatDurationLong } from "../lib/formatTime.js";
+import { computeCacheHitRate } from "../lib/cacheMetrics";
 import ToolbarButton from "./ui/ToolbarButton.jsx";
 import ResizablePanel from "./ResizablePanel.jsx";
 import { buildAutonomySummary } from "../lib/autonomyMetrics.js";
@@ -99,6 +100,7 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
         t.outputTokens += e.tokenUsage.outputTokens || 0;
         t.cacheRead += e.tokenUsage.cacheRead || 0;
         t.cacheWrite += e.tokenUsage.cacheWrite || 0;
+        t.cacheHitRate = computeCacheHitRate(t.inputTokens, t.cacheWrite, t.cacheRead);
         turnTokenMap[e.turnIndex] = t;
       }
       // Bucket by model; fall back to primaryModel for events without a model field
@@ -269,6 +271,8 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
                         {metadata.tokenUsage.cacheRead > 0 && (
                           <div style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, marginTop: 4 }}>
                             {metadata.tokenUsage.cacheRead.toLocaleString()} cache read
+                            {metadata.tokenUsage.cacheWrite > 0 ? " / " + metadata.tokenUsage.cacheWrite.toLocaleString() + " cache write" : ""}
+                            {metadata.tokenUsage.cacheHitRate != null ? " / " + (metadata.tokenUsage.cacheHitRate * 100).toFixed(1) + "% hit" : ""}
                           </div>
                         )}
                         <div style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, marginTop: 4 }}>{card.label}</div>
@@ -406,6 +410,11 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
                   {turnTokenMap[turn.index] && (
                     <span style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, flexShrink: 0 }}>
                       {formatCost(estimateCost(turnTokenMap[turn.index], metadata && metadata.primaryModel))}
+                    </span>
+                  )}
+                  {turnTokenMap[turn.index] && turnTokenMap[turn.index].cacheRead > 0 && (
+                    <span style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, flexShrink: 0 }}>
+                      {turnTokenMap[turn.index].cacheRead.toLocaleString()} cache read / {turnTokenMap[turn.index].cacheWrite.toLocaleString()} cache write / cache hit rate {turnTokenMap[turn.index].cacheHitRate != null ? (turnTokenMap[turn.index].cacheHitRate * 100).toFixed(1) : "0.0"}%
                     </span>
                   )}
                   {turn.hasError && (

--- a/src/lib/cacheMetrics.ts
+++ b/src/lib/cacheMetrics.ts
@@ -1,0 +1,22 @@
+export function computeEffectiveInputTokens(inputTokens: number, cacheReadTokens: number): number {
+  return Math.max(inputTokens - cacheReadTokens, 0);
+}
+
+export function computeCacheHitRateDenomTokens(
+  inputTokens: number,
+  cacheWriteTokens: number,
+  cacheReadTokens: number,
+): number {
+  var effectiveInput = computeEffectiveInputTokens(inputTokens, cacheReadTokens);
+  return effectiveInput + Math.max(cacheWriteTokens, 0) + Math.max(cacheReadTokens, 0);
+}
+
+export function computeCacheHitRate(
+  inputTokens: number,
+  cacheWriteTokens: number,
+  cacheReadTokens: number,
+): number | undefined {
+  var denom = computeCacheHitRateDenomTokens(inputTokens, cacheWriteTokens, cacheReadTokens);
+  if (denom <= 0) return undefined;
+  return Math.max(cacheReadTokens, 0) / denom;
+}

--- a/src/lib/copilotCliParser.ts
+++ b/src/lib/copilotCliParser.ts
@@ -22,6 +22,7 @@
  */
 
 import type { NormalizedEvent, ParsedSession, SessionMetadata, SessionTurn } from "./sessionTypes";
+import { computeCacheHitRate, computeCacheHitRateDenomTokens } from "./cacheMetrics";
 import type { TrackType } from "./theme";
 
 const MAX_TEXT_LENGTH = 4000;
@@ -537,7 +538,7 @@ function buildMetadata(
   let totalCacheReadTokens = 0;
   let totalCacheWriteTokens = 0;
   let totalCost: number | null = null;
-  let modelTokenUsage: Record<string, { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number }> | null = null;
+  let modelTokenUsage: Record<string, { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; cacheHitRate?: number; denomTokens?: number }> | null = null;
 
   if (sessionShutdown && sessionShutdown.modelMetrics) {
     const modelMetrics = sessionShutdown.modelMetrics;
@@ -546,15 +547,21 @@ function buildMetadata(
     for (const model of Object.keys(modelMetrics)) {
       const metric = modelMetrics[model];
       if (metric.usage) {
-        totalInputTokens += metric.usage.inputTokens || 0;
-        totalOutputTokens += metric.usage.outputTokens || 0;
-        totalCacheReadTokens += metric.usage.cacheReadTokens || 0;
-        totalCacheWriteTokens += metric.usage.cacheWriteTokens || 0;
+        const inputTokens = metric.usage.inputTokens || 0;
+        const outputTokens = metric.usage.outputTokens || 0;
+        const cacheReadTokens = metric.usage.cacheReadTokens || 0;
+        const cacheWriteTokens = metric.usage.cacheWriteTokens || 0;
+        totalInputTokens += inputTokens;
+        totalOutputTokens += outputTokens;
+        totalCacheReadTokens += cacheReadTokens;
+        totalCacheWriteTokens += cacheWriteTokens;
         modelTokenUsage[model] = {
-          inputTokens: metric.usage.inputTokens || 0,
-          outputTokens: metric.usage.outputTokens || 0,
-          cacheRead: metric.usage.cacheReadTokens || 0,
-          cacheWrite: metric.usage.cacheWriteTokens || 0,
+          inputTokens,
+          outputTokens,
+          cacheRead: cacheReadTokens,
+          cacheWrite: cacheWriteTokens,
+          cacheHitRate: computeCacheHitRate(inputTokens, cacheWriteTokens, cacheReadTokens),
+          denomTokens: computeCacheHitRateDenomTokens(inputTokens, cacheWriteTokens, cacheReadTokens),
         };
       }
       if (metric.requests) {
@@ -581,6 +588,9 @@ function buildMetadata(
 
   const context = sessionInfo && sessionInfo.context ? sessionInfo.context : {};
 
+  const cacheHitRate = computeCacheHitRate(totalInputTokens, totalCacheWriteTokens, totalCacheReadTokens);
+  const denomTokens = computeCacheHitRateDenomTokens(totalInputTokens, totalCacheWriteTokens, totalCacheReadTokens);
+
   return {
     totalEvents: events.length,
     totalTurns: turns.length,
@@ -595,6 +605,8 @@ function buildMetadata(
         outputTokens: totalOutputTokens,
         cacheRead: totalCacheReadTokens,
         cacheWrite: totalCacheWriteTokens,
+        cacheHitRate,
+        denomTokens,
       }
       : null,
     warnings,

--- a/src/lib/graphLayout.js
+++ b/src/lib/graphLayout.js
@@ -5,6 +5,7 @@
  * graph structure, then runs layout to get positioned nodes and edges.
  */
 import ELK from "elkjs/lib/elk-api.js";
+import { computeCacheHitRate } from "./cacheMetrics";
 
 var elk = new ELK({
   workerUrl: new URL("elkjs/lib/elk-worker.min.js", import.meta.url),
@@ -835,10 +836,32 @@ function getDominantTrack(events) {
   return dominant;
 }
 
+function summarizeTurnTokenUsage(turnEvents) {
+  var usage = { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0 };
+  var hasUsage = false;
+  for (var i = 0; i < turnEvents.length; i++) {
+    var tu = turnEvents[i].event && turnEvents[i].event.tokenUsage;
+    if (!tu) continue;
+    hasUsage = true;
+    usage.inputTokens += tu.inputTokens || 0;
+    usage.outputTokens += tu.outputTokens || 0;
+    usage.cacheRead += tu.cacheRead || 0;
+    usage.cacheWrite += tu.cacheWrite || 0;
+  }
+  if (!hasUsage || usage.cacheRead <= 0) return null;
+  usage.cacheHitRate = computeCacheHitRate(usage.inputTokens, usage.cacheWrite, usage.cacheRead);
+  return usage;
+}
+
 // Build a useful snippet for a turn node.
 // Priority: real user message > tool call summary > first reasoning text > fallback
 export function buildTurnSnippet(turn, turnEvents) {
   var msg = turn.userMessage || "";
+  var tokenUsage = summarizeTurnTokenUsage(turnEvents);
+
+  if (tokenUsage && tokenUsage.cacheRead > 0) {
+    return tokenUsage.cacheRead.toLocaleString() + " cache read / " + tokenUsage.cacheWrite.toLocaleString() + " cache write / cache hit rate " + (tokenUsage.cacheHitRate != null ? (tokenUsage.cacheHitRate * 100).toFixed(1) : "0.0") + "%";
+  }
 
   // If there's a real user message (not a placeholder), use it
   if (msg && msg !== "(continuation)" && msg !== "(system)") {

--- a/src/lib/graphLayout.js
+++ b/src/lib/graphLayout.js
@@ -854,18 +854,19 @@ function summarizeTurnTokenUsage(turnEvents) {
 }
 
 // Build a useful snippet for a turn node.
-// Priority: real user message > tool call summary > first reasoning text > fallback
+// Priority: real user message > cache metrics > tool call summary > first reasoning text > fallback
 export function buildTurnSnippet(turn, turnEvents) {
   var msg = turn.userMessage || "";
+  var hasRealUserMessage = msg && msg !== "(continuation)" && msg !== "(system)";
   var tokenUsage = summarizeTurnTokenUsage(turnEvents);
+
+  // If there's a real user message (not a placeholder), use it
+  if (hasRealUserMessage) {
+    return msg.length > 60 ? msg.slice(0, 57) + "..." : msg;
+  }
 
   if (tokenUsage && tokenUsage.cacheRead > 0) {
     return tokenUsage.cacheRead.toLocaleString() + " cache read / " + tokenUsage.cacheWrite.toLocaleString() + " cache write / cache hit rate " + (tokenUsage.cacheHitRate != null ? (tokenUsage.cacheHitRate * 100).toFixed(1) : "0.0") + "%";
-  }
-
-  // If there's a real user message (not a placeholder), use it
-  if (msg && msg !== "(continuation)" && msg !== "(system)") {
-    return msg.length > 60 ? msg.slice(0, 57) + "..." : msg;
   }
 
   // Summarize by tool calls used in this turn

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -186,14 +186,55 @@ function getUsageDedupKey(raw: RawRecord): string | null {
   return null;
 }
 
-function extractEventsFromRecord(raw: RawRecord, syntheticTime: number, issues: ParseIssues, seenUsageKeys?: Set<string>): NormalizedEvent[] {
+function mergeTokenUsage(previous: TokenUsage | null | undefined, next: TokenUsage): TokenUsage {
+  if (!previous) {
+    return {
+      inputTokens: next.inputTokens || 0,
+      outputTokens: next.outputTokens || 0,
+      cacheRead: next.cacheRead || 0,
+      cacheWrite: next.cacheWrite || 0,
+    };
+  }
+
+  return {
+    inputTokens: Math.max(previous.inputTokens || 0, next.inputTokens || 0),
+    outputTokens: Math.max(previous.outputTokens || 0, next.outputTokens || 0),
+    cacheRead: Math.max(previous.cacheRead || 0, next.cacheRead || 0),
+    cacheWrite: Math.max(previous.cacheWrite || 0, next.cacheWrite || 0),
+  };
+}
+
+function collectMergedUsageByKey(rawRecords: RawRecord[]): Map<string, TokenUsage> {
+  const usageByKey = new Map<string, TokenUsage>();
+
+  for (let index = 0; index < rawRecords.length; index += 1) {
+    const raw = rawRecords[index];
+    const usage = extractUsage(raw);
+    const usageDedupKey = getUsageDedupKey(raw);
+    if (!usage || !usageDedupKey) continue;
+
+    usageByKey.set(usageDedupKey, mergeTokenUsage(usageByKey.get(usageDedupKey), usage));
+  }
+
+  return usageByKey;
+}
+
+function extractEventsFromRecord(
+  raw: RawRecord,
+  syntheticTime: number,
+  issues: ParseIssues,
+  mergedUsageByKey?: Map<string, TokenUsage>,
+  attachedUsageKeys?: Set<string>,
+): NormalizedEvent[] {
   const events: NormalizedEvent[] = [];
   const timestamp = extractTimestamp(raw);
   const tSeconds = timestamp !== null ? timestamp : syntheticTime;
   const model = extractModel(raw);
-  const usage = extractUsage(raw);
-  const usageDedupKey = usage ? getUsageDedupKey(raw) : null;
-  const shouldAttachUsage = Boolean(usage) && (!usageDedupKey || !seenUsageKeys || !seenUsageKeys.has(usageDedupKey));
+  const usageDedupKey = getUsageDedupKey(raw);
+  const usage = usageDedupKey && mergedUsageByKey
+    ? mergedUsageByKey.get(usageDedupKey) || null
+    : extractUsage(raw);
+  const shouldAttachUsage = Boolean(usage) && (!usageDedupKey || !attachedUsageKeys || !attachedUsageKeys.has(usageDedupKey));
   let usageAttached = false;
 
   function pushEvent(event: Partial<NormalizedEvent>): void {
@@ -206,7 +247,7 @@ function extractEventsFromRecord(raw: RawRecord, syntheticTime: number, issues: 
     if (shouldAttachUsage && usage && !event.tokenUsage && !usageAttached) {
       event.tokenUsage = usage;
       usageAttached = true;
-      if (usageDedupKey && seenUsageKeys) seenUsageKeys.add(usageDedupKey);
+      if (usageDedupKey && attachedUsageKeys) attachedUsageKeys.add(usageDedupKey);
     }
     events.push(event);
   }
@@ -518,11 +559,12 @@ export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
   const hasRealTimestamps = timestampCount > rawRecords.length * 0.5;
 
   const events: NormalizedEvent[] = [];
-  const seenUsageKeys = new Set<string>();
+  const mergedUsageByKey = collectMergedUsageByKey(rawRecords);
+  const attachedUsageKeys = new Set<string>();
   let syntheticTime = 0;
 
   for (let index = 0; index < rawRecords.length; index += 1) {
-    const parsedEvents = extractEventsFromRecord(rawRecords[index], syntheticTime, issues, seenUsageKeys);
+    const parsedEvents = extractEventsFromRecord(rawRecords[index], syntheticTime, issues, mergedUsageByKey, attachedUsageKeys);
     events.push(...parsedEvents);
     syntheticTime += Math.max(1, parsedEvents.length);
   }

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -20,6 +20,7 @@
  */
 
 import type { NormalizedEvent, ParseIssues, ParsedSession, SessionMetadata, SessionTurn, TokenUsage } from "./sessionTypes";
+import { computeCacheHitRate, computeCacheHitRateDenomTokens } from "./cacheMetrics";
 
 type RawRecord = Record<string, any>;
 import { truncateText as truncate } from "./formatTime.js";
@@ -177,12 +178,23 @@ function detectError(block: MessageBlock, text: string): boolean {
   return ERROR_PATTERNS.some(function (pattern) { return pattern.test(text); });
 }
 
-function extractEventsFromRecord(raw: RawRecord, syntheticTime: number, issues: ParseIssues): NormalizedEvent[] {
+function getUsageDedupKey(raw: RawRecord): string | null {
+  const message = raw.message && typeof raw.message === "object" ? raw.message : null;
+  if ((raw.type === "assistant" || raw.role === "assistant") && message && typeof message.id === "string") {
+    return "assistant:" + message.id;
+  }
+  return null;
+}
+
+function extractEventsFromRecord(raw: RawRecord, syntheticTime: number, issues: ParseIssues, seenUsageKeys?: Set<string>): NormalizedEvent[] {
   const events: NormalizedEvent[] = [];
   const timestamp = extractTimestamp(raw);
   const tSeconds = timestamp !== null ? timestamp : syntheticTime;
   const model = extractModel(raw);
   const usage = extractUsage(raw);
+  const usageDedupKey = usage ? getUsageDedupKey(raw) : null;
+  const shouldAttachUsage = Boolean(usage) && (!usageDedupKey || !seenUsageKeys || !seenUsageKeys.has(usageDedupKey));
+  let usageAttached = false;
 
   function pushEvent(event: Partial<NormalizedEvent>): void {
     if (!isValidEvent(event)) {
@@ -191,7 +203,11 @@ function extractEventsFromRecord(raw: RawRecord, syntheticTime: number, issues: 
     }
 
     if (model && !event.model) event.model = model;
-    if (usage && !event.tokenUsage) event.tokenUsage = usage;
+    if (shouldAttachUsage && usage && !event.tokenUsage && !usageAttached) {
+      event.tokenUsage = usage;
+      usageAttached = true;
+      if (usageDedupKey && seenUsageKeys) seenUsageKeys.add(usageDedupKey);
+    }
     events.push(event);
   }
 
@@ -427,6 +443,8 @@ function buildMetadata(events: NormalizedEvent[], turns: SessionTurn[], issues: 
   const models: Record<string, number> = {};
   let totalInput = 0;
   let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCacheWrite = 0;
   let errorCount = 0;
   let toolCalls = 0;
 
@@ -436,6 +454,8 @@ function buildMetadata(events: NormalizedEvent[], turns: SessionTurn[], issues: 
     if (event.tokenUsage) {
       totalInput += event.tokenUsage.inputTokens || 0;
       totalOutput += event.tokenUsage.outputTokens || 0;
+      totalCacheRead += event.tokenUsage.cacheRead || 0;
+      totalCacheWrite += event.tokenUsage.cacheWrite || 0;
     }
     if (event.isError) errorCount += 1;
     if (event.track === "tool_call") toolCalls += 1;
@@ -449,6 +469,9 @@ function buildMetadata(events: NormalizedEvent[], turns: SessionTurn[], issues: 
     return right[1] - left[1];
   });
 
+  const cacheHitRate = computeCacheHitRate(totalInput, totalCacheWrite, totalCacheRead);
+  const denomTokens = computeCacheHitRateDenomTokens(totalInput, totalCacheWrite, totalCacheRead);
+
   return {
     totalEvents: events.length,
     totalTurns: turns.length,
@@ -457,8 +480,15 @@ function buildMetadata(events: NormalizedEvent[], turns: SessionTurn[], issues: 
     duration,
     models,
     primaryModel: modelEntries.length > 0 ? modelEntries[0][0] : null,
-    tokenUsage: totalInput + totalOutput > 0
-      ? { inputTokens: totalInput, outputTokens: totalOutput }
+    tokenUsage: totalInput + totalOutput + totalCacheRead + totalCacheWrite > 0
+      ? {
+        inputTokens: totalInput,
+        outputTokens: totalOutput,
+        cacheRead: totalCacheRead,
+        cacheWrite: totalCacheWrite,
+        cacheHitRate,
+        denomTokens,
+      }
       : null,
     warnings: buildWarnings(issues),
     parseIssues: issues,
@@ -488,10 +518,11 @@ export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
   const hasRealTimestamps = timestampCount > rawRecords.length * 0.5;
 
   const events: NormalizedEvent[] = [];
+  const seenUsageKeys = new Set<string>();
   let syntheticTime = 0;
 
   for (let index = 0; index < rawRecords.length; index += 1) {
-    const parsedEvents = extractEventsFromRecord(rawRecords[index], syntheticTime, issues);
+    const parsedEvents = extractEventsFromRecord(rawRecords[index], syntheticTime, issues, seenUsageKeys);
     events.push(...parsedEvents);
     syntheticTime += Math.max(1, parsedEvents.length);
   }

--- a/src/lib/qaClassifier.js
+++ b/src/lib/qaClassifier.js
@@ -185,6 +185,8 @@ function answerCost(data) {
   if (usage.inputTokens) lines.push("- Input tokens: " + usage.inputTokens.toLocaleString());
   if (usage.outputTokens) lines.push("- Output tokens: " + usage.outputTokens.toLocaleString());
   if (usage.cacheRead) lines.push("- Cache read: " + usage.cacheRead.toLocaleString());
+  if (usage.cacheWrite) lines.push("- Cache write: " + usage.cacheWrite.toLocaleString());
+  if (usage.cacheHitRate != null) lines.push("- Cache hit rate: " + (usage.cacheHitRate * 100).toFixed(1) + "%");
   if (model) lines.push("- Model: " + model);
   return instant(lines.join("\n"));
 }

--- a/src/lib/sessionTypes.ts
+++ b/src/lib/sessionTypes.ts
@@ -5,6 +5,8 @@ export interface TokenUsage {
   outputTokens?: number;
   cacheRead?: number;
   cacheWrite?: number;
+  cacheHitRate?: number;
+  denomTokens?: number;
 }
 
 export type SessionFormat = "claude-code" | "copilot-cli" | "vscode-chat";


### PR DESCRIPTION
## Summary
- Add cache hit rate as a first-class observability metric across supported session formats
- Fix Claude parser usage dedup for streamed assistant `message.id` snapshots without backpatching prior events
- Preserve Graph turn snippet priority for real user messages and tighten the QA/parser regression coverage

## Formula

```text
effectiveInput = inputTokens - cacheReadTokens
denom = effectiveInput + cacheWriteTokens + cacheReadTokens
cacheHitRate = cacheReadTokens / denom
```

Unified across formats. `input_tokens` already includes `cache_read_input_tokens` as a subset in Claude Code JSONL and Copilot CLI JSONL.

## Implementation notes

| File | What |
|------|------|
| `src/lib/cacheMetrics.ts` | Shared cache hit rate helpers |
| `src/lib/parser.ts` | Pre-collect merged usage by assistant `message.id`, then attach the merged usage once during event extraction |
| `src/lib/copilotCliParser.ts` | Add session-level and per-model `cacheHitRate` and `denomTokens` |
| `src/lib/sessionTypes.ts` | Extend `TokenUsage` with `cacheHitRate` and `denomTokens` |
| `src/components/StatsView.jsx` | Show per-turn cache read, cache write, and cache hit rate |
| `src/lib/graphLayout.js` | Keep real user messages ahead of cache snippets; show cache metrics for placeholder turns |
| `src/components/CompareView.jsx` | Add cache hit rate row in the comparison scorecard |
| `src/lib/qaClassifier.js` | Include cache write and hit rate in cost and usage answers |
| `src/__tests__/parser.test.js` | Cover repeated streamed usage snapshots for the same `message.id` |
| `src/__tests__/qaClassifier.test.js` | Fix cache-hit fixture math and restore missing token-usage coverage |
| `src/__tests__/graphLayout.test.js` | Cover real user message priority over cache snippets |

## Test Plan
- [x] `npm test -- --run src/__tests__/parser.test.js src/__tests__/graphLayout.test.js src/__tests__/qaClassifier.test.js`
- [x] `npm test`
- [x] `./node_modules/.bin/tsc --noEmit`
- [x] `./node_modules/.bin/vite build`
- [x] Load recent local Claude Code history files in AGENTVIZ and verify cache hit rate renders as expected

Closes #57
