### PR TITLE
Release v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to AGENTVIZ are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.1] - 2026-06-18
+
+### Fixed
+
+- **Diff viewer dropped a context line after every edit.** The Myers diff
+  backtracking guards offset the wrong axis when replaying a snake (the run of
+  matching lines that precedes an edit), so the single equal line immediately
+  following each insertion or deletion was silently omitted from rendered diffs.
+  Both sides of every hunk now reconstruct exactly. (#112)
+
+### Tests
+
+- Added regression coverage for context survival after deletions, insertions,
+  and mid-file edits, plus full both-side reconstruction across multiple edit
+  shapes.
+
+## [1.0.0] and earlier
+
+Earlier releases are recorded as git tags (`v0.1.1` through `v1.0.0`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentviz",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Session replay visualizer for AI agent workflows (Claude Code, VS Code, Copilot CLI)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
This is a patch release (v1.0.1) for the Myers diff context-line fix delivered in PR #112.

## What's in this release

- Bumps the package version from `1.0.0` to `1.0.1` in `package.json` and `package-lock.json`.
- Adds `CHANGELOG.md` documenting the 1.0.1 fix: the diff viewer was dropping the single context line immediately following every insertion or deletion, caused by the Myers diff backtracking guards offsetting the wrong axis when replaying a snake. Both sides of every hunk now reconstruct exactly.

## Verification

- `npm run build` succeeds.
- `npm test` passes (891 tests across 55 files).

## Release sequencing

> **Merge PR #112 BEFORE this release PR so that main contains the fix; then tag v1.0.1, build, and npm publish.**