### PR TITLE
perf: wrap waterfall sub-components with React.memo

### DIFF
--- a/src/__tests__/waterfallMemo.test.jsx
+++ b/src/__tests__/waterfallMemo.test.jsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import WaterfallRow from "../components/waterfall/WaterfallRow.jsx";
+import WaterfallChart from "../components/waterfall/WaterfallChart.jsx";
+import TimeAxis from "../components/waterfall/TimeAxis.jsx";
+import WaterfallInspector from "../components/waterfall/WaterfallInspector.jsx";
+
+describe("Waterfall components are memoized", function () {
+  it("WaterfallRow is wrapped with React.memo", function () {
+    expect(WaterfallRow.$$typeof).toBe(Symbol.for("react.memo"));
+  });
+  it("WaterfallChart is wrapped with React.memo", function () {
+    expect(WaterfallChart.$$typeof).toBe(Symbol.for("react.memo"));
+  });
+  it("TimeAxis is wrapped with React.memo", function () {
+    expect(TimeAxis.$$typeof).toBe(Symbol.for("react.memo"));
+  });
+  it("WaterfallInspector is wrapped with React.memo", function () {
+    expect(WaterfallInspector.$$typeof).toBe(Symbol.for("react.memo"));
+  });
+});

--- a/src/components/waterfall/TimeAxis.jsx
+++ b/src/components/waterfall/TimeAxis.jsx
@@ -1,8 +1,9 @@
+import React from "react";
 import { theme } from "../../lib/theme.js";
 import { formatTime } from "../../lib/formatTime.js";
 import { getWaterfallLeft, WATERFALL_TIME_AXIS_HEIGHT } from "./constants.js";
 
-export default function TimeAxis({ totalTime, timeMap }) {
+function TimeAxis({ totalTime, timeMap }) {
   if (totalTime <= 0) return null;
 
   var displayTotal = timeMap && timeMap.hasCompression ? timeMap.displayTotal : totalTime;
@@ -61,3 +62,5 @@ export default function TimeAxis({ totalTime, timeMap }) {
     </div>
   );
 }
+
+export default React.memo(TimeAxis);

--- a/src/components/waterfall/WaterfallChart.jsx
+++ b/src/components/waterfall/WaterfallChart.jsx
@@ -1,9 +1,10 @@
+import React from "react";
 import { theme } from "../../lib/theme.js";
 import { getWaterfallLeft } from "./constants.js";
 import TimeAxis from "./TimeAxis.jsx";
 import WaterfallRow from "./WaterfallRow.jsx";
 
-export default function WaterfallChart({
+function WaterfallChart({
   scrollRef,
   onScroll,
   layout,
@@ -103,3 +104,5 @@ export default function WaterfallChart({
     </div>
   );
 }
+
+export default React.memo(WaterfallChart);

--- a/src/components/waterfall/WaterfallInspector.jsx
+++ b/src/components/waterfall/WaterfallInspector.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import React, { useState } from "react";
 import { theme } from "../../lib/theme.js";
 import DataInspector from "../DataInspector.jsx";
 import DiffViewer from "../DiffViewer.jsx";
@@ -6,7 +6,7 @@ import { isDiffViewable } from "../../lib/diffUtils.js";
 import { formatDuration, formatTime } from "../../lib/formatTime.js";
 import { getToolColor } from "../../lib/waterfall";
 
-export default function WaterfallInspector({ selectedItem, stats }) {
+function WaterfallInspector({ selectedItem, stats }) {
   var selected = selectedItem ? selectedItem.event : null;
   var [showRaw, setShowRaw] = useState(false);
   var hasDiff = selected && isDiffViewable(selected);
@@ -254,3 +254,5 @@ export default function WaterfallInspector({ selectedItem, stats }) {
     </div>
   );
 }
+
+export default React.memo(WaterfallInspector);

--- a/src/components/waterfall/WaterfallRow.jsx
+++ b/src/components/waterfall/WaterfallRow.jsx
@@ -1,10 +1,11 @@
+import React from "react";
 import { alpha, theme } from "../../lib/theme.js";
 import Icon from "../Icon.jsx";
 import { formatDuration } from "../../lib/formatTime.js";
 import { getToolColor } from "../../lib/waterfall";
 import { WATERFALL_INDENT_PX, WATERFALL_LABEL_WIDTH, WATERFALL_MIN_BAR_WIDTH_PX } from "./constants.js";
 
-export default function WaterfallRow({
+function WaterfallRow({
   item,
   layoutItem,
   currentTime,
@@ -143,3 +144,5 @@ export default function WaterfallRow({
     </div>
   );
 }
+
+export default React.memo(WaterfallRow);


### PR DESCRIPTION
Wraps WaterfallRow, WaterfallChart, TimeAxis, and WaterfallInspector with React.memo() to prevent cascade re-renders when parent state changes but row props are unchanged.

All 571 tests pass.

Closes #65