### PR TITLE
perf: cache getConfiguredModel() to reduce redundant disk I/O

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,14 +22,29 @@ function getConfigPath() {
   return path.join(os.homedir(), ".agentviz", "config.json");
 }
 
+var _modelCache = null;
+var _modelCacheTime = 0;
+var MODEL_CACHE_TTL = 30000; // 30 seconds
+
 export function getConfiguredModel() {
   var envModel = process.env.AGENTVIZ_MODEL;
   if (envModel) return envModel;
+
+  var now = Date.now();
+  if (_modelCache !== null && now - _modelCacheTime < MODEL_CACHE_TTL) {
+    return _modelCache.value;
+  }
+
   try {
     var raw = fs.readFileSync(getConfigPath(), "utf8");
     var cfg = JSON.parse(raw);
-    return cfg.model || null;
+    var model = cfg.model || null;
+    _modelCache = { value: model };
+    _modelCacheTime = now;
+    return model;
   } catch (_) {
+    _modelCache = { value: null };
+    _modelCacheTime = now;
     return null;
   }
 }


### PR DESCRIPTION
## Problem

`getConfiguredModel()` in `server.js` reads the config file from disk synchronously on every call. It's called 3+ times per AI API request (in `routes/ai.js` at lines 61, 105, and 139), causing redundant synchronous disk I/O on every request.

## Solution

Add a simple in-memory cache with a 30-second TTL to `getConfiguredModel()`.

### Design choices

- **Wrapper object `{ value: model }`** — distinguishes "not yet cached" (`_modelCache === null`) from "cached a null result", so null model values are properly cached
- **Cache on error too** — failed reads (missing config file) are also cached to avoid retrying disk I/O every call
- **30s TTL** — config changes are picked up within 30 seconds, which is a reasonable tradeoff for a setting that rarely changes
- **Env var bypass** — `AGENTVIZ_MODEL` env var still takes immediate effect since it's already in-memory

## Testing

All 872 existing tests pass.