### PR TITLE
Add support for jsonl sessions from Copilot CLI 1.0.17+

### DIFF
--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -462,4 +462,109 @@ describe("parseClaudeCodeJSONL", function () {
       expect(result.events.length).toBeGreaterThan(400);
     });
   });
+
+  describe("newer dot-notation Claude Code format", function () {
+    it("parses user.message events", function () {
+      var session = makeSession([
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Hello world" } },
+        { type: "tool.execution_start", timestamp: 1775694846500, data: { toolName: "bash", arguments: '{"command":"echo hi"}' } },
+        { type: "tool.execution_complete", timestamp: 1775694847000, data: { success: "True", result: "hi" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      expect(result).not.toBeNull();
+      expect(result.events.length).toBe(3);
+      var userEvent = result.events.find(function (e) { return e.agent === "user"; });
+      expect(userEvent).toBeDefined();
+      expect(userEvent.text).toContain("Hello world");
+    });
+
+    it("parses tool.execution_start with JSON string arguments", function () {
+      var session = makeSession([
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Do something" } },
+        { type: "tool.execution_start", timestamp: 1775694846500, data: { toolName: "bash", arguments: '{"command":"ls -la","description":"List files"}' } },
+        { type: "tool.execution_complete", timestamp: 1775694847000, data: { success: "True", result: "total 42" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      var toolEvent = result.events.find(function (e) { return e.track === "tool_call"; });
+      expect(toolEvent).toBeDefined();
+      expect(toolEvent.toolName).toBe("bash");
+      expect(toolEvent.toolInput).toEqual({ command: "ls -la", description: "List files" });
+    });
+
+    it("parses tool.execution_complete with error results", function () {
+      var session = makeSession([
+        { type: "tool.execution_start", timestamp: 1775694846500, data: { toolName: "bash", arguments: '{"command":"bad"}' } },
+        { type: "tool.execution_complete", timestamp: 1775694847000, data: { success: "False", result: "command not found" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      var resultEvent = result.events.find(function (e) { return e.track === "context"; });
+      expect(resultEvent).toBeDefined();
+      expect(resultEvent.isError).toBe(true);
+    });
+
+    it("parses assistant.usage with model and token info", function () {
+      var session = makeSession([
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Hi" } },
+        { type: "assistant.usage", timestamp: 1775694851123, data: { inputTokens: 24842, outputTokens: 164, cacheReadTokens: 0, cacheWriteTokens: 0, model: "claude-opus-4.6" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      var usageEvent = result.events.find(function (e) { return e.tokenUsage; });
+      expect(usageEvent).toBeDefined();
+      expect(usageEvent.model).toBe("claude-opus-4.6");
+      expect(usageEvent.tokenUsage.inputTokens).toBe(24842);
+      expect(usageEvent.tokenUsage.outputTokens).toBe(164);
+    });
+
+    it("parses runner.error events", function () {
+      var session = makeSession([
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Hi" } },
+        { type: "runner.error", timestamp: 1775694964747, data: { message: "System.TimeoutException: Scenario timed out after 120s" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      var errorEvent = result.events.find(function (e) { return e.isError; });
+      expect(errorEvent).toBeDefined();
+      expect(errorEvent.text).toContain("TimeoutException");
+    });
+
+    it("parses skill.invoked events", function () {
+      var session = makeSession([
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Hi" } },
+        { type: "skill.invoked", timestamp: 1775694851194, data: { name: "csharp-scripts", path: "/skills/csharp-scripts/SKILL.md" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      var skillEvent = result.events.find(function (e) { return e.text.includes("Skill invoked"); });
+      expect(skillEvent).toBeDefined();
+      expect(skillEvent.text).toContain("csharp-scripts");
+    });
+
+    it("skips empty streaming deltas and session events", function () {
+      var session = makeSession([
+        { type: "session.custom_agents_updated", timestamp: 1775694844767, data: {} },
+        { type: "pending_messages.modified", timestamp: 1775694844772, data: {} },
+        { type: "assistant.streaming_delta", timestamp: 1775694850183, data: {} },
+        { type: "assistant.reasoning_delta", timestamp: 1775694850183, data: {} },
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Hello" } },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      expect(result.events.length).toBe(1);
+      expect(result.events[0].agent).toBe("user");
+    });
+
+    it("builds turns and metadata correctly", function () {
+      var session = makeSession([
+        { type: "user.message", timestamp: 1775694846300, data: { content: "Test question" } },
+        { type: "assistant.turn_start", timestamp: 1775694846690, data: {} },
+        { type: "tool.execution_start", timestamp: 1775694851123, data: { toolName: "bash", arguments: '{"command":"echo hello"}' } },
+        { type: "tool.execution_complete", timestamp: 1775694851500, data: { success: "True", result: "hello" } },
+        { type: "assistant.usage", timestamp: 1775694851600, data: { inputTokens: 1000, outputTokens: 50, cacheReadTokens: 0, cacheWriteTokens: 0, model: "claude-opus-4.6" } },
+        { type: "assistant.turn_end", timestamp: 1775694851700, data: {} },
+      ]);
+      var result = parseClaudeCodeJSONL(session);
+      expect(result).not.toBeNull();
+      expect(result.turns.length).toBe(1);
+      expect(result.metadata.totalToolCalls).toBe(1);
+      expect(result.metadata.primaryModel).toBe("claude-opus-4.6");
+      expect(result.metadata.tokenUsage.inputTokens).toBe(1000);
+    });
+  });
 });

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -366,6 +366,129 @@ function extractEventsFromRecord(raw: RawRecord, syntheticTime: number, issues: 
     }
   }
 
+  // --- Newer Claude Code event format (dot-notation types, data nested under `data`) ---
+  const data = raw.data && typeof raw.data === "object" ? raw.data as RawRecord : null;
+
+  if (raw.type === "user.message" && data) {
+    const content = typeof data.content === "string" ? data.content : extractContent(data.content);
+    if (content) {
+      pushEvent({
+        t: tSeconds,
+        agent: "user",
+        track: "output",
+        text: truncate(content, 300),
+        duration: 1,
+        intensity: 0.6,
+        raw,
+        isError: false,
+      });
+    }
+  }
+
+  if (raw.type === "tool.execution_start" && data) {
+    const toolName = typeof data.toolName === "string" ? data.toolName : "unknown_tool";
+    let toolInput: unknown = data.arguments;
+    if (typeof toolInput === "string") {
+      try { toolInput = JSON.parse(toolInput); } catch { /* keep as string */ }
+    }
+    pushEvent({
+      t: tSeconds,
+      agent: "assistant",
+      track: "tool_call",
+      text: toolName + "(" + formatToolInput(toolInput || {}) + ")",
+      toolName,
+      toolInput,
+      duration: 2,
+      intensity: 0.9,
+      raw,
+      isError: false,
+    });
+  }
+
+  if (raw.type === "tool.execution_complete" && data) {
+    const resultText = typeof data.result === "string" ? data.result : extractContent(data.result);
+    const isSuccess = data.success === "True" || data.success === true;
+    const hasError = !isSuccess || detectError(data, resultText);
+    pushEvent({
+      t: tSeconds,
+      agent: "assistant",
+      track: "context",
+      text: "Result: " + truncate(resultText, 200),
+      duration: 1,
+      intensity: hasError ? 1.0 : 0.5,
+      raw,
+      isError: hasError,
+    });
+  }
+
+  if (raw.type === "assistant.usage" && data) {
+    const inputTokens = data.inputTokens || 0;
+    const outputTokens = data.outputTokens || 0;
+    const cacheRead = data.cacheReadTokens || 0;
+    const cacheWrite = data.cacheWriteTokens || 0;
+    const modelName = typeof data.model === "string" ? data.model : undefined;
+    if (inputTokens + outputTokens > 0) {
+      pushEvent({
+        t: tSeconds,
+        agent: "system",
+        track: "context",
+        text: "Usage: " + inputTokens + " in / " + outputTokens + " out" + (modelName ? " (" + modelName + ")" : ""),
+        duration: 0.1,
+        intensity: 0.3,
+        raw,
+        isError: false,
+        model: modelName,
+        tokenUsage: { inputTokens, outputTokens, cacheRead, cacheWrite },
+      });
+    }
+  }
+
+  if (raw.type === "assistant.message" && data) {
+    const content = typeof data.content === "string" ? data.content : extractContent(data.content);
+    if (content) {
+      pushEvent({
+        t: tSeconds,
+        agent: "assistant",
+        track: "output",
+        text: truncate(content, 300),
+        duration: 2,
+        intensity: 0.7,
+        raw,
+        isError: false,
+      });
+    }
+  }
+
+  if (raw.type === "runner.error" && data) {
+    const message = typeof data.message === "string" ? data.message : extractContent(data.message);
+    if (message) {
+      pushEvent({
+        t: tSeconds,
+        agent: "system",
+        track: "output",
+        text: truncate(message, 300),
+        duration: 1,
+        intensity: 1.0,
+        raw,
+        isError: true,
+      });
+    }
+  }
+
+  if (raw.type === "skill.invoked" && data) {
+    const skillName = typeof data.name === "string" ? data.name : "unknown";
+    pushEvent({
+      t: tSeconds,
+      agent: "assistant",
+      track: "context",
+      text: "Skill invoked: " + skillName,
+      duration: 0.5,
+      intensity: 0.5,
+      raw,
+      isError: false,
+    });
+  }
+
   return events;
 }
 


### PR DESCRIPTION
### Context

Sessions produced by Copilot SDK 0.2.1 (running the Copilot CLI 1.0.17 under the hood) failed to be parsed - as new 'dot notations' were introduced for event types