### PR TITLE
Improve v2 Find recent activity sorting

### DIFF
--- a/src/__tests__/landingSessions.test.js
+++ b/src/__tests__/landingSessions.test.js
@@ -121,6 +121,17 @@ describe("sortLandingEntries", function () {
     expect(sortLandingEntries(importedOnlyEntries, "needs-review").map(function (entry) { return entry.id; })).toEqual(["b", "c", "a"]);
   });
 
+  it("falls back to mtime for discovered entries", function () {
+    var discoveredEntries = [
+      { id: "a", mtime: "2026-04-03T00:00:00.000Z" },
+      { id: "b", mtime: "2026-04-05T00:00:00.000Z" },
+      { id: "c", mtime: "2026-04-04T00:00:00.000Z" },
+    ];
+
+    expect(getLandingEntryTimestamp(discoveredEntries[0])).toBe("2026-04-03T00:00:00.000Z");
+    expect(sortLandingEntries(discoveredEntries, "most-recent").map(function (entry) { return entry.id; })).toEqual(["b", "c", "a"]);
+  });
+
   it("sorts by date helper", function () {
     expect(sortLandingEntriesByDate(entries).map(function (entry) { return entry.id; })).toEqual(["b", "c", "a"]);
   });

--- a/src/__tests__/v2Shell.test.jsx
+++ b/src/__tests__/v2Shell.test.jsx
@@ -574,6 +574,17 @@ describe("V2 shell routing", function () {
     expect(tagFiltered.map(function (entry) { return entry.id; })).toEqual(["stored-a", "discovered-c"]);
   });
 
+  it("sorts Find portfolio entries by global recent activity across sources", function () {
+    var entries = makePortfolioEntries();
+    var sorted = getFilteredPortfolioEntries(entries, "", "all", "most-recent");
+
+    expect(sorted.map(function (entry) { return entry.id; })).toEqual([
+      "discovered-c",
+      "stored-a",
+      "stored-b",
+    ]);
+  });
+
   it("renders FindPortfolio with layout toggle and multi-select compare", async function () {
     var onOpenSession = vi.fn();
     var onCompareSelected = vi.fn();

--- a/src/components/v2/FindPortfolio.jsx
+++ b/src/components/v2/FindPortfolio.jsx
@@ -13,6 +13,7 @@ import {
   getInitialTagsFromURL,
   getLandingEntryDisplayTitle,
   getLandingEntrySecondaryText,
+  getLandingEntryTimestamp,
   settleLandingRefresh,
   sortDiscoveredLandingEntries,
   sortLandingEntries,
@@ -74,9 +75,21 @@ export function getFilteredPortfolioEntries(entries, query, formatFilter, sortMo
   }
   filtered = filterByTags(filtered, activeTags);
 
+  if (sortMode === "most-recent") {
+    return sortLandingEntries(filtered, sortMode);
+  }
+
   var analyzed = filtered.filter(function (entry) { return !entry.isDiscovered; });
   var discovered = filtered.filter(function (entry) { return entry.isDiscovered; });
   return sortLandingEntries(analyzed, sortMode).concat(sortDiscoveredLandingEntries(discovered));
+}
+
+function buildActivityMeta(entry, timestamp) {
+  var parts = [formatLandingClientLabel(entry)];
+  if (entry.project) parts.push(entry.project);
+  if (entry.branch) parts.push(entry.branch);
+  if (timestamp) parts.push(formatRelativeTime(timestamp));
+  return parts.join(" · ");
 }
 
 function Stat({ label, value, sub }) {
@@ -126,6 +139,7 @@ function PortfolioCard({ entry, layout, selected, onToggleSelected, onOpen }) {
   var isDiscovered = Boolean(entry.isDiscovered);
   var sourcePath = entry.discoveredPath || null;
   var timestamp = getEntryTimestamp(entry);
+  var activityMeta = buildActivityMeta(entry, timestamp);
   var autonomy = entry.autonomyMetrics || {};
   var canOpen = canOpenEntry(entry);
   var metrics = [
@@ -199,14 +213,14 @@ function PortfolioCard({ entry, layout, selected, onToggleSelected, onOpen }) {
             }}>
               {title}
             </span>
-            <span style={{ color: theme.text.ghost, fontSize: theme.fontSize.xs, flexShrink: 0 }}>
-              {timestamp ? formatRelativeTime(timestamp) : "unknown"}
-            </span>
+            {timestamp && (
+              <span style={{ color: theme.text.ghost, fontSize: theme.fontSize.xs, flexShrink: 0 }}>
+                {getLandingEntryTimestamp(entry).slice(0, 10)}
+              </span>
+            )}
           </span>
           <span style={{ color: theme.text.muted, fontSize: theme.fontSize.sm, lineHeight: 1.5 }}>
-            {formatLandingClientLabel(entry)}
-            {entry.project ? " · " + entry.project : ""}
-            {entry.branch ? " · #" + entry.branch : ""}
+            {activityMeta}
           </span>
           {secondary && (
             <span style={{
@@ -271,7 +285,7 @@ export default function FindPortfolio({
   var [refreshing, setRefreshing] = useState(false);
   var [dragActive, setDragActive] = useState(false);
   var [layout, setLayout] = usePersistentState("agentviz:v2:portfolio-layout", "grid");
-  var [sortMode, setSortMode] = usePersistentState("agentviz:v2:portfolio-sort", "needs-review");
+  var [sortMode, setSortMode] = usePersistentState("agentviz:v2:portfolio-sort", "most-recent");
   var [formatFilter, setFormatFilter] = usePersistentState("agentviz:v2:portfolio-format", "all");
   var [activeTags, setActiveTags] = useState(getInitialTagsFromURL);
   var [selectedIds, setSelectedIds] = useState([]);

--- a/src/lib/landingSessions.js
+++ b/src/lib/landingSessions.js
@@ -139,7 +139,7 @@ export function getInitialTagsFromURL() {
 }
 
 export function getLandingEntryTimestamp(entry) {
-  return String(entry && (entry.updatedAt || entry.importedAt) || "");
+  return String(entry && (entry.updatedAt || entry.importedAt || entry.mtime) || "");
 }
 
 export function isLowSignalDiscoveredEntry(entry) {


### PR DESCRIPTION
## Summary
- Make v2 Find default to Most recent so it behaves more like a recent activity feed
- Sort Most recent globally across stored/analyzed and discovered sessions instead of appending discovered sessions after analyzed sessions
- Use discovered file mtime as a timestamp fallback and show clearer activity metadata on cards

## Validation
- `npm test -- --run src/__tests__/v2Shell.test.jsx src/__tests__/landingSessions.test.js`