### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentviz",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Session replay visualizer for AI agent workflows (Claude Code, VS Code, Copilot CLI)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Release v0.6.0

Version bump for the v0.6.0 release.

### Changes since v0.5.0

- **feat:** Static manifest mode (#39)
- **feat:** Copilot CLI 1.0.17+ JSONL session support (#77)
- **perf:** Pre-indexed search for O(1) toLowerCase on large sessions (#74)
- **perf:** Wrap waterfall sub-components with React.memo (#72)
- **perf:** Cache replay layout height estimates (#75)
- **perf:** Split PlaybackContext into three focused contexts (#70)
- **fix:** Multi-step filtering by tags in static manifest mode (#61)
- **fix:** Manifest mode follow-ups (#60)
- **chore:** Bring color-palette.html into the Five-Artifact Sync Rule (#59)
- **chore:** Codebase health cleanup -- 76 new tests (#78)