### PR TITLE
feat: filter bar with tool name, agent, and error-only filters

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,6 +18,7 @@ var CostView = React.lazy(function () { return lazyImport(function () { return i
 import CommandPalette from "./components/CommandPalette.jsx";
 import ShortcutsModal from "./components/ShortcutsModal.jsx";
 import AppHeader from "./components/app/AppHeader.jsx";
+import FilterBar from "./components/FilterBar.jsx";
 import AppLandingState from "./components/app/AppLandingState.jsx";
 import AppLoadingState from "./components/app/AppLoadingState.jsx";
 import CompareLandingState from "./components/app/CompareLandingState.jsx";
@@ -362,6 +363,32 @@ function AppSessionView({
   }, [session.events, session.turns, session.metadata, autonomyMetrics]);
   var qa = useQA(qaSessionData);
 
+  var toggleToolName = useCallback(function (name) {
+    pb.setToolNameFilter(function (prev) {
+      return prev.indexOf(name) !== -1
+        ? prev.filter(function (n) { return n !== name; })
+        : prev.concat(name);
+    });
+  }, [pb.setToolNameFilter]);
+
+  var toggleAgent = useCallback(function (name) {
+    pb.setAgentFilter(function (prev) {
+      return prev.indexOf(name) !== -1
+        ? prev.filter(function (n) { return n !== name; })
+        : prev.concat(name);
+    });
+  }, [pb.setAgentFilter]);
+
+  var toggleErrorsOnly = useCallback(function () {
+    pb.setErrorsOnly(function (prev) { return !prev; });
+  }, [pb.setErrorsOnly]);
+
+  var clearAdvancedFilters = useCallback(function () {
+    pb.setToolNameFilter([]);
+    pb.setAgentFilter([]);
+    pb.setErrorsOnly(false);
+  }, [pb.setToolNameFilter, pb.setAgentFilter, pb.setErrorsOnly]);
+
   useEffect(function () {
     if (!showFilters) return;
 
@@ -483,6 +510,21 @@ function AppSessionView({
         currentFile={session.file}
         onTryV2={onTryV2}
       />
+
+      {(showFilters || pb.advancedFilterCount > 0) && (
+        <FilterBar
+          toolNameFilter={pb.toolNameFilter}
+          onToggleToolName={toggleToolName}
+          agentFilter={pb.agentFilter}
+          onToggleAgent={toggleAgent}
+          errorsOnly={pb.errorsOnly}
+          onToggleErrorsOnly={toggleErrorsOnly}
+          uniqueToolNames={pb.uniqueToolNames}
+          uniqueAgents={pb.uniqueAgents}
+          onClearAll={clearAdvancedFilters}
+          activeCount={pb.advancedFilterCount}
+        />
+      )}
 
       <div style={{ padding: "8px 20px 0", flexShrink: 0 }}>
         <Timeline

--- a/src/__tests__/filterBar.test.jsx
+++ b/src/__tests__/filterBar.test.jsx
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildFilteredEventEntriesV2,
+  getUniqueToolNames,
+  getUniqueAgents,
+} from "../lib/session";
+
+function makeEvent(overrides) {
+  return Object.assign(
+    { t: 0, agent: "assistant", track: "tool_call", text: "", duration: 1, intensity: 1, isError: false },
+    overrides,
+  );
+}
+
+var sampleEvents = [
+  makeEvent({ agent: "assistant", track: "tool_call", toolName: "Read", isError: false }),
+  makeEvent({ agent: "assistant", track: "tool_call", toolName: "Write", isError: true }),
+  makeEvent({ agent: "user", track: "output", toolName: undefined, isError: false }),
+  makeEvent({ agent: "system", track: "reasoning", toolName: undefined, isError: false }),
+  makeEvent({ agent: "assistant", track: "tool_call", toolName: "Read", isError: false }),
+];
+
+describe("buildFilteredEventEntriesV2", function () {
+  it("filters by toolNames on tool_call events", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, {
+      hiddenTracks: {},
+      toolNames: ["Read"],
+    });
+    var toolEntries = result.filter(function (e) { return e.event.track === "tool_call"; });
+    expect(toolEntries.length).toBe(2);
+    toolEntries.forEach(function (e) {
+      expect(e.event.toolName).toBe("Read");
+    });
+    // Non-tool_call events should still pass through
+    var nonToolEntries = result.filter(function (e) { return e.event.track !== "tool_call"; });
+    expect(nonToolEntries.length).toBe(2);
+  });
+
+  it("filters by agents", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, {
+      hiddenTracks: {},
+      agents: ["user"],
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].event.agent).toBe("user");
+  });
+
+  it("filters errors only", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, {
+      hiddenTracks: {},
+      errorsOnly: true,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].event.isError).toBe(true);
+  });
+
+  it("applies combined filters with AND logic", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, {
+      hiddenTracks: {},
+      toolNames: ["Write"],
+      agents: ["assistant"],
+      errorsOnly: true,
+    });
+    expect(result.length).toBe(1);
+    expect(result[0].event.toolName).toBe("Write");
+    expect(result[0].event.isError).toBe(true);
+  });
+
+  it("respects hiddenTracks alongside new filters", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, {
+      hiddenTracks: { tool_call: true },
+      agents: ["assistant", "user", "system"],
+    });
+    // All tool_call events hidden, only output + reasoning remain
+    expect(result.length).toBe(2);
+    result.forEach(function (e) {
+      expect(e.event.track).not.toBe("tool_call");
+    });
+  });
+
+  it("returns all events when no filters are active", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, { hiddenTracks: {} });
+    expect(result.length).toBe(sampleEvents.length);
+  });
+
+  it("handles null events", function () {
+    expect(buildFilteredEventEntriesV2(null, { hiddenTracks: {} })).toEqual([]);
+  });
+
+  it("handles undefined events", function () {
+    expect(buildFilteredEventEntriesV2(undefined, { hiddenTracks: {} })).toEqual([]);
+  });
+
+  it("handles empty events array", function () {
+    expect(buildFilteredEventEntriesV2([], { hiddenTracks: {} })).toEqual([]);
+  });
+
+  it("preserves correct original indices", function () {
+    var result = buildFilteredEventEntriesV2(sampleEvents, {
+      hiddenTracks: {},
+      agents: ["user"],
+    });
+    expect(result[0].index).toBe(2);
+  });
+});
+
+describe("getUniqueToolNames", function () {
+  it("returns sorted unique tool names", function () {
+    var result = getUniqueToolNames(sampleEvents);
+    expect(result).toEqual(["Read", "Write"]);
+  });
+
+  it("handles null events", function () {
+    expect(getUniqueToolNames(null)).toEqual([]);
+  });
+
+  it("handles empty events", function () {
+    expect(getUniqueToolNames([])).toEqual([]);
+  });
+});
+
+describe("getUniqueAgents", function () {
+  it("returns sorted unique agents", function () {
+    var result = getUniqueAgents(sampleEvents);
+    expect(result).toEqual(["assistant", "system", "user"]);
+  });
+
+  it("handles null events", function () {
+    expect(getUniqueAgents(null)).toEqual([]);
+  });
+
+  it("handles undefined events", function () {
+    expect(getUniqueAgents(undefined)).toEqual([]);
+  });
+});

--- a/src/components/FilterBar.jsx
+++ b/src/components/FilterBar.jsx
@@ -1,0 +1,209 @@
+import { useState } from "react";
+import { theme, alpha } from "../lib/theme.js";
+import Icon from "./Icon.jsx";
+
+function MultiSelect({ label, options, selected, onToggle }) {
+  var [open, setOpen] = useState(false);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <button
+        className="av-interactive"
+        onClick={function () { setOpen(function (v) { return !v; }); }}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          padding: "3px 8px",
+          borderRadius: theme.radius.md,
+          border: "1px solid " + (selected.length > 0 ? theme.accent.primary : theme.border.default),
+          background: selected.length > 0 ? alpha(theme.accent.primary, 0.08) : theme.bg.surface,
+          color: selected.length > 0 ? theme.accent.primary : theme.text.secondary,
+          fontSize: theme.fontSize.xs,
+          fontFamily: theme.font.mono,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {label}
+        {selected.length > 0 && (
+          <span style={{
+            background: theme.accent.primary,
+            color: theme.bg.surface,
+            borderRadius: theme.radius.full,
+            padding: "0 5px",
+            fontSize: theme.fontSize.xs,
+            lineHeight: "16px",
+            minWidth: 16,
+            textAlign: "center",
+          }}>
+            {selected.length}
+          </span>
+        )}
+        <Icon name="chevron-down" size={10} />
+      </button>
+      {open && (
+        <div style={{
+          position: "absolute",
+          top: "calc(100% + 4px)",
+          left: 0,
+          background: theme.bg.surface,
+          border: "1px solid " + theme.border.strong,
+          borderRadius: theme.radius.lg,
+          padding: 4,
+          zIndex: theme.z.tooltip,
+          boxShadow: theme.shadow.md,
+          maxHeight: 240,
+          overflowY: "auto",
+          minWidth: 160,
+        }}>
+          {options.map(function (option) {
+            var isSelected = selected.indexOf(option) !== -1;
+            return (
+              <button
+                key={option}
+                className="av-interactive"
+                onClick={function () { onToggle(option); }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                  padding: "4px 8px",
+                  borderRadius: theme.radius.sm,
+                  width: "100%",
+                  background: "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+              >
+                <span style={{
+                  width: 14,
+                  height: 14,
+                  borderRadius: theme.radius.sm,
+                  border: "1px solid " + (isSelected ? theme.accent.primary : theme.border.default),
+                  background: isSelected ? theme.accent.primary : "transparent",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                }}>
+                  {isSelected && <Icon name="check" size={10} style={{ color: "#fff" }} />}
+                </span>
+                <span style={{
+                  fontSize: theme.fontSize.xs,
+                  fontFamily: theme.font.mono,
+                  color: theme.text.primary,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                }}>
+                  {option}
+                </span>
+              </button>
+            );
+          })}
+          {options.length === 0 && (
+            <span style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, padding: "4px 8px" }}>
+              None available
+            </span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function FilterBar({
+  toolNameFilter,
+  onToggleToolName,
+  agentFilter,
+  onToggleAgent,
+  errorsOnly,
+  onToggleErrorsOnly,
+  uniqueToolNames,
+  uniqueAgents,
+  onClearAll,
+  activeCount,
+}) {
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "center",
+      gap: 8,
+      padding: "4px 16px",
+      borderBottom: "1px solid " + theme.border.subtle,
+      background: theme.bg.base,
+      flexShrink: 0,
+    }}>
+      <span style={{
+        fontSize: theme.fontSize.xs,
+        color: theme.text.dim,
+        fontFamily: theme.font.ui,
+        textTransform: "uppercase",
+        letterSpacing: "0.05em",
+        flexShrink: 0,
+      }}>
+        Filters
+      </span>
+
+      <MultiSelect
+        label="Tool"
+        options={uniqueToolNames}
+        selected={toolNameFilter}
+        onToggle={onToggleToolName}
+      />
+
+      <MultiSelect
+        label="Agent"
+        options={uniqueAgents}
+        selected={agentFilter}
+        onToggle={onToggleAgent}
+      />
+
+      <button
+        className="av-interactive"
+        onClick={onToggleErrorsOnly}
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+          padding: "3px 8px",
+          borderRadius: theme.radius.md,
+          border: "1px solid " + (errorsOnly ? theme.semantic.error : theme.border.default),
+          background: errorsOnly ? theme.semantic.errorBg : theme.bg.surface,
+          color: errorsOnly ? theme.semantic.error : theme.text.secondary,
+          fontSize: theme.fontSize.xs,
+          fontFamily: theme.font.mono,
+          cursor: "pointer",
+        }}
+      >
+        <Icon name="alert-circle" size={11} />
+        Errors only
+      </button>
+
+      {activeCount > 0 && (
+        <button
+          className="av-interactive"
+          onClick={onClearAll}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 4,
+            padding: "3px 8px",
+            borderRadius: theme.radius.md,
+            border: "1px solid " + theme.border.default,
+            background: "transparent",
+            color: theme.text.muted,
+            fontSize: theme.fontSize.xs,
+            fontFamily: theme.font.mono,
+            cursor: "pointer",
+          }}
+        >
+          <Icon name="close" size={10} />
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -44,6 +44,7 @@ import {
   RefreshCw,
   Tag,
   Copy,
+  Check,
 } from "lucide-react";
 
 var ICON_MAP = {
@@ -92,6 +93,7 @@ var ICON_MAP = {
   "refresh-cw": RefreshCw,
   tag: Tag,
   copy: Copy,
+  check: Check,
 };
 
 export default function Icon({ name, size, strokeWidth, style, className }) {

--- a/src/contexts/PlaybackContext.jsx
+++ b/src/contexts/PlaybackContext.jsx
@@ -12,11 +12,11 @@
  * usePlaybackContext() still returns the combined shape for backward compat.
  */
 
-import React, { createContext, useContext, useMemo, useCallback, useEffect } from "react";
+import React, { createContext, useContext, useMemo, useCallback, useEffect, useState } from "react";
 import usePlayback from "../hooks/usePlayback.js";
 import useSearch from "../hooks/useSearch.js";
 import usePersistentState from "../hooks/usePersistentState.js";
-import { buildFilteredEventEntries, buildTurnStartMap, buildTimeMap } from "../lib/session";
+import { buildFilteredEventEntriesV2, getUniqueToolNames, getUniqueAgents, buildTurnStartMap, buildTimeMap } from "../lib/session";
 import { PLAYBACK_SPEEDS } from "../components/app/constants.js";
 
 var PlaybackTimeCtx = createContext(null);
@@ -28,7 +28,7 @@ var SearchCtx = createContext(null);
  *   session: { events, turns, total, isLive, metadata } from useSessionLoader
  */
 export function PlaybackProvider({ session, children }) {
-  // ── playback ──────────────────────────────────────────────────────────────
+  // -- playback --
   var playback = usePlayback(session.total, session.isLive);
 
   // Auto-seek to end when session data changes (live mode or initial load)
@@ -44,12 +44,28 @@ export function PlaybackProvider({ session, children }) {
     playback.setSpeed(next);
   }, [playback.speed, playback.setSpeed]);
 
-  // ── filters ───────────────────────────────────────────────────────────────
+  // -- filters --
   var [trackFilters, setTrackFilters] = usePersistentState("agentviz:track-filters", {});
+  var [toolNameFilter, setToolNameFilter] = useState([]);
+  var [agentFilter, setAgentFilter] = useState([]);
+  var [errorsOnly, setErrorsOnly] = useState(false);
 
   var filteredEventEntries = useMemo(function () {
-    return buildFilteredEventEntries(session.events, trackFilters);
-  }, [session.events, trackFilters]);
+    return buildFilteredEventEntriesV2(session.events, {
+      hiddenTracks: trackFilters,
+      toolNames: toolNameFilter.length > 0 ? toolNameFilter : undefined,
+      agents: agentFilter.length > 0 ? agentFilter : undefined,
+      errorsOnly: errorsOnly,
+    });
+  }, [session.events, trackFilters, toolNameFilter, agentFilter, errorsOnly]);
+
+  var uniqueToolNames = useMemo(function () {
+    return getUniqueToolNames(session.events);
+  }, [session.events]);
+
+  var uniqueAgents = useMemo(function () {
+    return getUniqueAgents(session.events);
+  }, [session.events]);
 
   var filteredEvents = useMemo(function () {
     return filteredEventEntries.map(function (entry) { return entry.event; });
@@ -79,7 +95,8 @@ export function PlaybackProvider({ session, children }) {
     });
   }, [setTrackFilters]);
 
-  var activeFilterCount = Object.keys(trackFilters).length;
+  var advancedFilterCount = toolNameFilter.length + agentFilter.length + (errorsOnly ? 1 : 0);
+  var activeFilterCount = Object.keys(trackFilters).length + advancedFilterCount;
 
   var filterValue = useMemo(function () {
     return {
@@ -90,19 +107,30 @@ export function PlaybackProvider({ session, children }) {
       errorEntries: errorEntries,
       trackFilters: trackFilters,
       activeFilterCount: activeFilterCount,
+      advancedFilterCount: advancedFilterCount,
       toggleTrackFilter: toggleTrackFilter,
+      toolNameFilter: toolNameFilter,
+      setToolNameFilter: setToolNameFilter,
+      agentFilter: agentFilter,
+      setAgentFilter: setAgentFilter,
+      errorsOnly: errorsOnly,
+      setErrorsOnly: setErrorsOnly,
+      uniqueToolNames: uniqueToolNames,
+      uniqueAgents: uniqueAgents,
     };
   }, [filteredEventEntries, filteredEvents, turnStartMap, timeMap,
-      errorEntries, trackFilters, activeFilterCount, toggleTrackFilter]);
+      errorEntries, trackFilters, activeFilterCount, advancedFilterCount,
+      toggleTrackFilter, toolNameFilter, agentFilter, errorsOnly,
+      uniqueToolNames, uniqueAgents]);
 
-  // ── search ────────────────────────────────────────────────────────────────
+  // -- search --
   var search = useSearch(filteredEventEntries);
 
   var searchValue = useMemo(function () {
     return { search: search };
   }, [search]);
 
-  // ── navigation (cross-cutting: needs playback + filter + search) ──────────
+  // -- navigation (cross-cutting: needs playback + filter + search) --
   var jumpToEntries = useCallback(function (entries, direction) {
     if (!entries || entries.length === 0) return;
 
@@ -138,6 +166,9 @@ export function PlaybackProvider({ session, children }) {
     playback.resetPlayback(0);
     search.clearSearch();
     setTrackFilters({});
+    setToolNameFilter([]);
+    setAgentFilter([]);
+    setErrorsOnly(false);
   }, [playback.resetPlayback, search.clearSearch, setTrackFilters]);
 
   // Navigation lives in PlaybackTimeCtx since it depends on playback.time
@@ -160,7 +191,7 @@ export function PlaybackProvider({ session, children }) {
   );
 }
 
-// ── Granular hooks (subscribe to one slice only) ────────────────────────────
+// -- Granular hooks (subscribe to one slice only) --
 
 export function usePlaybackTime() {
   var ctx = useContext(PlaybackTimeCtx);
@@ -180,7 +211,7 @@ export function useSearchContext() {
   return ctx;
 }
 
-// ── Backward-compatible combined hook (composes all three) ──────────────────
+// -- Backward-compatible combined hook (composes all three) --
 
 export function usePlaybackContext() {
   var playbackCtx = useContext(PlaybackTimeCtx);

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -28,6 +28,55 @@ export function buildFilteredEventEntries(
   return entries;
 }
 
+export interface EventFilters {
+  hiddenTracks: Record<string, boolean | undefined>;
+  toolNames?: string[];
+  agents?: string[];
+  errorsOnly?: boolean;
+}
+
+export function buildFilteredEventEntriesV2(
+  events: NormalizedEvent[] | null | undefined,
+  filters: EventFilters,
+): EventEntry[] {
+  if (!events) return [];
+
+  const entries: EventEntry[] = [];
+  const hasToolFilter = filters.toolNames && filters.toolNames.length > 0;
+  const hasAgentFilter = filters.agents && filters.agents.length > 0;
+  const toolSet = hasToolFilter ? new Set(filters.toolNames) : null;
+  const agentSet = hasAgentFilter ? new Set(filters.agents) : null;
+
+  for (let i = 0; i < events.length; i += 1) {
+    const ev = events[i];
+    if (filters.hiddenTracks[ev.track]) continue;
+    if (hasToolFilter && ev.track === "tool_call" && !toolSet!.has(ev.toolName || "")) continue;
+    if (hasAgentFilter && !agentSet!.has(ev.agent || "")) continue;
+    if (filters.errorsOnly && !ev.isError) continue;
+    entries.push({ index: i, event: ev });
+  }
+
+  return entries;
+}
+
+export function getUniqueToolNames(events: NormalizedEvent[] | null | undefined): string[] {
+  if (!events) return [];
+  const set = new Set<string>();
+  for (let i = 0; i < events.length; i += 1) {
+    if (events[i].toolName) set.add(events[i].toolName!);
+  }
+  return Array.from(set).sort();
+}
+
+export function getUniqueAgents(events: NormalizedEvent[] | null | undefined): string[] {
+  if (!events) return [];
+  const set = new Set<string>();
+  for (let i = 0; i < events.length; i += 1) {
+    if (events[i].agent) set.add(events[i].agent);
+  }
+  return Array.from(set).sort();
+}
+
 export function buildTurnStartMap(turns: SessionTurn[]): Record<number, SessionTurn> {
   const map: Record<number, SessionTurn> = {};
 


### PR DESCRIPTION
Adds collapsible filter bar below header with multi-select dropdowns for tool names and agents, plus error-only toggle. Filters compose with AND logic across all views.

13 new tests. All 583 tests pass.

Closes #64