### PR TITLE
Improve incremental live session parsing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,7 @@ src/
     parser.ts          # parseClaudeCodeJSONL() - Claude Code JSONL parser
     copilotCliParser.ts # parseCopilotCliJSONL() - Copilot CLI JSONL parser
     vscodeSessionParser.ts # parseVSCodeChatJSON() - VS Code Copilot Chat JSON parser
+    liveSessionParser.ts # Incremental live JSONL parser for appended session text
     parseSession.ts    # Auto-detect format router: detectFormat() + parseSession()
     session.ts         # Pure helpers: getSessionTotal, buildFilteredEventEntries, buildTurnStartMap
     sessionLibrary.js  # localStorage-backed session library with content persistence

--- a/src/__tests__/copilotCliParser.test.js
+++ b/src/__tests__/copilotCliParser.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { detectCopilotCli, parseCopilotCliJSONL } from "../lib/copilotCliParser";
+import { detectCopilotCli, parseCopilotCliJSONL, parseCopilotCliRecords } from "../lib/copilotCliParser";
 import { detectFormat, parseSession } from "../lib/parseSession";
 
 // Helper to build a minimal Copilot CLI JSONL trace
@@ -166,6 +166,12 @@ describe("detectFormat", function () {
 // ---- Parser: basic structure ----
 
 describe("parseCopilotCliJSONL", function () {
+  it("parseCopilotCliRecords matches parseCopilotCliJSONL", function () {
+    var text = buildTrace(BASIC_TRACE);
+    var records = BASIC_TRACE.map(function (item) { return JSON.parse(JSON.stringify(item)); });
+    expect(parseCopilotCliRecords(records, 0)).toEqual(parseCopilotCliJSONL(text));
+  });
+
   it("returns events, turns, metadata", function () {
     var result = parseCopilotCliJSONL(buildTrace(BASIC_TRACE));
     expect(result).not.toBeNull();

--- a/src/__tests__/liveSessionParser.test.ts
+++ b/src/__tests__/liveSessionParser.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { createLiveSessionParser, appendLiveSessionText } from "../lib/liveSessionParser";
+import { parseSession } from "../lib/parseSession";
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj);
+}
+
+function readFixture(name: string): string {
+  return readFileSync(join(__dirname, "fixtures", name), "utf8");
+}
+
+function expectSameSession(actual: any, expected: any): void {
+  expect(actual).not.toBeNull();
+  expect(expected).not.toBeNull();
+  expect(actual.events).toEqual(expected.events);
+  expect(actual.turns).toEqual(expected.turns);
+  expect(actual.metadata).toEqual(expected.metadata);
+}
+
+function appendInBatches(lines: string[], batchSizes: number[]): any {
+  var state = createLiveSessionParser("");
+  var cursor = 0;
+  for (var index = 0; index < batchSizes.length && cursor < lines.length; index += 1) {
+    var take = batchSizes[index];
+    state = appendLiveSessionText(state, lines.slice(cursor, cursor + take).join("\n")).state;
+    cursor += take;
+  }
+  if (cursor < lines.length) {
+    state = appendLiveSessionText(state, lines.slice(cursor).join("\n")).state;
+  }
+  return state;
+}
+
+function buildVSCodePatchJsonlFixture(): string {
+  var base = {
+    version: 3,
+    sessionId: "patch-test",
+    creationDate: 1772000000000,
+    requests: [],
+  };
+  var request = {
+    requestId: "req-1",
+    timestamp: 1772000010000,
+    message: { text: "Hello from patch" },
+    response: [],
+    result: { timings: { totalElapsed: 5000 } },
+  };
+  return [
+    line({ kind: 0, v: base }),
+    line({ kind: 1, k: ["customTitle"], v: "Patched Title" }),
+    line({ kind: 2, k: ["requests"], v: [request] }),
+    line({ kind: 2, k: ["requests", 0, "response"], v: [
+      { kind: "thinking", value: "Let me think..." },
+      { kind: "toolInvocationSerialized", toolId: "copilot_readFile", invocationMessage: { value: "Read file.ts" }, isConfirmed: { type: 1 }, isComplete: true },
+      { value: "Done" },
+    ] }),
+  ].join("\n");
+}
+
+describe("liveSessionParser", function () {
+  it("starts empty and reports no parsed session", function () {
+    var state = createLiveSessionParser("");
+    expect(state.result).toBeNull();
+    expect(state.rawText).toBe("");
+    expect(state.completeLineCount).toBe(0);
+    expect(state.parsedRecordCount).toBe(0);
+    expect(state.initialFullParseCount).toBe(0);
+    expect(state.fallbackFullParseCount).toBe(0);
+  });
+
+  it("matches full parse for Claude Code when appended one line at a time", function () {
+    var user = { type: "human", timestamp: "2026-01-01T00:00:00.000Z", message: { content: "hello" } };
+    var assistant = { type: "assistant", timestamp: "2026-01-01T00:00:02.000Z", message: { content: [{ type: "text", text: "hi" }] } };
+    var lines = [line(user), line(assistant)];
+    var state = appendInBatches(lines, [1, 1]);
+    expectSameSession(state.result, parseSession(lines.join("\n")));
+    expect(state.lastAppendParsedLineCount).toBe(1);
+    expect(state.fallbackFullParseCount).toBe(0);
+  });
+
+  it("matches full parse for Copilot CLI fixture", function () {
+    var text = readFixture("test-copilot.jsonl").trim();
+    var lines = text.split("\n");
+    var state = appendInBatches(lines, [1, 3, 2, 10]);
+    expectSameSession(state.result, parseSession(text));
+    expect(state.fallbackFullParseCount).toBe(0);
+  });
+
+  it("matches full parse for VS Code JSONL patches", function () {
+    var text = buildVSCodePatchJsonlFixture();
+    var lines = text.split("\n");
+    var state = appendInBatches(lines, [1, 1, 2]);
+    expectSameSession(state.result, parseSession(text));
+    expect(state.format).toBe("vscode-chat");
+    expect(state.fallbackFullParseCount).toBe(0);
+  });
+
+  it("counts malformed complete lines while preserving valid records", function () {
+    var user = line({ type: "human", timestamp: "2026-01-01T00:00:00.000Z", message: { content: "hello" } });
+    var assistant = line({ type: "assistant", timestamp: "2026-01-01T00:00:02.000Z", message: { content: [{ type: "text", text: "hi" }] } });
+    var text = user + "\n{broken json\n" + assistant;
+    var state = appendLiveSessionText(createLiveSessionParser(""), text).state;
+    expect(state.malformedLineCount).toBe(1);
+    expectSameSession(state.result, parseSession(text));
+  });
+
+  it("detects Copilot format from an empty initial state when session.start arrives first", function () {
+    var start = line({ type: "session.start", data: { producer: "copilot-agent", startTime: "2026-03-18T15:00:00.000Z" }, timestamp: "2026-03-18T15:00:00.000Z" });
+    var state = appendLiveSessionText(createLiveSessionParser(""), start).state;
+    expect(state.format).toBe("copilot-cli");
+  });
+
+  it("detects VS Code format from an empty initial state when kind 0 arrives first", function () {
+    var base = line({ kind: 0, v: { version: 3, sessionId: "x", creationDate: 1772000000000, requests: [] } });
+    var state = appendLiveSessionText(createLiveSessionParser(""), base).state;
+    expect(state.format).toBe("vscode-chat");
+  });
+
+  it("does not double-insert newlines when initial raw text already ends with newline", function () {
+    var first = line({ type: "human", message: { content: "hello" } });
+    var second = line({ type: "assistant", message: { content: [{ type: "text", text: "hi" }] } });
+    var state = createLiveSessionParser(first + "\n");
+    state = appendLiveSessionText(state, second).state;
+    expect(state.rawText).toBe(first + "\n" + second);
+  });
+
+  it("falls back to full parse when appended records conflict with established format", function () {
+    var claude = line({ type: "human", message: { content: "hello" } });
+    var copilot = line({ type: "session.start", data: { producer: "copilot-agent" }, timestamp: "2026-01-01T00:00:00.000Z" });
+    var state = createLiveSessionParser(claude);
+    state = appendLiveSessionText(state, copilot).state;
+    expect(state.fallbackFullParseCount).toBeGreaterThan(0);
+  });
+
+  it("buffers incomplete trailing JSON instead of counting it malformed", function () {
+    var state = appendLiveSessionText(createLiveSessionParser(""), "{\"type\":\"human\",").state;
+    expect(state.malformedLineCount).toBe(0);
+    expect(state.pendingText).not.toBe("");
+  });
+
+  it("joins split JSON fragments without inserting a synthetic newline", function () {
+    var first = "{\"type\":\"human\",";
+    var second = "\"message\":{\"content\":\"hello\"}}";
+    var state = appendLiveSessionText(createLiveSessionParser(""), first).state;
+    state = appendLiveSessionText(state, second).state;
+    expect(state.rawText).toBe(first + second);
+    expect(state.pendingText).toBe("");
+    expect(state.parsedRecordCount).toBe(1);
+  });
+
+  it("keeps append parse counters proportional to appended lines", function () {
+    var lines: string[] = [];
+    for (var index = 0; index < 100; index += 1) {
+      lines.push(line({
+        type: "human",
+        timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        message: { content: "msg " + index },
+      }));
+    }
+
+    var state = createLiveSessionParser(lines.slice(0, 90).join("\n"));
+    var initialFullParses = state.initialFullParseCount;
+    state = appendLiveSessionText(state, lines.slice(90).join("\n")).state;
+
+    expect(state.initialFullParseCount).toBe(initialFullParses);
+    expect(state.fallbackFullParseCount).toBe(0);
+    expect(state.lastAppendParsedLineCount).toBe(10);
+    expect(state.parsedRecordCount).toBe(100);
+  });
+
+  it("applies VS Code patches without fallback after kind 0", function () {
+    var lines = buildVSCodePatchJsonlFixture().split("\n");
+    var state = createLiveSessionParser(lines[0]);
+    state = appendLiveSessionText(state, lines.slice(1).join("\n")).state;
+    expect(state.format).toBe("vscode-chat");
+    expect(state.fallbackFullParseCount).toBe(0);
+    expect(state.lastAppendParsedLineCount).toBe(lines.length - 1);
+  });
+});

--- a/src/__tests__/parser.test.js
+++ b/src/__tests__/parser.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseClaudeCodeJSONL } from "../lib/parser";
+import { parseClaudeCodeJSONL, parseClaudeCodeRecords } from "../lib/parser";
 
 // ── Helpers ──
 
@@ -126,6 +126,14 @@ var NO_TS_ASSISTANT = {
 describe("parseClaudeCodeJSONL", function () {
 
   describe("basic parsing", function () {
+    it("parseClaudeCodeRecords matches parseClaudeCodeJSONL", function () {
+      var lines = [USER_MSG, ASSISTANT_THINKING, ASSISTANT_TEXT, ASSISTANT_TOOL_USE, TOOL_RESULT_OK];
+      var text = makeSession(lines);
+      var records = lines.map(function (item) { return JSON.parse(JSON.stringify(item)); });
+
+      expect(parseClaudeCodeRecords(records)).toEqual(parseClaudeCodeJSONL(text));
+    });
+
     it("returns null for empty input", function () {
       expect(parseClaudeCodeJSONL("")).toBeNull();
       expect(parseClaudeCodeJSONL("   \n  \n  ")).toBeNull();

--- a/src/__tests__/sessionLoaderUtils.test.js
+++ b/src/__tests__/sessionLoaderUtils.test.js
@@ -4,7 +4,7 @@ import {
   buildAppliedSession,
   parseSessionText,
 } from "../lib/sessionParsing";
-import { appendRawLines, shouldApplyLiveLines } from "../hooks/useSessionLoader.js";
+import { LIVE_NOTIFY_DEBOUNCE_MS, shouldApplyLiveLines } from "../hooks/useSessionLoader.js";
 
 function buildResult() {
   return {
@@ -18,9 +18,8 @@ function buildResult() {
 }
 
 describe("useSessionLoader helpers", function () {
-  it("appends live text with stable newline handling", function () {
-    expect(appendRawLines("", "line-1")).toBe("line-1");
-    expect(appendRawLines("line-1", "line-2")).toBe("line-1\nline-2");
+  it("exposes the live notify debounce delay", function () {
+    expect(LIVE_NOTIFY_DEBOUNCE_MS).toBe(250);
   });
 
   it("only accepts live updates from the active live request", function () {

--- a/src/__tests__/vscodeSessionParser.test.ts
+++ b/src/__tests__/vscodeSessionParser.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { detectVSCodeChat, parseVSCodeChatJSON } from "../lib/vscodeSessionParser";
+import {
+  applyVSCodeJsonlPatch,
+  detectVSCodeChat,
+  parseVSCodeChatJSON,
+  parseVSCodeChatSession,
+} from "../lib/vscodeSessionParser";
 import { detectFormat, parseSession } from "../lib/parseSession";
 
 var FIXTURE = readFileSync(join(__dirname, "fixtures/test-vscode-chat.json"), "utf8");
@@ -214,6 +219,30 @@ describe("JSONL wrapper format", function () {
 });
 
 describe("JSONL incremental patches", function () {
+  it("parseVSCodeChatSession matches parseVSCodeChatJSON for plain session objects", function () {
+    var session = JSON.parse(FIXTURE);
+    expect(parseVSCodeChatSession(session)).toEqual(parseVSCodeChatJSON(FIXTURE));
+  });
+
+  it("applyVSCodeJsonlPatch preserves existing patch semantics", function () {
+    var session: any = {
+      version: 3,
+      sessionId: "patch-test",
+      creationDate: 1772000000000,
+      requests: [],
+    };
+    expect(applyVSCodeJsonlPatch(session, { kind: 1, k: ["customTitle"], v: "Patched Title" })).toBe(true);
+    expect(applyVSCodeJsonlPatch(session, { kind: 2, k: ["requests"], v: [{ requestId: "req-1", timestamp: 1772000010000, message: { text: "Hello" }, response: [] }] })).toBe(true);
+    expect(session.customTitle).toBe("Patched Title");
+    expect(session.requests.length).toBe(1);
+  });
+
+  it("applyVSCodeJsonlPatch rejects dangerous key segments", function () {
+    var session: any = { version: 3, sessionId: "safe", requests: [] };
+    expect(applyVSCodeJsonlPatch(session, { kind: 1, k: ["__proto__", "polluted"], v: true })).toBe(false);
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
   it("applies kind:1 set and kind:2 append patches", function () {
     // Base session with empty requests
     var base = {
@@ -274,7 +303,33 @@ describe("JSONL incremental patches", function () {
     expect(result).toBeNull();
   });
 
-  it("ignores dangerous prototype pollution patch paths", function () {
+  it("returns false instead of throwing for invalid primitive traversal patches", function () {
+    var session = JSON.parse(FIXTURE);
+    expect(applyVSCodeJsonlPatch(session, { kind: 1, k: ["sessionId", "x"], v: "bad" })).toBe(false);
+    expect(applyVSCodeJsonlPatch(session, { kind: 2, k: ["sessionId"], v: ["bad"] })).toBe(false);
+  });
+
+  it("ignores invalid primitive traversal patches while parsing JSONL", function () {
+    var base = { version: 3, sessionId: "bad-patch", creationDate: 1772000000000, requests: [] };
+    var request = {
+      requestId: "req-1",
+      timestamp: 1772000010000,
+      message: { text: "still parses" },
+      response: [{ value: "ok" }],
+      result: { timings: { totalElapsed: 1000 } },
+    };
+    var text = [
+      JSON.stringify({ kind: 0, v: base }),
+      JSON.stringify({ kind: 1, k: ["sessionId", "x"], v: "bad" }),
+      JSON.stringify({ kind: 2, k: ["requests"], v: [request] }),
+    ].join("\n");
+    var parsed = parseVSCodeChatJSON(text);
+    expect(parsed).not.toBeNull();
+    expect(parsed?.metadata.sessionId).toBe("bad-patch");
+    expect(parsed?.events[0].text).toBe("still parses");
+  });
+
+  it("ignores prototype pollution patch paths", function () {
     var base = {
       version: 3,
       sessionId: "safe-session",

--- a/src/hooks/useSessionLoader.js
+++ b/src/hooks/useSessionLoader.js
@@ -1,12 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import { parseSession } from "../lib/parseSession";
+import { appendLiveSessionText, createLiveSessionParser } from "../lib/liveSessionParser";
 import { SAMPLE_EVENTS, SAMPLE_TOTAL, SAMPLE_TURNS, SAMPLE_METADATA, MULTIAGENT_SAMPLE_EVENTS, MULTIAGENT_SAMPLE_TOTAL, MULTIAGENT_SAMPLE_TURNS, MULTIAGENT_SAMPLE_METADATA } from "../lib/constants.js";
 import { getSessionTotal } from "../lib/session";
 import { buildAppliedSession, parseSessionText } from "../lib/sessionParsing";
 
-export function appendRawLines(existingText, newLines) {
-  return existingText ? existingText + "\n" + newLines : newLines;
-}
+export var LIVE_NOTIFY_DEBOUNCE_MS = 250;
 
 export function shouldApplyLiveLines(liveRequestId, requestId) {
   return liveRequestId === requestId;
@@ -25,8 +24,10 @@ export default function useSessionLoader(options) {
   var [showHero, setShowHero] = useState(false);
   var [isLive, setIsLive] = useState(false);
   var parseTimeoutRef = useRef(null);
+  var liveNotifyTimeoutRef = useRef(null);
   var requestIdRef = useRef(0);
   var rawTextRef = useRef("");
+  var liveParserRef = useRef(createLiveSessionParser(""));
   // Tracks the requestId that initiated the current live session. appendLines
   // checks this so stale live data from a previous session never overwrites a
   // newly-loaded file.
@@ -49,6 +50,27 @@ export default function useSessionLoader(options) {
     }
   }, [onSessionParsed]);
 
+  var clearLiveNotify = useCallback(function () {
+    if (liveNotifyTimeoutRef.current) {
+      clearTimeout(liveNotifyTimeoutRef.current);
+      liveNotifyTimeoutRef.current = null;
+    }
+  }, []);
+
+  var notifyLiveSessionParsed = useCallback(function (result, name, text) {
+    if (typeof onSessionParsed !== "function") return;
+    clearLiveNotify();
+    liveNotifyTimeoutRef.current = setTimeout(function () {
+      liveNotifyTimeoutRef.current = null;
+      onSessionParsed(result, name, text);
+    }, LIVE_NOTIFY_DEBOUNCE_MS);
+  }, [clearLiveNotify, onSessionParsed]);
+
+  var resetLiveParser = useCallback(function (text) {
+    clearLiveNotify();
+    liveParserRef.current = createLiveSessionParser(text || "");
+  }, [clearLiveNotify]);
+
   var handleFile = useCallback(function (text, name) {
     requestIdRef.current += 1;
     var requestId = requestIdRef.current;
@@ -59,6 +81,7 @@ export default function useSessionLoader(options) {
     }
 
     rawTextRef.current = text;
+    resetLiveParser(text);
     setError(null);
     setLoading(true);
     setIsLive(false);
@@ -80,24 +103,27 @@ export default function useSessionLoader(options) {
       applySession(parsed.result, name);
       notifySessionParsed(parsed.result, name, text);
     }, 16);
-  }, [applySession, notifySessionParsed]);
+  }, [applySession, notifySessionParsed, resetLiveParser]);
 
   // Called by useLiveStream with each batch of new JSONL lines.
-  // Appends to rawText and re-parses the full accumulated text.
-  // Guards against stale live data overwriting a newly-loaded file.
+  // Parses only appended lines and rebuilds normalized session output from the
+  // accumulated parsed records. Guards against stale live data overwriting a
+  // newly-loaded file.
   var appendLines = useCallback(function (newLines) {
     if (!shouldApplyLiveLines(liveRequestIdRef.current, requestIdRef.current)) return;
-    rawTextRef.current = appendRawLines(rawTextRef.current, newLines);
 
-    var parsed = parseSessionText(rawTextRef.current);
-    if (!parsed.result) return;
+    var updated = appendLiveSessionText(liveParserRef.current, newLines);
+    liveParserRef.current = updated.state;
+    rawTextRef.current = updated.state.rawText;
 
-    setEvents(parsed.result.events);
-    setTurns(parsed.result.turns);
-    setMetadata(parsed.result.metadata);
-    setTotal(getSessionTotal(parsed.result.events));
-    notifySessionParsed(parsed.result, file || "live-session.jsonl", rawTextRef.current);
-  }, [file, notifySessionParsed]);
+    if (!updated.result) return;
+
+    setEvents(updated.result.events);
+    setTurns(updated.result.turns);
+    setMetadata(updated.result.metadata);
+    setTotal(getSessionTotal(updated.result.events));
+    notifyLiveSessionParsed(updated.result, file || "live-session.jsonl", updated.state.rawText);
+  }, [file, notifyLiveSessionParsed]);
 
   var loadSample = useCallback(function (mode) {
     requestIdRef.current += 1;
@@ -108,6 +134,7 @@ export default function useSessionLoader(options) {
 
     var isMultiAgent = mode === "multiagent";
     rawTextRef.current = "";
+    resetLiveParser("");
     setEvents(isMultiAgent ? MULTIAGENT_SAMPLE_EVENTS : SAMPLE_EVENTS);
     setTurns(isMultiAgent ? MULTIAGENT_SAMPLE_TURNS : SAMPLE_TURNS);
     setMetadata(isMultiAgent ? MULTIAGENT_SAMPLE_METADATA : SAMPLE_METADATA);
@@ -117,7 +144,7 @@ export default function useSessionLoader(options) {
     setLoading(false);
     setIsLive(false);
     setShowHero(true);
-  }, []);
+  }, [resetLiveParser]);
 
   var resetSession = useCallback(function () {
     requestIdRef.current += 1;
@@ -127,6 +154,7 @@ export default function useSessionLoader(options) {
     }
 
     rawTextRef.current = "";
+    resetLiveParser("");
     setEvents(null);
     setTurns([]);
     setMetadata(null);
@@ -136,7 +164,7 @@ export default function useSessionLoader(options) {
     setLoading(false);
     setIsLive(false);
     setShowHero(false);
-  }, []);
+  }, [resetLiveParser]);
 
   var dismissHero = useCallback(function () {
     setShowHero(false);
@@ -156,6 +184,7 @@ export default function useSessionLoader(options) {
           .then(function (text) {
             if (!text) return;
             rawTextRef.current = text;
+            resetLiveParser(text);
             requestIdRef.current += 1;
             if (meta.live) {
               liveRequestIdRef.current = requestIdRef.current;
@@ -178,17 +207,18 @@ export default function useSessionLoader(options) {
           });
       })
       .catch(function () {});
-  }, [autoBootstrap, notifySessionParsed]);
+  }, [autoBootstrap, notifySessionParsed, resetLiveParser]);
 
   useEffect(function () {
     return function () {
       requestIdRef.current += 1;
+      clearLiveNotify();
       if (parseTimeoutRef.current) {
         clearTimeout(parseTimeoutRef.current);
         parseTimeoutRef.current = null;
       }
     };
-  }, []);
+  }, [clearLiveNotify]);
 
   return {
     events: events,

--- a/src/lib/copilotCliParser.ts
+++ b/src/lib/copilotCliParser.ts
@@ -641,9 +641,7 @@ export function detectCopilotCli(text: string): boolean {
   }
 }
 
-export function parseCopilotCliJSONL(text: string): ParsedSession | null {
-  const parsed = parseRawRecords(text);
-  const records = parsed.records;
+export function parseCopilotCliRecords(records: RawRecord[], malformedLines: number): ParsedSession | null {
   if (records.length === 0) return null;
 
   let sessionStartSec: number | null = null;
@@ -668,7 +666,12 @@ export function parseCopilotCliJSONL(text: string): ParsedSession | null {
   if (events.length === 0) return null;
 
   const turns = buildTurns(records, events, sessionStartSec);
-  const metadata = buildMetadata(records, events, turns, parsed.malformedLines);
+  const metadata = buildMetadata(records, events, turns, malformedLines);
 
   return { events, turns, metadata };
+}
+
+export function parseCopilotCliJSONL(text: string): ParsedSession | null {
+  const parsed = parseRawRecords(text);
+  return parseCopilotCliRecords(parsed.records, parsed.malformedLines);
 }

--- a/src/lib/liveSessionParser.ts
+++ b/src/lib/liveSessionParser.ts
@@ -1,0 +1,278 @@
+import { detectFormat, parseSession } from "./parseSession";
+import { parseCopilotCliRecords } from "./copilotCliParser";
+import { parseClaudeCodeRecords } from "./parser";
+import {
+  applyVSCodeJsonlPatch,
+  parseVSCodeChatSession,
+  type VSCodeSession,
+} from "./vscodeSessionParser";
+import type { ParsedSession, SessionFormat } from "./sessionTypes";
+
+type RawRecord = Record<string, any>;
+
+interface ParseIssues {
+  malformedLines: number;
+  invalidEvents: number;
+}
+
+export interface LiveSessionParserState {
+  rawText: string;
+  pendingText: string;
+  completeLineCount: number;
+  parsedRecordCount: number;
+  malformedLineCount: number;
+  lastAppendParsedLineCount: number;
+  format: SessionFormat | null;
+  result: ParsedSession | null;
+  records: RawRecord[];
+  vscodeSession: VSCodeSession | null;
+  initialFullParseCount: number;
+  fallbackFullParseCount: number;
+}
+
+export interface LiveSessionParserUpdate {
+  state: LiveSessionParserState;
+  result: ParsedSession | null;
+}
+
+function createEmptyState(): LiveSessionParserState {
+  return {
+    rawText: "",
+    pendingText: "",
+    completeLineCount: 0,
+    parsedRecordCount: 0,
+    malformedLineCount: 0,
+    lastAppendParsedLineCount: 0,
+    format: null,
+    result: null,
+    records: [],
+    vscodeSession: null,
+    initialFullParseCount: 0,
+    fallbackFullParseCount: 0,
+  };
+}
+
+function cloneJson<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function appendRawText(previous: string, next: string): string {
+  if (!previous) return next;
+  if (!next) return previous;
+  if (previous.endsWith("\n") || next.startsWith("\n")) return previous + next;
+  return previous + "\n" + next;
+}
+
+function splitCompleteLines(text: string): { lines: string[]; pendingText: string } {
+  if (!text) return { lines: [], pendingText: "" };
+
+  const rawLines = text.split("\n");
+  const endsWithNewline = text.endsWith("\n") || text.endsWith("\r");
+  const lines: string[] = [];
+  let pendingText = "";
+
+  for (let index = 0; index < rawLines.length; index += 1) {
+    const rawLine = rawLines[index];
+    const trimmed = rawLine.trim();
+    const isLast = index === rawLines.length - 1;
+    if (!trimmed) continue;
+
+    if (isLast && !endsWithNewline) {
+      try {
+        JSON.parse(trimmed);
+        lines.push(trimmed);
+      } catch {
+        pendingText = rawLine;
+      }
+    } else {
+      lines.push(trimmed);
+    }
+  }
+
+  return { lines, pendingText };
+}
+
+function parseLines(lines: string[]): { records: RawRecord[]; malformedLines: number } {
+  const records: RawRecord[] = [];
+  let malformedLines = 0;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    try {
+      const parsed = JSON.parse(lines[index]);
+      if (parsed && typeof parsed === "object") {
+        records.push(parsed);
+      } else {
+        malformedLines += 1;
+      }
+    } catch {
+      malformedLines += 1;
+    }
+  }
+
+  return { records, malformedLines };
+}
+
+function isCopilotStart(record: RawRecord): boolean {
+  return (
+    (record.type === "session.start" || record.type === "session.resume") &&
+    record.data &&
+    (record.data.producer === "copilot-agent" || record.data.copilotVersion)
+  );
+}
+
+function isVSCodeBase(record: RawRecord): boolean {
+  const value = record.v;
+  return Boolean(
+    record.kind === 0 &&
+    value &&
+    typeof value.version === "number" &&
+    typeof value.sessionId === "string" &&
+    Array.isArray(value.requests)
+  );
+}
+
+function detectExplicitFormatFromRecords(records: RawRecord[]): SessionFormat | null {
+  if (records.length === 0) return null;
+  if (isCopilotStart(records[0])) return "copilot-cli";
+  if (isVSCodeBase(records[0])) return "vscode-chat";
+  return null;
+}
+
+function detectFormatFromRecords(records: RawRecord[]): SessionFormat | null {
+  return detectExplicitFormatFromRecords(records) || (records.length > 0 ? "claude-code" : null);
+}
+
+function createIssues(malformedLineCount: number): ParseIssues {
+  return { malformedLines: malformedLineCount, invalidEvents: 0 };
+}
+
+function buildVSCodeSession(records: RawRecord[], existingSession: VSCodeSession | null): VSCodeSession | null {
+  let session = existingSession;
+
+  for (let index = 0; index < records.length; index += 1) {
+    const record = records[index];
+    if (isVSCodeBase(record)) {
+      session = cloneJson(record.v);
+    } else if (session) {
+      applyVSCodeJsonlPatch(session, record);
+    }
+  }
+
+  return session;
+}
+
+function deriveResult(
+  format: SessionFormat | null,
+  records: RawRecord[],
+  malformedLineCount: number,
+  vscodeSession: VSCodeSession | null,
+): { result: ParsedSession | null; vscodeSession: VSCodeSession | null } {
+  if (!format) return { result: null, vscodeSession };
+  if (format === "copilot-cli") {
+    return { result: parseCopilotCliRecords(records, malformedLineCount), vscodeSession };
+  }
+  if (format === "vscode-chat") {
+    const session = buildVSCodeSession(records, null);
+    return { result: session ? parseVSCodeChatSession(session) : null, vscodeSession: session };
+  }
+  return {
+    result: parseClaudeCodeRecords(records, createIssues(malformedLineCount)),
+    vscodeSession,
+  };
+}
+
+function detectPlainVSCodeJson(text: string): boolean {
+  try {
+    const parsed = JSON.parse(text.trim());
+    return Boolean(
+      parsed &&
+      typeof parsed === "object" &&
+      typeof parsed.version === "number" &&
+      typeof parsed.sessionId === "string" &&
+      Array.isArray(parsed.requests)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function rebuildStateFromRawText(
+  rawText: string,
+  initialFullParseCount: number,
+  fallbackFullParseCount: number,
+): LiveSessionParserState {
+  const split = splitCompleteLines(rawText);
+  const parsed = parseLines(split.lines);
+  const format = detectFormatFromRecords(parsed.records) || (rawText.trim() ? detectFormat(rawText) : null);
+  const derived = deriveResult(format, parsed.records, parsed.malformedLines, null);
+  const result = derived.result || (rawText.trim() ? parseSession(rawText) : null);
+
+  return {
+    rawText,
+    pendingText: split.pendingText,
+    completeLineCount: split.lines.length,
+    parsedRecordCount: parsed.records.length,
+    malformedLineCount: parsed.malformedLines,
+    lastAppendParsedLineCount: 0,
+    format,
+    result,
+    records: parsed.records,
+    vscodeSession: derived.vscodeSession,
+    initialFullParseCount,
+    fallbackFullParseCount,
+  };
+}
+
+export function createLiveSessionParser(initialText: string): LiveSessionParserState {
+  if (!initialText.trim()) return createEmptyState();
+
+  const state = rebuildStateFromRawText(initialText, detectPlainVSCodeJson(initialText) ? 1 : 0, 0);
+  if (!state.result && detectPlainVSCodeJson(initialText)) {
+    return { ...state, result: parseSession(initialText), format: "vscode-chat" };
+  }
+  return state;
+}
+
+export function appendLiveSessionText(
+  previous: LiveSessionParserState,
+  newText: string,
+): LiveSessionParserUpdate {
+  const rawText = previous.pendingText
+    ? previous.rawText + newText
+    : appendRawText(previous.rawText, newText);
+  const split = splitCompleteLines(previous.pendingText + newText);
+  const parsed = parseLines(split.lines);
+  const incomingFormat = detectExplicitFormatFromRecords(parsed.records);
+
+  if (previous.format && incomingFormat && incomingFormat !== previous.format) {
+    const fallbackState = rebuildStateFromRawText(
+      rawText,
+      previous.initialFullParseCount,
+      previous.fallbackFullParseCount + 1,
+    );
+    return { state: fallbackState, result: fallbackState.result };
+  }
+
+  const format = previous.format || incomingFormat || detectFormatFromRecords(parsed.records);
+  const records = previous.records.concat(parsed.records);
+  const malformedLineCount = previous.malformedLineCount + parsed.malformedLines;
+  const derived = deriveResult(format, records, malformedLineCount, previous.vscodeSession);
+  const result = derived.result || previous.result;
+
+  const state: LiveSessionParserState = {
+    rawText,
+    pendingText: split.pendingText,
+    completeLineCount: previous.completeLineCount + split.lines.length,
+    parsedRecordCount: records.length,
+    malformedLineCount,
+    lastAppendParsedLineCount: split.lines.length,
+    format,
+    result,
+    records,
+    vscodeSession: derived.vscodeSession,
+    initialFullParseCount: previous.initialFullParseCount,
+    fallbackFullParseCount: previous.fallbackFullParseCount,
+  };
+
+  return { state, result };
+}

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -658,19 +658,8 @@ function buildMetadata(events: NormalizedEvent[], turns: SessionTurn[], issues: 
   };
 }
 
-export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
-  const lines = text.trim().split("\n").filter(Boolean);
-  const rawRecords: RawRecord[] = [];
-  const issues = createParseIssues();
-
-  for (let index = 0; index < lines.length; index += 1) {
-    try {
-      rawRecords.push(JSON.parse(lines[index]));
-    } catch {
-      issues.malformedLines += 1;
-    }
-  }
-
+export function parseClaudeCodeRecords(rawRecords: RawRecord[], issues?: ParseIssues): ParsedSession | null {
+  const parseIssues = issues || createParseIssues();
   if (rawRecords.length === 0) return null;
 
   let timestampCount = 0;
@@ -685,7 +674,7 @@ export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
   let syntheticTime = 0;
 
   for (let index = 0; index < rawRecords.length; index += 1) {
-    const parsedEvents = extractEventsFromRecord(rawRecords[index], syntheticTime, issues, mergedUsageByKey, attachedUsageKeys);
+    const parsedEvents = extractEventsFromRecord(rawRecords[index], syntheticTime, parseIssues, mergedUsageByKey, attachedUsageKeys);
     events.push(...parsedEvents);
     syntheticTime += Math.max(1, parsedEvents.length);
   }
@@ -715,7 +704,23 @@ export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
   if (hasRealTimestamps) computeDurations(events);
 
   const turns = buildTurns(events);
-  const metadata = buildMetadata(events, turns, issues);
+  const metadata = buildMetadata(events, turns, parseIssues);
 
   return { events, turns, metadata };
+}
+
+export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
+  const lines = text.trim().split("\n").filter(Boolean);
+  const rawRecords: RawRecord[] = [];
+  const issues = createParseIssues();
+
+  for (let index = 0; index < lines.length; index += 1) {
+    try {
+      rawRecords.push(JSON.parse(lines[index]));
+    } catch {
+      issues.malformedLines += 1;
+    }
+  }
+
+  return parseClaudeCodeRecords(rawRecords, issues);
 }

--- a/src/lib/vscodeSessionParser.ts
+++ b/src/lib/vscodeSessionParser.ts
@@ -17,7 +17,7 @@ import type { TrackType } from "./theme";
 
 type ResponsePart = Record<string, any>;
 type VSCodeRequest = Record<string, any>;
-type VSCodeSession = Record<string, any>;
+export type VSCodeSession = Record<string, any>;
 
 const MAX_TEXT_LENGTH = 4000;
 const DANGEROUS_KEY_SEGMENTS = new Set(["__proto__", "constructor", "prototype"]);
@@ -34,6 +34,40 @@ import { truncateText as truncate } from "./formatTime.js";
  *   kind 1: {"kind":1,"k":["path","to","key"],"v":val}  -- set value at key path
  *   kind 2: {"kind":2,"k":["path","to","arr"],"v":[...]} -- append items to array
  */
+function canTraverse(value: unknown): value is Record<string | number, any> {
+  return Boolean((typeof value === "object" || typeof value === "function") && value !== null);
+}
+
+export function applyVSCodeJsonlPatch(session: VSCodeSession, patch: Record<string, any>): boolean {
+  const keyPath: (string | number)[] = patch.k;
+  if (!Array.isArray(keyPath) || keyPath.length === 0) return false;
+  if (keyPath.some(function (segment) { return DANGEROUS_KEY_SEGMENTS.has(String(segment)); })) return false;
+
+  if (patch.kind === 1) {
+    let target: any = session;
+    for (let index = 0; index < keyPath.length - 1; index += 1) {
+      if (!canTraverse(target)) return false;
+      target = target[keyPath[index]];
+    }
+    if (!canTraverse(target)) return false;
+    target[keyPath[keyPath.length - 1]] = patch.v;
+    return true;
+  }
+
+  if (patch.kind === 2) {
+    let target: any = session;
+    for (let index = 0; index < keyPath.length; index += 1) {
+      if (!canTraverse(target)) return false;
+      target = target[keyPath[index]];
+    }
+    if (!Array.isArray(target) || !Array.isArray(patch.v)) return false;
+    for (let index = 0; index < patch.v.length; index += 1) target.push(patch.v[index]);
+    return true;
+  }
+
+  return false;
+}
+
 function unwrapJsonl(text: string): VSCodeSession | null {
   const lines = text.split("\n").filter(function (l) { return l.trim().length > 0; });
   if (lines.length === 0) return null;
@@ -54,30 +88,7 @@ function unwrapJsonl(text: string): VSCodeSession | null {
   // Apply incremental patches from remaining lines
   for (let i = 1; i < lines.length; i++) {
     try {
-      const patch = JSON.parse(lines[i]);
-      const keyPath: (string | number)[] = patch.k;
-      if (!Array.isArray(keyPath) || keyPath.length === 0) continue;
-      if (keyPath.some(function (segment) { return DANGEROUS_KEY_SEGMENTS.has(String(segment)); })) continue;
-
-      if (patch.kind === 1) {
-        // Set: navigate to parent, set last key
-        let target: any = session;
-        for (let j = 0; j < keyPath.length - 1; j++) {
-          if (target == null) break;
-          target = target[keyPath[j]];
-        }
-        if (target != null) target[keyPath[keyPath.length - 1]] = patch.v;
-      } else if (patch.kind === 2) {
-        // Append: navigate to the array, push items
-        let target: any = session;
-        for (let j = 0; j < keyPath.length; j++) {
-          if (target == null) break;
-          target = target[keyPath[j]];
-        }
-        if (Array.isArray(target) && Array.isArray(patch.v)) {
-          for (let j = 0; j < patch.v.length; j++) target.push(patch.v[j]);
-        }
-      }
+      if (session) applyVSCodeJsonlPatch(session, JSON.parse(lines[i]));
     } catch {
       // skip malformed patch lines
     }
@@ -475,6 +486,17 @@ function buildMetadata(
 
 // ── Main parser ──────────────────────────────────────────────────────────────
 
+export function parseVSCodeChatSession(session: VSCodeSession): ParsedSession | null {
+  if (!isVSCodeSession(session)) return null;
+
+  const { events, turns } = buildTimeline(session);
+  if (events.length === 0) return null;
+
+  const metadata = buildMetadata(events, turns, session);
+
+  return { events, turns, metadata };
+}
+
 export function parseVSCodeChatJSON(text: string): ParsedSession | null {
   let session: VSCodeSession | null = null;
 
@@ -492,12 +514,6 @@ export function parseVSCodeChatJSON(text: string): ParsedSession | null {
     session = unwrapJsonl(text);
   }
 
-  if (!session || !isVSCodeSession(session)) return null;
-
-  const { events, turns } = buildTimeline(session);
-  if (events.length === 0) return null;
-
-  const metadata = buildMetadata(events, turns, session);
-
-  return { events, turns, metadata };
+  if (!session) return null;
+  return parseVSCodeChatSession(session);
 }


### PR DESCRIPTION
## Summary
- add an incremental live JSONL parser for appended session text
- extract record-based parser entry points for Claude Code, Copilot CLI, and VS Code sessions
- debounce live session persistence and reset live parser state across session changes
- add parity and regression tests for incremental parsing and VS Code patch handling

## Validation
- npm run typecheck
- npm test
- npm run build