### PR TITLE
Add headless HTML export

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ npx agentviz ~/.claude/projects/my-project/
 
 The browser opens with a pulsing **LIVE** badge. As Claude Code writes new events to the session file, they stream into the view in real time via SSE, including records that are written incrementally before the trailing newline lands.
 
+### CLI (self-contained manifest export)
+
+Generate a single HTML file from a static manifest and its local session files:
+
+```bash
+npx agentviz export --manifest ./data/manifest.json --out ./agentviz-report.html
+```
+
+The output embeds the AGENTVIZ app, the manifest, and all referenced JSONL sessions. It can be opened directly from disk without running a local web server. Manifest session URLs must be local paths relative to the manifest file; remote URLs are rejected because they cannot be embedded.
+
 ### Finding your session files
 
 ```bash
@@ -407,6 +417,12 @@ The manifest lists sessions with display names, relative URLs, and freeform tags
 
 Session URLs are resolved relative to the manifest location. Tags appear as filter chips in the inbox (AND logic). Pre-apply filters with `&tag=X` query params.
 
+To package a static manifest deployment as one shareable file instead of hosting the manifest and JSONL files, run:
+
+```bash
+npx agentviz export --manifest ./data/manifest.json --out ./agentviz-report.html
+```
+
 ## Architecture
 
 ```
@@ -465,6 +481,7 @@ src/
     pricing.js           # Claude and OpenAI/Copilot model pricing table and cost estimation
     pricing.d.ts         # TypeScript declarations for pricing.js
     exportHtml.js        # Self-contained HTML export for single sessions and comparisons
+    headlessExport.js    # CLI/headless self-contained HTML export for static manifests
     formatTime.d.ts      # TypeScript declarations for formatTime.js
     formatTime.js        # Duration and date formatting utilities
     landingSessions.js   # Shared landing browser labels, filters, and format options

--- a/bin/agentviz.js
+++ b/bin/agentviz.js
@@ -101,14 +101,15 @@ async function handleExport(args) {
   if (!manifestPath) throw new Error("Missing required option: --manifest <path>");
   if (!outPath) throw new Error("Missing required option: --out <path>");
 
-  if (!fs.existsSync(path.join(distDir, "index.html"))) {
+  var exportDistDir = process.env.AGENTVIZ_EXPORT_DIST_DIR || distDir;
+  if (!fs.existsSync(path.join(exportDistDir, "index.html"))) {
     throw new Error("dist/ not found. Run `npm run build` inside the agentviz package first.");
   }
 
   await writeSelfContainedManifestHtml({
     manifestPath: path.resolve(manifestPath),
     outPath: path.resolve(outPath),
-    distDir: distDir,
+    distDir: exportDistDir,
   });
 
   process.stdout.write("Wrote self-contained AGENTVIZ report to " + path.resolve(outPath) + "\n");

--- a/bin/agentviz.js
+++ b/bin/agentviz.js
@@ -13,6 +13,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { execFile, spawn } from "child_process";
 import net from "net";
+import { writeSelfContainedManifestHtml } from "../src/lib/headlessExport.js";
 
 var __dirname = path.dirname(fileURLToPath(import.meta.url));
 var rootDir = path.resolve(__dirname, "..");
@@ -57,6 +58,63 @@ function findLatestSessionFile(dir) {
 var sessionFile = null;
 var noOpen = false;
 var argv = process.argv.slice(2);
+
+if (argv[0] === "export") {
+  await handleExport(argv.slice(1)).catch(function (err) {
+    process.stderr.write("Error: " + (err && err.message ? err.message : String(err)) + "\n");
+    process.exit(1);
+  });
+}
+
+function readOption(args, name) {
+  var index = args.indexOf(name);
+  if (index === -1) return null;
+  var value = args[index + 1];
+  if (!value || value.startsWith("-")) {
+    throw new Error(name + " requires a value");
+  }
+  return value;
+}
+
+function hasFlag(args, name) {
+  return args.indexOf(name) !== -1;
+}
+
+async function handleExport(args) {
+  if (hasFlag(args, "-h") || hasFlag(args, "--help")) {
+    process.stdout.write([
+      "Usage: agentviz export --manifest <path> --out <path>",
+      "",
+      "Generate a self-contained HTML report from an agentviz static manifest.",
+      "",
+      "Options:",
+      "  --manifest <path>  Path to manifest.json with relative session URLs",
+      "  --out <path>       Output HTML file",
+      "  -h, --help         Show this help",
+      "",
+    ].join("\n"));
+    process.exit(0);
+  }
+
+  var manifestPath = readOption(args, "--manifest");
+  var outPath = readOption(args, "--out") || readOption(args, "--output");
+  if (!manifestPath) throw new Error("Missing required option: --manifest <path>");
+  if (!outPath) throw new Error("Missing required option: --out <path>");
+
+  if (!fs.existsSync(path.join(distDir, "index.html"))) {
+    throw new Error("dist/ not found. Run `npm run build` inside the agentviz package first.");
+  }
+
+  await writeSelfContainedManifestHtml({
+    manifestPath: path.resolve(manifestPath),
+    outPath: path.resolve(outPath),
+    distDir: distDir,
+  });
+
+  process.stdout.write("Wrote self-contained AGENTVIZ report to " + path.resolve(outPath) + "\n");
+  process.exit(0);
+}
+
 for (var i = 0; i < argv.length; i++) {
   var arg = argv[i];
   if (arg === "--no-open") { noOpen = true; continue; }

--- a/src/__tests__/headlessExport.test.js
+++ b/src/__tests__/headlessExport.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from "vitest";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { execFile } from "child_process";
+import { fileURLToPath } from "url";
+import {
+  buildSelfContainedManifestHtml,
+  writeSelfContainedManifestHtml,
+} from "../lib/headlessExport.js";
+
+var tempRoots = [];
+var repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+afterEach(async function () {
+  await Promise.all(tempRoots.map(function (root) {
+    return fs.rm(root, { recursive: true, force: true });
+  }));
+  tempRoots = [];
+});
+
+async function makeTempRoot() {
+  var root = await fs.mkdtemp(path.join(os.tmpdir(), "agentviz-headless-export-"));
+  tempRoots.push(root);
+  return root;
+}
+
+async function createFixture() {
+  var root = await makeTempRoot();
+  var distDir = path.join(root, "dist");
+  var assetsDir = path.join(distDir, "assets");
+  var dataDir = path.join(root, "data");
+  await fs.mkdir(assetsDir, { recursive: true });
+  await fs.mkdir(path.join(dataDir, "sessions"), { recursive: true });
+
+  await fs.writeFile(path.join(distDir, "index.html"), [
+    "<!doctype html>",
+    "<html>",
+    "<head>",
+    "  <title>AGENTVIZ</title>",
+    "  <script type=\"module\" crossorigin src=\"./assets/index-main.js\"></script>",
+    "</head>",
+    "<body><div id=\"root\"></div></body>",
+    "</html>",
+  ].join("\n"));
+  await fs.writeFile(
+    path.join(assetsDir, "index-main.js"),
+    "console.log('main'); import(\"./GraphView.js\"); fetch('data/manifest.json');\n"
+  );
+  await fs.writeFile(
+    path.join(assetsDir, "GraphView.js"),
+    "import { x } from \"./index-main.js\"; console.log('graph', x, new URL(\"\"+new URL(\"elk-worker.js\",import.meta.url).href,import.meta.url));\n"
+  );
+  await fs.writeFile(path.join(assetsDir, "elk-worker.js"), "self.onmessage = function() {};\n");
+  await fs.writeFile(
+    path.join(dataDir, "manifest.json"),
+    JSON.stringify({
+      generated: "2026-04-28T00:00:00Z",
+      sessions: [
+        {
+          id: "one",
+          name: "Session One",
+          url: "sessions/one.jsonl",
+          tags: ["test"],
+          mtime: 1,
+        },
+      ],
+    })
+  );
+  await fs.writeFile(
+    path.join(dataDir, "sessions", "one.jsonl"),
+    "{\"type\":\"session.start\",\"producer\":\"copilot-agent\"}\n"
+  );
+
+  return {
+    root: root,
+    distDir: distDir,
+    manifestPath: path.join(dataDir, "manifest.json"),
+  };
+}
+
+describe("headless HTML export", function () {
+  it("builds a self-contained manifest report", async function () {
+    var fixture = await createFixture();
+    var html = await buildSelfContainedManifestHtml({
+      manifestPath: fixture.manifestPath,
+      distDir: fixture.distDir,
+    });
+
+    expect(html).toContain("Session One");
+    expect(html).toContain("session.start");
+    expect(html).toContain("window.fetch = function");
+    expect(html).toContain("window.__AGENTVIZ_ASSET_URLS__");
+    expect(html).toContain("import(window.__AGENTVIZ_ASSET_URLS__");
+    expect(html).toContain("URL.createObjectURL");
+    expect(html).not.toContain("src=\"./assets/index-main.js\"");
+  });
+
+  it("writes a self-contained report file", async function () {
+    var fixture = await createFixture();
+    var outPath = path.join(fixture.root, "report.html");
+
+    await writeSelfContainedManifestHtml({
+      manifestPath: fixture.manifestPath,
+      distDir: fixture.distDir,
+      outPath: outPath,
+    });
+
+    var html = await fs.readFile(outPath, "utf8");
+    expect(html).toContain("Session One");
+  });
+
+  it("rejects remote session URLs", async function () {
+    var fixture = await createFixture();
+    await fs.writeFile(
+      fixture.manifestPath,
+      JSON.stringify({ sessions: [{ url: "https://example.com/session.jsonl" }] })
+    );
+
+    await expect(buildSelfContainedManifestHtml({
+      manifestPath: fixture.manifestPath,
+      distDir: fixture.distDir,
+    })).rejects.toThrow("Cannot embed remote session URL");
+  });
+
+  it("supports the agentviz export CLI", async function () {
+    var fixture = await createFixture();
+    var outPath = path.join(fixture.root, "cli-report.html");
+    await new Promise(function (resolve, reject) {
+      execFile(
+        process.execPath,
+        [
+          path.join(repoRoot, "bin", "agentviz.js"),
+          "export",
+          "--manifest",
+          fixture.manifestPath,
+          "--out",
+          outPath,
+        ],
+        { cwd: repoRoot },
+        function (error, stdout, stderr) {
+          if (error) {
+            error.message += "\nstdout:\n" + stdout + "\nstderr:\n" + stderr;
+            reject(error);
+            return;
+          }
+          resolve();
+        }
+      );
+    });
+
+    var html = await fs.readFile(outPath, "utf8");
+    expect(html).toContain("Session One");
+  });
+});

--- a/src/__tests__/headlessExport.test.js
+++ b/src/__tests__/headlessExport.test.js
@@ -96,6 +96,22 @@ describe("headless HTML export", function () {
     expect(html).not.toContain("src=\"./assets/index-main.js\"");
   });
 
+  it("embeds payloads with replacement-string tokens literally", async function () {
+    var fixture = await createFixture();
+    await fs.writeFile(
+      path.join(fixture.root, "data", "sessions", "one.jsonl"),
+      "{\"type\":\"message\",\"content\":\"Regex anchors: ^/$` and match token $&\"}\n"
+    );
+
+    var html = await buildSelfContainedManifestHtml({
+      manifestPath: fixture.manifestPath,
+      distDir: fixture.distDir,
+    });
+
+    expect(html.match(/<!doctype html>/g)).toHaveLength(1);
+    expect(html).toContain("^/$` and match token $\\u0026");
+  });
+
   it("writes a self-contained report file", async function () {
     var fixture = await createFixture();
     var outPath = path.join(fixture.root, "report.html");

--- a/src/__tests__/headlessExport.test.js
+++ b/src/__tests__/headlessExport.test.js
@@ -153,7 +153,12 @@ describe("headless HTML export", function () {
           "--out",
           outPath,
         ],
-        { cwd: repoRoot },
+        {
+          cwd: repoRoot,
+          env: Object.assign({}, process.env, {
+            AGENTVIZ_EXPORT_DIST_DIR: fixture.distDir,
+          }),
+        },
         function (error, stdout, stderr) {
           if (error) {
             error.message += "\nstdout:\n" + stdout + "\nstderr:\n" + stderr;

--- a/src/lib/headlessExport.js
+++ b/src/lib/headlessExport.js
@@ -1,0 +1,176 @@
+import fs from "fs/promises";
+import path from "path";
+
+function jsonSafe(value) {
+  return JSON.stringify(value)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026");
+}
+
+function scriptSafeText(value) {
+  return jsonSafe(value).replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
+}
+
+function toUrlPath(value) {
+  return value.replace(/\\/g, "/");
+}
+
+function resolveSessionPath(manifestPath, sessionUrl) {
+  if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(sessionUrl)) {
+    throw new Error("Cannot embed remote session URL: " + sessionUrl);
+  }
+  return path.resolve(path.dirname(manifestPath), sessionUrl);
+}
+
+async function readText(filePath) {
+  return fs.readFile(filePath, "utf8");
+}
+
+async function readManifestWithSessions(manifestPath) {
+  var resolvedManifestPath = path.resolve(manifestPath);
+  var manifest = JSON.parse(await readText(resolvedManifestPath));
+  if (!manifest || !Array.isArray(manifest.sessions)) {
+    throw new Error("Manifest must contain a sessions array: " + resolvedManifestPath);
+  }
+
+  var sessionTexts = {};
+  for (var i = 0; i < manifest.sessions.length; i++) {
+    var session = manifest.sessions[i];
+    if (!session || !session.url) continue;
+    var normalizedUrl = toUrlPath(session.url);
+    var sessionPath = resolveSessionPath(resolvedManifestPath, normalizedUrl);
+    sessionTexts["data/" + normalizedUrl] = await readText(sessionPath);
+  }
+
+  return { manifest: manifest, sessionTexts: sessionTexts };
+}
+
+function findMainScript(indexHtml) {
+  var match = indexHtml.match(/<script\b[^>]*type=["']module["'][^>]*src=["']([^"']+)["'][^>]*>\s*<\/script>/);
+  if (!match) {
+    throw new Error("Could not find production module script in dist/index.html");
+  }
+  return match[1];
+}
+
+async function readAssetSources(distDir, mainScriptSrc) {
+  var assetsDir = path.join(distDir, "assets");
+  var entries = await fs.readdir(assetsDir, { withFileTypes: true });
+  var sources = {};
+
+  for (var i = 0; i < entries.length; i++) {
+    var entry = entries[i];
+    if (!entry.isFile() || !entry.name.endsWith(".js")) continue;
+    sources[entry.name] = await readText(path.join(assetsDir, entry.name));
+  }
+
+  var mainName = path.basename(mainScriptSrc);
+  if (!sources[mainName]) {
+    throw new Error("Could not find main bundle asset: " + mainName);
+  }
+
+  return { mainName: mainName, sources: sources };
+}
+
+function buildSetupScript(manifest, sessionTexts) {
+  return "<script>\n" +
+    "(function() {\n" +
+    "  var manifest = " + jsonSafe(manifest) + ";\n" +
+    "  var sessions = " + jsonSafe(sessionTexts) + ";\n" +
+    "  var url = new URL(window.location.href);\n" +
+    "  if (!url.searchParams.has('manifest')) {\n" +
+    "    url.searchParams.set('manifest', 'data/manifest.json');\n" +
+    "    window.history.replaceState(null, '', url.href);\n" +
+    "  }\n" +
+    "  function keyFor(input) {\n" +
+    "    var raw = String(input && input.url ? input.url : input);\n" +
+    "    if (raw === 'data/manifest.json') return raw;\n" +
+    "    if (raw.indexOf('data/') === 0) return raw;\n" +
+    "    try {\n" +
+    "      var parsed = new URL(raw, window.location.href);\n" +
+    "      var pathname = decodeURIComponent(parsed.pathname).replace(/\\\\/g, '/');\n" +
+    "      var dataIndex = pathname.lastIndexOf('/data/');\n" +
+    "      if (dataIndex >= 0) return pathname.slice(dataIndex + 1);\n" +
+    "    } catch (e) {}\n" +
+    "    return raw;\n" +
+    "  }\n" +
+    "  var originalFetch = window.fetch ? window.fetch.bind(window) : null;\n" +
+    "  window.fetch = function(input, init) {\n" +
+    "    var key = keyFor(input);\n" +
+    "    if (key === 'data/manifest.json') {\n" +
+    "      return Promise.resolve(new Response(JSON.stringify(manifest), { status: 200, headers: { 'Content-Type': 'application/json' } }));\n" +
+    "    }\n" +
+    "    if (Object.prototype.hasOwnProperty.call(sessions, key)) {\n" +
+    "      return Promise.resolve(new Response(sessions[key], { status: 200, headers: { 'Content-Type': 'text/plain' } }));\n" +
+    "    }\n" +
+    "    if (!originalFetch) return Promise.reject(new Error('No fetch handler for ' + key));\n" +
+    "    return originalFetch(input, init);\n" +
+    "  };\n" +
+    "}());\n" +
+    "</" + "script>";
+}
+
+function buildBundleBootstrap(mainName, sources) {
+  return "<script>\n" +
+    "(function() {\n" +
+    "  var sources = " + scriptSafeText(sources) + ";\n" +
+    "  var mainName = " + jsonSafe(mainName) + ";\n" +
+    "  var urls = {};\n" +
+    "  var workerNames = Object.keys(sources).filter(function(name) { return /worker/i.test(name); });\n" +
+    "  workerNames.forEach(function(name) {\n" +
+    "    urls[name] = URL.createObjectURL(new Blob([sources[name]], { type: 'text/javascript' }));\n" +
+    "  });\n" +
+    "  var mainSource = sources[mainName]\n" +
+    "    .replace(/import\\(\\\"\\.\\/([^\\\"]+\\.js)\\\"\\)/g, 'import(window.__AGENTVIZ_ASSET_URLS__[\"$1\"])');\n" +
+    "  urls[mainName] = URL.createObjectURL(new Blob([mainSource], { type: 'text/javascript' }));\n" +
+    "  Object.keys(sources).forEach(function(name) {\n" +
+    "    if (name === mainName || urls[name]) return;\n" +
+    "    var source = sources[name]\n" +
+    "      .replace(/from\\\"\\.\\/([^\\\"]+\\.js)\\\"/g, function(_match, dep) {\n" +
+    "        if (dep === mainName) return 'from \"' + urls[mainName] + '\"';\n" +
+    "        return 'from \"' + (urls[dep] || dep) + '\"';\n" +
+    "      })\n" +
+    "      .replace(/new URL\\(\\\"\\\"\\+new URL\\(\\\"([^\\\"]*worker[^\\\"]*\\.js)\\\",import\\.meta\\.url\\)\\.href,import\\.meta\\.url\\)/g, function(_match, dep) {\n" +
+    "        return 'window.__AGENTVIZ_ASSET_URLS__[\"' + dep + '\"]';\n" +
+    "      });\n" +
+    "    urls[name] = URL.createObjectURL(new Blob([source], { type: 'text/javascript' }));\n" +
+    "  });\n" +
+    "  window.__AGENTVIZ_ASSET_URLS__ = urls;\n" +
+    "  import(urls[mainName]);\n" +
+    "}());\n" +
+    "</" + "script>";
+}
+
+function buildSelfContainedHtml(indexHtml, mainScriptSrc, setupScript, bootstrapScript) {
+  var withoutModuleScript = indexHtml.replace(
+    /<script\b[^>]*type=["']module["'][^>]*src=["'][^"']+["'][^>]*>\s*<\/script>/,
+    ""
+  );
+  var injection = setupScript + "\n" + bootstrapScript;
+  if (withoutModuleScript.includes("</body>")) {
+    return withoutModuleScript.replace("</body>", injection + "\n</body>");
+  }
+  return withoutModuleScript + "\n" + injection + "\n";
+}
+
+export async function buildSelfContainedManifestHtml(options) {
+  if (!options || !options.manifestPath) throw new Error("manifestPath is required");
+  if (!options.distDir) throw new Error("distDir is required");
+
+  var distDir = path.resolve(options.distDir);
+  var indexHtml = await readText(path.join(distDir, "index.html"));
+  var mainScriptSrc = findMainScript(indexHtml);
+  var bundle = await readAssetSources(distDir, mainScriptSrc);
+  var manifestData = await readManifestWithSessions(options.manifestPath);
+  var setupScript = buildSetupScript(manifestData.manifest, manifestData.sessionTexts);
+  var bootstrapScript = buildBundleBootstrap(bundle.mainName, bundle.sources);
+  return buildSelfContainedHtml(indexHtml, mainScriptSrc, setupScript, bootstrapScript);
+}
+
+export async function writeSelfContainedManifestHtml(options) {
+  if (!options || !options.outPath) throw new Error("outPath is required");
+  var html = await buildSelfContainedManifestHtml(options);
+  await fs.mkdir(path.dirname(path.resolve(options.outPath)), { recursive: true });
+  await fs.writeFile(options.outPath, html, "utf8");
+}

--- a/src/lib/headlessExport.js
+++ b/src/lib/headlessExport.js
@@ -149,7 +149,9 @@ function buildSelfContainedHtml(indexHtml, mainScriptSrc, setupScript, bootstrap
   );
   var injection = setupScript + "\n" + bootstrapScript;
   if (withoutModuleScript.includes("</body>")) {
-    return withoutModuleScript.replace("</body>", injection + "\n</body>");
+    return withoutModuleScript.replace("</body>", function () {
+      return injection + "\n</body>";
+    });
   }
   return withoutModuleScript + "\n" + injection + "\n";
 }


### PR DESCRIPTION
## Headless HTML export

Fixes #110

Adds a CLI/headless self-contained HTML export path so a static manifest deployment can be packaged into a single shareable file instead of hosting the manifest plus its JSONL session files:

```
npx agentviz export --manifest ./data/manifest.json --out ./agentviz-report.html
```

### Changes
- `src/lib/headlessExport.js` -- CLI/headless self-contained HTML export for static manifests
- `bin/agentviz.js` -- wires up the new `export` subcommand
- `src/__tests__/headlessExport.test.js` -- coverage for the export pipeline (incl. replacement/escaping edge cases)
- `README.md` -- documents the new command and architecture entry

### Why
This feature will be consumed by [microsoft/evaluate (vally)](https://github.com/microsoft/evaluate), which needs a way to produce single-file, self-contained AGENTVIZ reports from static session manifests without standing up a host.

### Validation
- `npm test` -- 886 tests pass
- `npm run build` -- succeeds
