### PR TITLE
fix: improve multi-model display and formatting in Replay/Stats panels

### DIFF
--- a/src/__tests__/formatTime.test.js
+++ b/src/__tests__/formatTime.test.js
@@ -51,6 +51,12 @@ describe("formatDurationLong", function () {
   it("formats minutes and seconds", function () {
     expect(formatDurationLong(125)).toBe("2m 05s");
   });
+
+  it("formats hours and minutes", function () {
+    expect(formatDurationLong(3661)).toBe("1h 01m");
+    expect(formatDurationLong(7200)).toBe("2h 00m");
+    expect(formatDurationLong(654240)).toBe("181h 44m");
+  });
 });
 
 describe("truncateText", function () {

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -9,6 +9,7 @@ import Icon from "./Icon.jsx";
 import { isDiffViewable } from "../lib/diffUtils.js";
 import { formatCost } from "../lib/pricing.js";
 import { getSessionCost } from "../lib/autonomyMetrics.js";
+import { formatDurationLong } from "../lib/formatTime.js";
 
 var REPLAY_WINDOW_OVERSCAN = 600;
 var REPLAY_BOTTOM_THRESHOLD = 80;
@@ -77,7 +78,16 @@ function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, toolEn
               ["Turns", metadata.totalTurns, theme.text.primary],
               ["Tools", metadata.totalToolCalls, theme.track.tool_call],
               metadata.errorCount > 0 ? ["Errors", metadata.errorCount, theme.semantic.error] : null,
-              metadata.primaryModel ? ["Model", metadata.primaryModel.split("-").slice(0, 3).join("-"), theme.track.context] : null,
+              metadata.duration > 0 ? ["Duration", formatDurationLong(metadata.duration), theme.text.primary] : null,
+              (function () {
+                if (!metadata.models || Object.keys(metadata.models).length === 0) return null;
+                var entries = Object.entries(metadata.models).sort(function (a, b) { return b[1] - a[1]; });
+                if (entries.length === 1) {
+                  return ["Model", entries[0][0].split("-").slice(0, 3).join("-"), theme.track.context];
+                }
+                var primary = entries[0][0].split("-").slice(0, 3).join("-");
+                return ["Models", primary + " +" + (entries.length - 1) + " more", theme.track.context];
+              })(),
               metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0
                 ? ["Tokens", (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens).toLocaleString(), theme.accent.primary] : null,
               (function () {

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -447,7 +447,11 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
     }
 
     var usageCards = [];
-    usageCards.push({ label: "Model", value: metadata.primaryModel, color: theme.track.context });
+    var mKeys = Object.keys(metadata.models || {});
+    var modelCardValue = mKeys.length > 1
+      ? metadata.primaryModel.split("-").slice(0, 3).join("-") + " +" + (mKeys.length - 1) + " more"
+      : metadata.primaryModel;
+    usageCards.push({ label: mKeys.length > 1 ? "Models" : "Model", value: modelCardValue, color: theme.track.context });
     if (hasTokens) {
       usageCards.push({ label: "Tokens", color: theme.accent.primary, isTokenCard: true });
     }
@@ -457,12 +461,10 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
     if (estimated > 0) {
       usageCards.push({ label: "Est. Cost", value: formatCost(estimated), color: hasApiCost ? theme.text.muted : theme.semantic.success, sub: "based on " + modelLabel });
     }
-    var allModelsText = Object.keys(metadata.models).length > 1
-      ? Object.entries(metadata.models).map(function (entry) {
-          return entry[0].split("-").slice(0, 3).join("-") + " (" + entry[1] + ")";
-        }).join(", ")
+    var allModelsEntries = Object.keys(metadata.models).length > 1
+      ? Object.entries(metadata.models).sort(function (a, b) { return b[1] - a[1]; })
       : null;
-    modelUsageData = { usageCards: usageCards, allModelsText: allModelsText };
+    modelUsageData = { usageCards: usageCards, allModelsEntries: allModelsEntries };
   }
 
   return (
@@ -533,14 +535,18 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
                   <div key={card.label} style={cardStyle}>
                     {card.isTokenCard ? (
                       <div>
-                        <div style={{ fontSize: theme.fontSize.lg, fontWeight: 700, fontFamily: theme.font.mono }}>
-                          <span style={{ color: theme.accent.primary }}>{metadata.tokenUsage.inputTokens.toLocaleString()}</span>
-                          <span style={{ color: theme.text.muted }}>{" in / "}</span>
-                          <span style={{ color: theme.semantic.success }}>{metadata.tokenUsage.outputTokens.toLocaleString()}</span>
-                          <span style={{ color: theme.text.muted }}>{" out"}</span>
+                        <div style={{ display: "flex", flexDirection: "column", gap: 2, fontFamily: theme.font.mono }}>
+                          <div style={{ fontSize: theme.fontSize.lg, fontWeight: 700 }}>
+                            <span style={{ color: theme.accent.primary }}>{metadata.tokenUsage.inputTokens.toLocaleString()}</span>
+                            <span style={{ color: theme.text.muted }}>{" in"}</span>
+                          </div>
+                          <div style={{ fontSize: theme.fontSize.lg, fontWeight: 700 }}>
+                            <span style={{ color: theme.semantic.success }}>{metadata.tokenUsage.outputTokens.toLocaleString()}</span>
+                            <span style={{ color: theme.text.muted }}>{" out"}</span>
+                          </div>
                         </div>
                         {sessionCacheSummary && (
-                          <div style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, marginTop: 4 }}>
+                          <div style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, marginTop: 6 }}>
                             {sessionCacheSummary}
                           </div>
                         )}
@@ -557,13 +563,20 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
                 );
               })}
             </div>
-            {modelUsageData.allModelsText && (
+            {modelUsageData.allModelsEntries && (
               <div style={Object.assign({}, cardStyle, { marginTop: 12 })}>
                 <div style={{ fontSize: theme.fontSize.xs, color: theme.text.dim, textTransform: "uppercase", letterSpacing: 1, marginBottom: 8 }}>
                   All Models
                 </div>
-                <div style={{ fontSize: theme.fontSize.sm, color: theme.text.muted, lineHeight: 1.6 }}>
-                  {modelUsageData.allModelsText}
+                <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                  {modelUsageData.allModelsEntries.map(function (entry) {
+                    return (
+                      <div key={entry[0]} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", fontSize: theme.fontSize.sm }}>
+                        <span style={{ color: theme.text.secondary, fontFamily: theme.font.mono }}>{entry[0].split("-").slice(0, 3).join("-")}</span>
+                        <span style={{ color: theme.text.muted, fontFamily: theme.font.mono }}>{entry[1] + " calls"}</span>
+                      </div>
+                    );
+                  })}
                 </div>
               </div>
             )}

--- a/src/lib/formatTime.js
+++ b/src/lib/formatTime.js
@@ -20,11 +20,13 @@ export function formatTime(seconds) {
   return m + ":" + (s < 10 ? "0" : "") + s;
 }
 
-// Formats a duration in seconds as "Xm Ys" for summary stats panels.
+// Formats a duration in seconds as "Xh Ym Zs" for summary stats panels.
 export function formatDurationLong(secs) {
   if (!secs) return "--";
-  var m = Math.floor(secs / 60);
+  var h = Math.floor(secs / 3600);
+  var m = Math.floor((secs % 3600) / 60);
   var s = Math.round(secs % 60);
+  if (h > 0) return h + "h " + (m < 10 ? "0" : "") + m + "m";
   return m > 0 ? m + "m " + (s < 10 ? "0" : "") + s + "s" : s + "s";
 }
 


### PR DESCRIPTION
## Summary

Fixes formatting issues in the Replay and Stats panels when sessions use multiple models or have long durations.

## Changes

### Replay - Session Info Panel
- **Models**: Now shows all models (e.g. \claude-opus-4.6 +2 more\) instead of only the primary model
- **Duration**: Added missing duration row using \ormatDurationLong\

### Stats View
- **Duration**: Fixed \ormatDurationLong\ to handle hours -- was showing \10904m 23s\ instead of \181h 44m\
- **Model card**: Shows \+N more\ when multiple models are used
- **ALL MODELS section**: Replaced hard-to-read comma-separated text with structured rows (model name + call count)
- **Token card**: Stacked input/output on separate lines for readability with large token counts

### Tests
- Added hour-formatting test cases for \ormatDurationLong\

## Verification
- \
pm run build\ passes
- \
pm test\ passes (687 tests)
