### PR TITLE
perf: cache replay layout height estimates

### DIFF
--- a/src/__tests__/replayLayout.test.js
+++ b/src/__tests__/replayLayout.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildReplayLayout, getReplayWindow } from "../lib/replayLayout.js";
+import { buildReplayLayout, getReplayWindow, clearEstimateCache } from "../lib/replayLayout.js";
 
 function makeEntry(index, text) {
   return {
@@ -38,6 +38,26 @@ describe("buildReplayLayout", function () {
     var layout = buildReplayLayout([makeEntry(0, "short"), makeEntry(1, "short")], turnStartMap);
 
     expect(layout.items[1].height).toBeGreaterThan(layout.items[0].height);
+  });
+
+  it("cache produces identical results on repeated calls", function () {
+    clearEstimateCache();
+    var entries = [makeEntry(0, "hello world"), makeEntry(1, "hello world"), makeEntry(2, "different text")];
+    var layout1 = buildReplayLayout(entries, {});
+    var layout2 = buildReplayLayout(entries, {});
+    expect(layout1.items[0].height).toBe(layout2.items[0].height);
+    expect(layout1.items[1].height).toBe(layout2.items[1].height);
+    expect(layout1.totalHeight).toBe(layout2.totalHeight);
+  });
+
+  it("clearEstimateCache resets the cache", function () {
+    clearEstimateCache();
+    var entries = [makeEntry(0, "cached text")];
+    buildReplayLayout(entries, {});
+    clearEstimateCache();
+    // After clearing, should still produce same results (just recomputed)
+    var layout = buildReplayLayout(entries, {});
+    expect(layout.items[0].height).toBeGreaterThan(0);
   });
 });
 

--- a/src/lib/replayLayout.js
+++ b/src/lib/replayLayout.js
@@ -22,6 +22,24 @@ function estimateTextLines(text) {
   return lines;
 }
 
+var _estimateCache = new Map();
+var MAX_CACHE_SIZE = 50000;
+
+function cachedEstimateTextLines(text) {
+  if (!text) return 1;
+  var cached = _estimateCache.get(text);
+  if (cached !== undefined) return cached;
+  var result = estimateTextLines(text);
+  if (_estimateCache.size < MAX_CACHE_SIZE) {
+    _estimateCache.set(text, result);
+  }
+  return result;
+}
+
+export function clearEstimateCache() {
+  _estimateCache.clear();
+}
+
 export function buildReplayLayout(entries, turnStartMap, measuredHeights) {
   var top = 0;
   var items = [];
@@ -31,7 +49,7 @@ export function buildReplayLayout(entries, turnStartMap, measuredHeights) {
     var entry = entries[i];
     var turn = turnStartMap[entry.index];
     var hasTurnHeader = Boolean(turn && turn.index > 0);
-    var textLines = estimateTextLines(entry.event.text);
+    var textLines = cachedEstimateTextLines(entry.event.text);
     var estimatedHeight = REPLAY_ROW_BASE_HEIGHT
       + ((textLines - 1) * REPLAY_CONTENT_LINE_HEIGHT)
       + (hasTurnHeader ? REPLAY_TURN_HEADER_HEIGHT : 0);


### PR DESCRIPTION
Adds Map cache for estimateTextLines() results in replayLayout.js. Avoids recalculating text line counts for the same event text across filter toggles. 50k entry cap.

All 569 tests pass.

Closes #69