### PR TITLE
Release AGENTVIZ 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "0.7.0",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentviz",
-  "version": "0.7.0",
+  "version": "1.0.0",
   "description": "Session replay visualizer for AI agent workflows (Claude Code, VS Code, Copilot CLI)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump AGENTVIZ from 0.7.0 to 1.0.0 after the v2 default workflow merge
- Updates package.json and package-lock.json only

## Validation
- npm run typecheck
- npm test
- npm run test:e2e:v2
- npm run build
- npm pack --dry-run

## Notes
- Publish and tag should happen after this release PR merges into main.