### PR TITLE
perf: memoize expensive render-path computations in Timeline and StatsView

### DIFF
--- a/src/__tests__/session-ux.test.js
+++ b/src/__tests__/session-ux.test.js
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { buildReplayLayout, getReplayWindow } from "../lib/replayLayout.js";
 import { buildCommandPaletteIndex, searchCommandPalette } from "../lib/commandPalette.js";
 import { buildTimelineBins } from "../components/Timeline.jsx";
+import { theme } from "../lib/theme.js";
 
 describe("replay layout helpers", function () {
   it("adds extra height for turn headers", function () {
@@ -100,5 +101,25 @@ describe("timeline binning", function () {
     }, 0);
 
     expect(filled).toBeGreaterThan(1);
+  });
+
+  it("preserves agent type colors when binning agent events", function () {
+    var entries = [
+      {
+        index: 0,
+        event: {
+          t: 0,
+          duration: 1,
+          intensity: 0.5,
+          isError: false,
+          track: "agent",
+          agentName: "task",
+        },
+      },
+    ];
+
+    var bins = buildTimelineBins(entries, 100, null, null);
+
+    expect(bins[0].color).toBe(theme.agentType.task);
   });
 });

--- a/src/__tests__/statsView.test.jsx
+++ b/src/__tests__/statsView.test.jsx
@@ -32,6 +32,10 @@ function normalizeCssColor(value) {
   return node.style.background;
 }
 
+function getCardValue(container, label) {
+  return findExactText(container, label).parentElement.firstElementChild.textContent;
+}
+
 describe("StatsView theme updates", function () {
   beforeEach(function () {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -58,6 +62,10 @@ describe("StatsView theme updates", function () {
     var StatsView = StatsViewMod.default;
     var lightSurface = normalizeCssColor(themeMod.getThemeTokensForMode("light", "dark").bg.surface);
     var darkSurface = normalizeCssColor(themeMod.getThemeTokensForMode("dark", "dark").bg.surface);
+    var lightTextPrimary = normalizeCssColor(themeMod.getThemeTokensForMode("light", "dark").text.primary);
+    var darkTextPrimary = normalizeCssColor(themeMod.getThemeTokensForMode("dark", "dark").text.primary);
+    var lightTrackContext = normalizeCssColor(themeMod.getThemeTokensForMode("light", "dark").track.context);
+    var darkTrackContext = normalizeCssColor(themeMod.getThemeTokensForMode("dark", "dark").track.context);
     var container = document.createElement("div");
     document.body.appendChild(container);
     var root = createRoot(container);
@@ -85,6 +93,9 @@ describe("StatsView theme updates", function () {
 
     var totalEventsCard = findExactText(container, "Total Events").parentElement;
     expect(totalEventsCard.style.background).toBe(lightSurface);
+    expect(totalEventsCard.firstElementChild.style.color).toBe(lightTextPrimary);
+    var modelCard = findExactText(container, "Model").parentElement;
+    expect(modelCard.firstElementChild.style.color).toBe(lightTrackContext);
 
     themeMod.syncThemeState("dark", "dark");
     await act(async function () {
@@ -93,6 +104,70 @@ describe("StatsView theme updates", function () {
 
     totalEventsCard = findExactText(container, "Total Events").parentElement;
     expect(totalEventsCard.style.background).toBe(darkSurface);
+    expect(totalEventsCard.firstElementChild.style.color).toBe(darkTextPrimary);
+    modelCard = findExactText(container, "Model").parentElement;
+    expect(modelCard.firstElementChild.style.color).toBe(darkTrackContext);
+
+    await act(async function () {
+      root.unmount();
+    });
+  });
+
+  it("updates memoized derived cards when events and metadata change", async function () {
+    vi.resetModules();
+
+    var React = await import("react");
+    var ReactDOM = await import("react-dom/client");
+    var StatsViewMod = await import("../components/StatsView.jsx");
+
+    var act = React.act;
+    var createRoot = ReactDOM.createRoot;
+    var StatsView = StatsViewMod.default;
+    var container = document.createElement("div");
+    document.body.appendChild(container);
+    var root = createRoot(container);
+    var props = {
+      events: [
+        { agent: "assistant", track: "output", text: "Done", isError: false },
+      ],
+      totalTime: 12,
+      metadata: {
+        totalTurns: 1,
+        errorCount: 0,
+        primaryModel: "claude-haiku-4.5",
+        tokenUsage: { inputTokens: 10, outputTokens: 20, cacheRead: 0, cacheWrite: 0 },
+        models: { "claude-haiku-4.5": 1 },
+      },
+      turns: [
+        { index: 0, userMessage: "Summarize", toolCount: 0, hasError: false },
+      ],
+      autonomyMetrics: null,
+    };
+
+    await act(async function () {
+      root.render(<StatsView {...props} />);
+    });
+
+    expect(getCardValue(container, "Total Events")).toBe("1");
+    expect(getCardValue(container, "Tool Calls")).toBe("0");
+    expect(getCardValue(container, "Errors")).toBe("0");
+
+    await act(async function () {
+      root.render(
+        <StatsView
+          {...props}
+          events={[
+            props.events[0],
+            { agent: "assistant", track: "tool_call", text: "Run command", isError: true },
+          ]}
+          metadata={Object.assign({}, props.metadata, { errorCount: 1 })}
+        />,
+      );
+    });
+
+    expect(getCardValue(container, "Total Events")).toBe("2");
+    expect(getCardValue(container, "Tool Calls")).toBe("1");
+    expect(getCardValue(container, "Errors")).toBe("1");
 
     await act(async function () {
       root.unmount();

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -337,6 +337,7 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
   var [showAllTurns, setShowAllTurns] = useState(false);
   var TURNS_PREVIEW = 15;
   var cardStyle = getCardStyle();
+  var themeMode = theme.mode;
 
   // Memoize O(n) event iterations so they don't re-run on every parent re-render.
   var trackStats = useMemo(function () {
@@ -412,7 +413,7 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
       { label: "Errors", value: errorCount, color: errorCount > 0 ? theme.semantic.error : theme.text.muted },
       { label: "Duration", value: formatDurationLong(totalTime), color: theme.track.context },
     ];
-  }, [events.length, metadata, turns, totalTime, trackStats, userMsgs, errorCount]);
+  }, [events.length, metadata, turns, totalTime, trackStats, userMsgs, errorCount, themeMode]);
   var autonomySummary = useMemo(function () {
     return buildAutonomySummary(autonomyMetrics);
   }, [autonomyMetrics]);
@@ -486,7 +487,7 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
       ? Object.entries(metadata.models).sort(function (a, b) { return b[1] - a[1]; })
       : null;
     return { usageCards: usageCards, allModelsEntries: allModelsEntries };
-  }, [metadata, modelTokenMap]);
+  }, [metadata, modelTokenMap, themeMode]);
 
   return (
     <ResizablePanel initialSplit={0.72} minPx={200} direction="horizontal">

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -338,62 +338,84 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
   var TURNS_PREVIEW = 15;
   var cardStyle = getCardStyle();
 
-  var trackStats = {};
-  events.forEach(function (e) {
-    if (!trackStats[e.track]) trackStats[e.track] = { count: 0 };
-    trackStats[e.track].count++;
-  });
+  // Memoize O(n) event iterations so they don't re-run on every parent re-render.
+  var trackStats = useMemo(function () {
+    var stats = {};
+    events.forEach(function (e) {
+      if (!stats[e.track]) stats[e.track] = { count: 0 };
+      stats[e.track].count++;
+    });
+    return stats;
+  }, [events]);
 
-  // Compute subagent stats
-  var agentStats = {};
-  events.forEach(function (e) {
-    if (e.agentName) {
-      if (!agentStats[e.agentName]) {
-        agentStats[e.agentName] = { count: 0, totalDuration: 0, displayName: e.agentDisplayName || e.agentName, errors: 0 };
+  var agentData = useMemo(function () {
+    var stats = {};
+    events.forEach(function (e) {
+      if (e.agentName) {
+        if (!stats[e.agentName]) {
+          stats[e.agentName] = { count: 0, totalDuration: 0, displayName: e.agentDisplayName || e.agentName, errors: 0 };
+        }
+        stats[e.agentName].count++;
+        if (e.track === "agent" && e.duration > 0) stats[e.agentName].totalDuration += e.duration;
+        if (e.isError) stats[e.agentName].errors++;
       }
-      agentStats[e.agentName].count++;
-      if (e.track === "agent" && e.duration > 0) agentStats[e.agentName].totalDuration += e.duration;
-      if (e.isError) agentStats[e.agentName].errors++;
-    }
-  });
-  var agentEntries = Object.entries(agentStats).sort(function (a, b) { return b[1].count - a[1].count; });
-  var totalAgentEvents = agentEntries.reduce(function (sum, e) { return sum + e[1].count; }, 0);
+    });
+    var entries = Object.entries(stats).sort(function (a, b) { return b[1].count - a[1].count; });
+    var total = entries.reduce(function (sum, e) { return sum + e[1].count; }, 0);
+    return { agentStats: stats, agentEntries: entries, totalAgentEvents: total };
+  }, [events]);
+  var agentStats = agentData.agentStats;
+  var agentEntries = agentData.agentEntries;
+  var totalAgentEvents = agentData.totalAgentEvents;
 
-  var userMsgs = events.filter(function (e) { return e.agent === "user"; }).length;
-  var errorCount = metadata ? metadata.errorCount : events.filter(function (e) { return e.isError; }).length;
+  var eventCounts = useMemo(function () {
+    var userMsgs = events.filter(function (e) { return e.agent === "user"; }).length;
+    var errorCount = metadata ? metadata.errorCount : events.filter(function (e) { return e.isError; }).length;
+    return { userMsgs: userMsgs, errorCount: errorCount };
+  }, [events, metadata]);
+  var userMsgs = eventCounts.userMsgs;
+  var errorCount = eventCounts.errorCount;
 
-  // Aggregate token usage per turn
-  var turnTokenMap = {};
-  var modelTokenMap = {};
-  events.forEach(function (e) {
-    if (e.tokenUsage) {
-      if (e.turnIndex !== undefined) {
-        var t = summarizeTokenUsage([turnTokenMap[e.turnIndex], e.tokenUsage]);
-        turnTokenMap[e.turnIndex] = t;
+  var tokenMaps = useMemo(function () {
+    var turnMap = {};
+    var modelMap = {};
+    events.forEach(function (e) {
+      if (e.tokenUsage) {
+        if (e.turnIndex !== undefined) {
+          var t = summarizeTokenUsage([turnMap[e.turnIndex], e.tokenUsage]);
+          turnMap[e.turnIndex] = t;
+        }
+        var modelKey = e.model || (metadata && metadata.primaryModel) || "__unknown__";
+        var m = modelMap[modelKey] || { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0 };
+        m.inputTokens += e.tokenUsage.inputTokens || 0;
+        m.outputTokens += e.tokenUsage.outputTokens || 0;
+        m.cacheRead += e.tokenUsage.cacheRead || 0;
+        m.cacheWrite += e.tokenUsage.cacheWrite || 0;
+        modelMap[modelKey] = m;
       }
-      // Bucket by model; fall back to primaryModel for events without a model field
-      var modelKey = e.model || (metadata && metadata.primaryModel) || "__unknown__";
-      var m = modelTokenMap[modelKey] || { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0 };
-      m.inputTokens += e.tokenUsage.inputTokens || 0;
-      m.outputTokens += e.tokenUsage.outputTokens || 0;
-      m.cacheRead += e.tokenUsage.cacheRead || 0;
-      m.cacheWrite += e.tokenUsage.cacheWrite || 0;
-      modelTokenMap[modelKey] = m;
-    }
-  });
-  var sessionCacheSummary = metadata && metadata.tokenUsage
-    ? formatCacheUsageSummary(metadata.tokenUsage, { variant: "compact" })
-    : null;
+    });
+    var cacheSummary = metadata && metadata.tokenUsage
+      ? formatCacheUsageSummary(metadata.tokenUsage, { variant: "compact" })
+      : null;
+    return { turnTokenMap: turnMap, modelTokenMap: modelMap, sessionCacheSummary: cacheSummary };
+  }, [events, metadata]);
+  var turnTokenMap = tokenMaps.turnTokenMap;
+  var modelTokenMap = tokenMaps.modelTokenMap;
+  var sessionCacheSummary = tokenMaps.sessionCacheSummary;
 
-  var cards = [
-    { label: "Total Events", value: events.length, color: theme.text.primary },
-    { label: "Turns", value: metadata ? metadata.totalTurns : (turns ? turns.length : 0), color: theme.accent.primary },
-    { label: "User Messages", value: userMsgs, color: theme.accent.primary },
-    { label: "Tool Calls", value: (trackStats.tool_call || {}).count || 0, color: theme.track.tool_call },
-    { label: "Errors", value: errorCount, color: errorCount > 0 ? theme.semantic.error : theme.text.muted },
-    { label: "Duration", value: formatDurationLong(totalTime), color: theme.track.context },
-  ];
-  var autonomySummary = buildAutonomySummary(autonomyMetrics);
+  var cards = useMemo(function () {
+    return [
+      { label: "Total Events", value: events.length, color: theme.text.primary },
+      { label: "Turns", value: metadata ? metadata.totalTurns : (turns ? turns.length : 0), color: theme.accent.primary },
+      { label: "User Messages", value: userMsgs, color: theme.accent.primary },
+      { label: "Tool Calls", value: (trackStats.tool_call || {}).count || 0, color: theme.track.tool_call },
+      { label: "Errors", value: errorCount, color: errorCount > 0 ? theme.semantic.error : theme.text.muted },
+      { label: "Duration", value: formatDurationLong(totalTime), color: theme.track.context },
+    ];
+  }, [events.length, metadata, turns, totalTime, trackStats, userMsgs, errorCount]);
+  var autonomySummary = useMemo(function () {
+    return buildAutonomySummary(autonomyMetrics);
+  }, [autonomyMetrics]);
 
   function getAutonomyItemColor(label) {
     if (!autonomyMetrics) return theme.accent.primary;
@@ -423,9 +445,8 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
     return theme.accent.primary;
   }
 
-  // Pre-compute model usage data for the Model & Usage section
-  var modelUsageData = null;
-  if (metadata && metadata.primaryModel) {
+  var modelUsageData = useMemo(function () {
+    if (!metadata || !metadata.primaryModel) return null;
     var hasTokens = metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0;
     var hasApiCost = metadata.totalCost != null;
     var perModelData = metadata.modelTokenUsage || (Object.keys(modelTokenMap).length > 0 ? modelTokenMap : null);
@@ -464,8 +485,8 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
     var allModelsEntries = Object.keys(metadata.models).length > 1
       ? Object.entries(metadata.models).sort(function (a, b) { return b[1] - a[1]; })
       : null;
-    modelUsageData = { usageCards: usageCards, allModelsEntries: allModelsEntries };
-  }
+    return { usageCards: usageCards, allModelsEntries: allModelsEntries };
+  }, [metadata, modelTokenMap]);
 
   return (
     <ResizablePanel initialSplit={0.72} minPx={200} direction="horizontal">

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -62,6 +62,13 @@ export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPl
     return turns[turns.length - 1];
   }, [currentTime, turns]);
 
+  // Memoize bin calculation -- depends only on event data, not currentTime,
+  // so it avoids re-running O(events) work on every 100ms playback tick.
+  var bins = useMemo(function () {
+    if (eventEntries.length <= TIMELINE_BINS) return null;
+    return buildTimelineBins(eventEntries, totalTime, timeMap, matchSet);
+  }, [eventEntries, totalTime, timeMap, matchSet]);
+
   return (
     <div style={{ paddingBottom: theme.space.md }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 6 }}>
@@ -134,8 +141,7 @@ export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPl
             }} />
           );
         })}
-        {eventEntries.length > TIMELINE_BINS ? (function () {
-          var bins = buildTimelineBins(eventEntries, totalTime, timeMap, matchSet);
+        {bins ? (function () {
           var result = [];
           for (var j = 0; j < TIMELINE_BINS; j++) {
             if (bins[j].count === 0) continue;

--- a/src/components/Timeline.jsx
+++ b/src/components/Timeline.jsx
@@ -4,6 +4,13 @@ import Icon from "./Icon.jsx";
 
 var TIMELINE_BINS = 200;
 
+function getTimelineEventColor(ev) {
+  var info = TRACK_TYPES[ev.track];
+  if (ev.isError) return theme.semantic.error;
+  if (ev.track === "agent" && ev.agentName) return theme.agentType[ev.agentName] || theme.agentType.default;
+  return info ? info.color : theme.text.muted;
+}
+
 export function buildTimelineBins(eventEntries, totalTime, timeMap, matchSet) {
   var bins = [];
   for (var b = 0; b < TIMELINE_BINS; b++) {
@@ -16,14 +23,14 @@ export function buildTimelineBins(eventEntries, totalTime, timeMap, matchSet) {
     var endPos = timeMap ? timeMap.toPosition(ev.t + ev.duration) : (totalTime > 0 ? (ev.t + ev.duration) / totalTime : startPos);
     var startBin = Math.min(TIMELINE_BINS - 1, Math.max(0, Math.floor(startPos * TIMELINE_BINS)));
     var endBin = Math.min(TIMELINE_BINS - 1, Math.max(startBin, Math.floor(endPos * TIMELINE_BINS)));
-    var info = TRACK_TYPES[ev.track];
+    var color = getTimelineEventColor(ev);
 
     for (var bin = startBin; bin <= endBin; bin++) {
       bins[bin].count++;
       bins[bin].intensity = Math.max(bins[bin].intensity, ev.intensity || 0.3);
       if (ev.isError) bins[bin].isError = true;
       if (matchSet && matchSet.has(eventEntries[i].index)) bins[bin].isMatch = true;
-      if (!bins[bin].color && info) bins[bin].color = info.color;
+      if (!bins[bin].color) bins[bin].color = color;
     }
   }
 
@@ -62,12 +69,14 @@ export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPl
     return turns[turns.length - 1];
   }, [currentTime, turns]);
 
+  var themeMode = theme.mode;
+
   // Memoize bin calculation -- depends only on event data, not currentTime,
-  // so it avoids re-running O(events) work on every 100ms playback tick.
+  // so it avoids re-running O(events) work on each playback tick.
   var bins = useMemo(function () {
     if (eventEntries.length <= TIMELINE_BINS) return null;
     return buildTimelineBins(eventEntries, totalTime, timeMap, matchSet);
-  }, [eventEntries, totalTime, timeMap, matchSet]);
+  }, [eventEntries, totalTime, timeMap, matchSet, themeMode]);
 
   return (
     <div style={{ paddingBottom: theme.space.md }}>
@@ -168,10 +177,7 @@ export default function Timeline({ currentTime, totalTime, timeMap, onSeek, isPl
           var ev = entry.event;
           var left = timeMap ? timeMap.toPosition(ev.t) * 100 : (totalTime > 0 ? (ev.t / totalTime) * 100 : 0);
           var width = Math.max(0.3, timeMap ? (timeMap.toPosition(ev.t + ev.duration) - timeMap.toPosition(ev.t)) * 100 : (totalTime > 0 ? (ev.duration / totalTime) * 100 : 1));
-          var info = TRACK_TYPES[ev.track];
-          var color = ev.isError ? theme.semantic.error
-            : (ev.track === "agent" && ev.agentName) ? (theme.agentType[ev.agentName] || theme.agentType.default)
-            : (info ? info.color : theme.text.muted);
+          var color = getTimelineEventColor(ev);
           var isMatch = matchSet && matchSet.has(entry.index);
           return (
             <div key={entry.index} style={{


### PR DESCRIPTION
## Problem

During playback, the app ticks at ~10fps (100ms intervals). Two components perform expensive O(n) computations on every re-render that don't depend on `currentTime`:

### Timeline (`buildTimelineBins`)
- Called as an **inline IIFE** inside JSX -- runs O(events) on every render
- The bins only depend on `eventEntries`, `totalTime`, `timeMap`, and `matchSet` (none change during playback)
- For sessions with thousands of events, this was ~10 wasted O(n) iterations/sec

### StatsView (6+ unmemoized iterations)
- `trackStats`, `agentStats`, `eventCounts`, `turnTokenMap`, `modelTokenMap`, `modelUsageData`, `autonomySummary` -- all iterate over the full events array on every render
- Parent (`AppSessionView`) subscribes to `PlaybackTimeCtx` via `usePlaybackContext()`, so StatsView re-renders every 100ms during playback even though its props are referentially stable

## Fix

- **Timeline**: Extract `buildTimelineBins()` into a `useMemo` with deps `[eventEntries, totalTime, timeMap, matchSet]`
- **StatsView**: Wrap all O(n) event iterations and derived computations in `useMemo` with appropriate dependency arrays

## Other opportunities identified (not in this PR)

1. **Main view components missing `React.memo()`** -- ReplayView, StatsView, TracksView, etc. still re-render on every playback tick even when props haven't changed. Adding `React.memo()` + stabilizing callback props would prevent JSX reconciliation entirely.
2. **`usePlaybackContext()` subscribes to all three contexts** -- `AppSessionView` uses the combined hook, causing it to re-render on every time tick. Switching to granular hooks (`usePlaybackTime`, `useFilterContext`) where possible would reduce the re-render blast radius.

## Verification

- All 776 tests pass
- Production build succeeds