### PR TITLE
fix: Multi-step filtering by tags in static manifest mode (follow-up PR #39)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -169,20 +169,21 @@ export default function App() {
         if (s.sessionId) discoveredBySessionId[s.sessionId] = s;
       });
 
-      // Enrich library entries with discoveredPath if we can match them to a discovered session
+      // Enrich library entries with discoveredPath from discovered/manifest sessions
       var enrichedLibrary = visibleLibraryEntries.map(function (e) {
         if (e.discoveredPath) return e; // already has it
         var match = (e.sessionId && discoveredBySessionId[e.sessionId])
-          || (e.discoveredPath && discoveredByPath[e.discoveredPath]);
+          || discoveredByPath[e.discoveredPath];
         if (match) return Object.assign({}, e, { discoveredPath: match.path });
         return e;
       });
 
-      // Only add discovered entries that aren't already in the library
+      // Only add discovered entries that aren't already in the library.
+      // Use enrichedLibrary (which has discoveredPath set) for accurate dedup.
       var discoveredOnly = discovered.sessions.filter(function (s) {
         if (s.source !== "manifest" && s.size < 5000) return false;
-        return !visibleLibraryEntries.some(function (e) {
-          return e.discoveredPath === s.path || e.sessionId === s.sessionId;
+        return !enrichedLibrary.some(function (e) {
+          return e.discoveredPath === s.path || (e.sessionId && e.sessionId === s.sessionId);
         });
       }).map(function (s) {
         return {
@@ -312,13 +313,18 @@ export default function App() {
     function afterLoad(rawText) {
       setView("stats");
       handleFile(rawText, sessionName);
-      if (sessionPath) {
+      // Patch discoveredPath and tags onto the persisted library entry so that
+      // tag filtering continues to work after the session is in localStorage.
+      var entryTags = entry.tags && entry.tags.length > 0 ? entry.tags : null;
+      if (sessionPath || entryTags) {
         setLibraryEntries(function (prev) {
           return prev.map(function (e) {
-            if (e.id === entry.id && !e.discoveredPath) {
-              return Object.assign({}, e, { discoveredPath: sessionPath });
-            }
-            return e;
+            if (e.id !== entry.id) return e;
+            var updates = {};
+            if (!e.discoveredPath && sessionPath) updates.discoveredPath = sessionPath;
+            if (entryTags && (!e.tags || e.tags.length === 0)) updates.tags = entryTags;
+            if (Object.keys(updates).length === 0) return e;
+            return Object.assign({}, e, updates);
           });
         });
       }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,12 +161,10 @@ export default function App() {
         return true;
       });
 
-      // Build a lookup: discoveredPath/sessionId -> discovered session for path enrichment
-      var discoveredByPath = {};
+      // Build a lookup: sessionId -> discovered session for path enrichment
       var discoveredBySessionId = {};
       discovered.sessions.forEach(function (s) {
         if (s.source !== "manifest" && s.size < 5000) return;
-        if (s.path) discoveredByPath[s.path] = s;
         if (s.sessionId) discoveredBySessionId[s.sessionId] = s;
       });
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,6 +135,7 @@ export default function App() {
   var [showFilters, setShowFilters] = useState(false);
   var [compareLanding, setCompareLanding] = useState(false);
   var [showQA, setShowQA] = useState(false);
+  var [loadError, setLoadError] = useState(null);
   var qaFlag = useFeatureFlag("qa", false);
   var searchInputRef = useRef(null);
   var filtersRef = useRef(null);
@@ -172,8 +173,7 @@ export default function App() {
       // Enrich library entries with discoveredPath from discovered/manifest sessions
       var enrichedLibrary = visibleLibraryEntries.map(function (e) {
         if (e.discoveredPath) return e; // already has it
-        var match = (e.sessionId && discoveredBySessionId[e.sessionId])
-          || discoveredByPath[e.discoveredPath];
+        var match = (e.sessionId && discoveredBySessionId[e.sessionId]);
         if (match) return Object.assign({}, e, { discoveredPath: match.path });
         return e;
       });
@@ -311,6 +311,7 @@ export default function App() {
     var sessionName = entry.file || entry.summary || entry.filename || "events.jsonl";
 
     function afterLoad(rawText) {
+      setLoadError(null);
       setView("stats");
       handleFile(rawText, sessionName);
       // Patch discoveredPath and tags onto the persisted library entry so that
@@ -330,22 +331,24 @@ export default function App() {
       }
     }
 
+    function onFetchError(err) {
+      console.error("[session] failed to load:", sessionName, err);
+      setLoadError("Failed to load session: " + sessionName);
+    }
+
+    // Manifest or discovered sessions: fetch via the discovered-sessions hook
     if ((entry.source === "manifest" || entry.isDiscovered) && sessionPath) {
       var fetchArg = entry.source === "manifest"
         ? { source: "manifest", path: sessionPath }
         : sessionPath;
-      discovered.fetchSessionContent(fetchArg).then(afterLoad).catch(function (err) {
-        console.error("[" + (entry.source || "discovered") + "] failed to load session:", sessionPath, err);
-      });
+      discovered.fetchSessionContent(fetchArg).then(afterLoad).catch(onFetchError);
       return;
     }
 
     var rawText = loadStoredSessionContent(entry.id);
     if (rawText) { afterLoad(rawText); return; }
     if (sessionPath) {
-      discovered.fetchSessionContent(sessionPath).then(afterLoad).catch(function (err) {
-        console.error("[discovered] failed to load session:", sessionPath, err);
-      });
+      discovered.fetchSessionContent(sessionPath).then(afterLoad).catch(onFetchError);
       return;
     }
 
@@ -437,7 +440,7 @@ export default function App() {
   if (!session.events) {
     return (
       <AppLandingState
-        error={session.error}
+        error={session.error || loadError}
         onLoad={handleFile}
         onLoadSample={loadSample}
         onStartCompare={function () { setCompareLanding(true); }}

--- a/src/__tests__/manifestHelpers.test.js
+++ b/src/__tests__/manifestHelpers.test.js
@@ -158,3 +158,97 @@ describe("manifest URL resolution (new URL)", function () {
     expect(new URL(sessionUrl, manifestUrl).href).toBe("https://example.com/data/session.jsonl");
   });
 });
+
+describe("tag propagation after session open", function () {
+  // Simulates the allSessions merge behavior: library entries that were opened
+  // from manifest sessions should retain tags through filtering.
+
+  it("library entry without tags is excluded by filterByTags", function () {
+    // After opening a manifest session, the library entry has no tags.
+    // Tag filtering must correctly exclude it.
+    var libraryEntry = { file: "opened.jsonl", tags: [] };
+    var manifestEntry = { file: "unopened.jsonl", tags: ["nightly", "bugfix"] };
+    var result = filterByTags([libraryEntry, manifestEntry], ["bugfix"]);
+    expect(result).toEqual([manifestEntry]);
+  });
+
+  it("library entry with patched tags is included by filterByTags", function () {
+    // After the afterLoad fix, tags are patched onto the library entry.
+    var patchedEntry = { file: "opened.jsonl", tags: ["nightly", "bugfix"] };
+    var manifestEntry = { file: "unopened.jsonl", tags: ["nightly", "bugfix"] };
+    var result = filterByTags([patchedEntry, manifestEntry], ["bugfix"]);
+    expect(result).toEqual([patchedEntry, manifestEntry]);
+  });
+
+  it("patched tags work with AND logic across multiple active tags", function () {
+    var entries = [
+      { file: "a.jsonl", tags: ["nightly", "bugfix"] },
+      { file: "b.jsonl", tags: ["nightly"] },
+      { file: "c.jsonl", tags: ["bugfix"] },
+    ];
+    var result = filterByTags(entries, ["nightly", "bugfix"]);
+    expect(result.map(function (e) { return e.file; })).toEqual(["a.jsonl"]);
+  });
+});
+
+describe("dedup: enrichedLibrary vs discoveredOnly", function () {
+  // Tests the dedup logic: library entries matched by discoveredPath should
+  // prevent the same manifest session from appearing as a discovered entry.
+
+  function simulateDedup(libraryEntries, discoveredSessions) {
+    // Mirrors the allSessions merge logic in App.jsx
+    var discoveredBySessionId = {};
+    discoveredSessions.forEach(function (s) {
+      if (s.sessionId) discoveredBySessionId[s.sessionId] = s;
+    });
+
+    var enrichedLibrary = libraryEntries.map(function (e) {
+      if (e.discoveredPath) return e;
+      var match = (e.sessionId && discoveredBySessionId[e.sessionId]);
+      if (match) return Object.assign({}, e, { discoveredPath: match.path });
+      return e;
+    });
+
+    var discoveredOnly = discoveredSessions.filter(function (s) {
+      return !enrichedLibrary.some(function (e) {
+        return e.discoveredPath === s.path || (e.sessionId && e.sessionId === s.sessionId);
+      });
+    });
+
+    return { enrichedLibrary: enrichedLibrary, discoveredOnly: discoveredOnly };
+  }
+
+  it("removes discovered session that matches library by discoveredPath", function () {
+    var lib = [{ id: "lib1", discoveredPath: "http://x.com/a.jsonl", tags: ["bugfix"] }];
+    var disc = [{ path: "http://x.com/a.jsonl", tags: ["bugfix"], source: "manifest" }];
+    var result = simulateDedup(lib, disc);
+    expect(result.discoveredOnly).toEqual([]);
+    expect(result.enrichedLibrary.length).toBe(1);
+  });
+
+  it("removes discovered session that matches library by sessionId", function () {
+    var lib = [{ id: "lib1", sessionId: "sess-123" }];
+    var disc = [{ path: "http://x.com/a.jsonl", sessionId: "sess-123", source: "manifest" }];
+    var result = simulateDedup(lib, disc);
+    expect(result.discoveredOnly).toEqual([]);
+    expect(result.enrichedLibrary[0].discoveredPath).toBe("http://x.com/a.jsonl");
+  });
+
+  it("does not match when sessionId is null on both sides", function () {
+    var lib = [{ id: "lib1", sessionId: null, discoveredPath: "http://x.com/other.jsonl" }];
+    var disc = [{ path: "http://x.com/a.jsonl", sessionId: null, source: "manifest" }];
+    var result = simulateDedup(lib, disc);
+    expect(result.discoveredOnly.length).toBe(1);
+  });
+
+  it("keeps unmatched discovered sessions", function () {
+    var lib = [{ id: "lib1", discoveredPath: "http://x.com/a.jsonl" }];
+    var disc = [
+      { path: "http://x.com/a.jsonl", tags: ["nightly"], source: "manifest" },
+      { path: "http://x.com/b.jsonl", tags: ["bugfix"], source: "manifest" },
+    ];
+    var result = simulateDedup(lib, disc);
+    expect(result.discoveredOnly.length).toBe(1);
+    expect(result.discoveredOnly[0].path).toBe("http://x.com/b.jsonl");
+  });
+});

--- a/src/hooks/useDiscoveredSessions.js
+++ b/src/hooks/useDiscoveredSessions.js
@@ -19,6 +19,9 @@ export default function useDiscoveredSessions() {
     // Static manifest mode: ?manifest=URL skips the backend entirely
     if (manifestUrl) {
       setManifestError(null);
+      // Resolve manifestUrl against current page so relative paths (e.g. "/manifest.json") become absolute,
+      // which is required for new URL(sessionUrl, base) to work correctly.
+      var absoluteManifestUrl = new URL(manifestUrl, window.location.href).href;
       return fetch(manifestUrl)
         .then(function (r) {
           if (!r.ok) throw new Error("manifest fetch failed: HTTP " + r.status);
@@ -30,7 +33,7 @@ export default function useDiscoveredSessions() {
               return s && s.url;
             }).map(function (s) {
               return {
-                path: new URL(s.url, manifestUrl).href,
+                path: new URL(s.url, absoluteManifestUrl).href,
                 file: s.name || s.filename || s.url,
                 filename: s.filename || s.name || s.url,
                 mtime: s.mtime || 0,

--- a/src/hooks/useDiscoveredSessions.js
+++ b/src/hooks/useDiscoveredSessions.js
@@ -72,7 +72,7 @@ export default function useDiscoveredSessions() {
         setAvailable(false);
         setLoading(false);
       });
-  }, []);
+  }, [forceEmpty, manifestUrl]);
 
   useEffect(function () {
     fetchSessions();
@@ -100,5 +100,13 @@ export default function useDiscoveredSessions() {
       });
   }, []);
 
-  return { sessions: sessions, loading: loading, available: available, manifestError: manifestError, isManifestMode: Boolean(manifestUrl), fetchSessionContent: fetchSessionContent, refresh: fetchSessions };
+  return {
+    sessions: sessions,
+    loading: loading,
+    available: available,
+    manifestError: manifestError,
+    isManifestMode: Boolean(manifestUrl),
+    fetchSessionContent: fetchSessionContent,
+    refresh: fetchSessions,
+  };
 }


### PR DESCRIPTION
### Problem

When filtering by multiple tags consecutively (clicking one after another) - the previous filters were not remembered.