### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to AGENTVIZ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-06-19
+
+### Fixed
+
+- Fixed parser regressions in VS Code Copilot Chat, Copilot CLI, Claude Code,
+  Codex, and ATIF sessions that could corrupt turn linkage, omit tool calls, or
+  under-report session duration.
+- Fixed replay turn headers when filtered tracks hide the original turn-start
+  event.
+- Fixed waterfall concurrency accounting for zero-duration and back-to-back tool
+  calls.
+- Fixed autonomy idle-gap detection for overlapping long-running events.
+
+### Tests
+
+- Added regression coverage for parser turn invariants, tool output mapping,
+  metadata duration, waterfall stats, replay headers, and autonomy metrics.
+
 ## [1.0.1] - 2026-06-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentviz",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Session replay visualizer for AI agent workflows (Claude Code, VS Code, Copilot CLI)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump AGENTVIZ package version to 1.0.2
- Add changelog notes for parser, replay, waterfall, and autonomy fixes merged in #114

## Validation
- npm run typecheck
- npm test, 906 tests
- npm run build
- npm pack --dry-run

## Publish note
- npm publish still requires an authenticated npm session or token.