### PR TITLE
Fix standalone HTML lazy chunk loading

### DIFF
--- a/src/__tests__/exportHtml.test.js
+++ b/src/__tests__/exportHtml.test.js
@@ -1,10 +1,15 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 
 // exportHtml.js relies on browser APIs (document, fetch, URL, Blob).
 // We test in the default node environment since jsdom is not configured;
 // the module loads fine but DOM calls throw, which we validate.
 
 describe("exportHtml module", function () {
+  afterEach(function () {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   it("exports exportSingleSession and exportComparison as async functions", async function () {
     var mod = await import("../lib/exportHtml.js");
     expect(typeof mod.exportSingleSession).toBe("function");
@@ -21,5 +26,69 @@ describe("exportHtml module", function () {
     await expect(
       mod.exportComparison("text-a", "a.jsonl", "text-b", "b.jsonl")
     ).rejects.toThrow();
+  });
+
+  it("embeds lazy chunks and worker assets in single-session exports", async function () {
+    var entryUrl = "https://example.test/assets/index-abc.js";
+    var chunkUrl = "https://example.test/assets/GraphView-def.js";
+    var sideEffectUrl = "https://example.test/assets/setup-jkl.js";
+    var workerUrl = "https://example.test/assets/elk-worker-ghi.js";
+    var responses = {};
+    responses[entryUrl] = new Response(
+      'import"./setup-jkl.js";import("./GraphView-def.js");'
+    );
+    responses[chunkUrl] = new Response(
+      'import{a}from"./index-abc.js";new URL("elk-worker-ghi.js",import.meta.url);'
+    );
+    responses[sideEffectUrl] = new Response('globalThis.__setup=true;');
+    responses[workerUrl] = new Response("self.onmessage=function(){};", {
+      headers: { "Content-Type": "text/javascript" },
+    });
+
+    var downloadedBlob = null;
+    var anchor = { click: vi.fn() };
+    vi.stubGlobal("document", {
+      querySelector: vi.fn(function () { return { src: entryUrl }; }),
+      createElement: vi.fn(function () { return anchor; }),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+    });
+    vi.stubGlobal("fetch", vi.fn(function (url) {
+      return Promise.resolve(responses[url].clone());
+    }));
+    vi.stubGlobal("URL", Object.assign(URL, {
+      createObjectURL: vi.fn(function (blob) {
+        downloadedBlob = blob;
+        return "blob:export";
+      }),
+      revokeObjectURL: vi.fn(),
+    }));
+    vi.stubGlobal("btoa", function (value) {
+      return Buffer.from(value, "binary").toString("base64");
+    });
+
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var html = await downloadedBlob.text();
+
+    expect(fetch).toHaveBeenCalledWith(entryUrl);
+    expect(fetch).toHaveBeenCalledWith(chunkUrl);
+    expect(fetch).toHaveBeenCalledWith(sideEffectUrl);
+    expect(fetch).toHaveBeenCalledWith(workerUrl);
+    expect(html).toContain('<script type="importmap">');
+    expect(html).toContain("window.__AGENTVIZ_STANDALONE__ = true");
+    expect(html).not.toContain('import("./GraphView-def.js")');
+
+    var importMapText = html.match(/<script type="importmap">(.*?)<\/script>/)[1];
+    var importMap = JSON.parse(importMapText);
+    expect(importMap.imports[entryUrl]).toMatch(/^data:text\/javascript;base64,/);
+    expect(importMap.imports[chunkUrl]).toMatch(/^data:text\/javascript;base64,/);
+    expect(importMap.imports[sideEffectUrl]).toMatch(/^data:text\/javascript;base64,/);
+
+    var chunkSource = Buffer.from(
+      importMap.imports[chunkUrl].split(",")[1],
+      "base64"
+    ).toString("utf8");
+    expect(chunkSource).toContain("data:text/javascript;base64,");
+    expect(chunkSource).not.toContain("elk-worker-ghi.js");
   });
 });

--- a/src/__tests__/lazyImport.test.js
+++ b/src/__tests__/lazyImport.test.js
@@ -3,11 +3,14 @@ import lazyImport, { clearChunkReloadFlag } from "../lib/lazyImport.js";
 
 var RELOAD_KEY = "agentviz:chunk-reload";
 
-function installBrowserStubs(initialValue) {
+function installBrowserStubs(initialValue, options) {
   var store = {};
   if (initialValue != null) store[RELOAD_KEY] = initialValue;
   var reload = vi.fn();
-  vi.stubGlobal("window", { location: { reload: reload } });
+  vi.stubGlobal("window", {
+    __AGENTVIZ_STANDALONE__: options && options.standalone,
+    location: { reload: reload, protocol: options && options.protocol || "https:" },
+  });
   vi.stubGlobal("sessionStorage", {
     getItem: vi.fn(function (key) { return store[key] || null; }),
     setItem: vi.fn(function (key, value) { store[key] = value; }),
@@ -48,6 +51,16 @@ describe("lazyImport", function () {
     var error = new Error("ChunkLoadError");
 
     await expect(lazyImport(function () { return Promise.reject(error); })).rejects.toThrow("ChunkLoadError");
+    expect(stubs.reload).not.toHaveBeenCalled();
+  });
+
+  it("does not reload standalone file exports for missing chunks", async function () {
+    var stubs = installBrowserStubs(null, { standalone: true, protocol: "file:" });
+    var error = new Error("Failed to fetch dynamically imported module");
+
+    await expect(lazyImport(function () { return Promise.reject(error); })).rejects.toThrow(
+      "Failed to fetch dynamically imported module"
+    );
     expect(stubs.reload).not.toHaveBeenCalled();
   });
 

--- a/src/lib/exportHtml.js
+++ b/src/lib/exportHtml.js
@@ -51,7 +51,62 @@ function escapeHtmlAttr(str) {
   return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-async function fetchBundleText() {
+function bytesToDataUrl(bytes, mimeType) {
+  var binary = "";
+  var chunkSize = 0x8000;
+  for (var i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
+  }
+  return "data:" + mimeType + ";base64," + btoa(binary);
+}
+
+function textToDataUrl(text, mimeType) {
+  return bytesToDataUrl(new TextEncoder().encode(text), mimeType);
+}
+
+function findModuleSpecifiers(source) {
+  var specifiers = [];
+  var pattern = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*)(["'])([^"']+)\1/g;
+  var match;
+  while ((match = pattern.exec(source)) !== null) {
+    specifiers.push(match[2]);
+  }
+  return specifiers;
+}
+
+function findAssetSpecifiers(source) {
+  var specifiers = [];
+  var pattern = /new URL\(\s*(["'])([^"'\\\s+]+)\1\s*,\s*import\.meta\.url\s*\)/g;
+  var match;
+  while ((match = pattern.exec(source)) !== null) {
+    specifiers.push(match[2]);
+  }
+  return specifiers;
+}
+
+function rewriteModuleSpecifiers(source, moduleUrl) {
+  return source.replace(
+    /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s*)(["'])([^"']+)\2/g,
+    function (full, prefix, quote, specifier) {
+      if (!specifier.startsWith(".")) return full;
+      return prefix + quote + new URL(specifier, moduleUrl).href + quote;
+    }
+  );
+}
+
+function rewriteAssetSpecifiers(source, moduleUrl, assetDataUrls) {
+  return source.replace(
+    /new URL\(\s*(["'])([^"'\\\s+]+)\1\s*,\s*import\.meta\.url\s*\)/g,
+    function (full, quote, specifier) {
+      var assetUrl = new URL(specifier, moduleUrl).href;
+      var dataUrl = assetDataUrls[assetUrl];
+      if (!dataUrl) return full;
+      return "new URL(" + quote + dataUrl + quote + ",import.meta.url)";
+    }
+  );
+}
+
+async function fetchBundleGraph() {
   var scriptEl = document.querySelector('script[type="module"][src*="/assets/index-"]');
   if (!scriptEl) {
     throw new Error(
@@ -59,14 +114,62 @@ async function fetchBundleText() {
       "`node bin/agentviz.js` or `node server.js` (not the Vite dev server)."
     );
   }
-  var resp = await fetch(scriptEl.src);
-  if (!resp.ok) throw new Error("Failed to fetch bundle: HTTP " + resp.status);
-  return resp.text();
+
+  var entryUrl = scriptEl.src;
+  var moduleSources = {};
+  var assetDataUrls = {};
+  var pendingModules = {};
+  var pendingAssets = {};
+
+  async function fetchAsset(assetUrl) {
+    if (assetDataUrls[assetUrl]) return;
+    if (pendingAssets[assetUrl]) return pendingAssets[assetUrl];
+
+    pendingAssets[assetUrl] = fetch(assetUrl).then(async function (resp) {
+      if (!resp.ok) throw new Error("Failed to fetch export asset: HTTP " + resp.status);
+      var mimeType = resp.headers.get("Content-Type") || "application/octet-stream";
+      var buffer = await resp.arrayBuffer();
+      assetDataUrls[assetUrl] = bytesToDataUrl(new Uint8Array(buffer), mimeType);
+    });
+    return pendingAssets[assetUrl];
+  }
+
+  async function fetchModule(moduleUrl) {
+    if (moduleSources[moduleUrl]) return;
+    if (pendingModules[moduleUrl]) return pendingModules[moduleUrl];
+
+    pendingModules[moduleUrl] = fetch(moduleUrl).then(async function (resp) {
+      if (!resp.ok) throw new Error("Failed to fetch export bundle: HTTP " + resp.status);
+      var source = await resp.text();
+      moduleSources[moduleUrl] = source;
+
+      var moduleUrls = findModuleSpecifiers(source)
+        .filter(function (specifier) { return specifier.startsWith("."); })
+        .map(function (specifier) { return new URL(specifier, moduleUrl).href; });
+      var assetUrls = findAssetSpecifiers(source)
+        .map(function (specifier) { return new URL(specifier, moduleUrl).href; });
+
+      await Promise.all(
+        moduleUrls.map(fetchModule).concat(assetUrls.map(fetchAsset))
+      );
+    });
+    return pendingModules[moduleUrl];
+  }
+
+  await fetchModule(entryUrl);
+
+  var imports = {};
+  Object.keys(moduleSources).forEach(function (moduleUrl) {
+    var source = rewriteModuleSpecifiers(moduleSources[moduleUrl], moduleUrl);
+    source = rewriteAssetSpecifiers(source, moduleUrl, assetDataUrls);
+    imports[moduleUrl] = textToDataUrl(source, "text/javascript");
+  });
+
+  return { entryUrl: entryUrl, imports: imports };
 }
 
-function buildHtml(title, setupScript, bundleText) {
-  // The <\/script> split trick prevents the HTML parser from ending the
-  // outer script block early if bundleText itself contains </script>.
+function buildHtml(title, setupScript, bundleGraph) {
+  var importMap = jsonSafe({ imports: bundleGraph.imports });
   return "<!DOCTYPE html>\n" +
     '<html lang="en">\n' +
     "<head>\n" +
@@ -81,9 +184,8 @@ function buildHtml(title, setupScript, bundleText) {
     "<body>\n" +
     '  <div id="root"></div>\n' +
     (setupScript ? "  " + setupScript + "\n" : "") +
-    '  <script type="module">\n' +
-    bundleText + "\n" +
-    "  </" + "script>\n" +
+    '  <script type="importmap">' + importMap + "</" + "script>\n" +
+    '  <script type="module">import(' + jsonSafe(bundleGraph.entryUrl) + ");</" + "script>\n" +
     "</body>\n" +
     "</html>";
 }
@@ -103,7 +205,7 @@ function downloadHtml(html, filename) {
 // Export a single session as a self-contained HTML file.
 // rawText: the full JSONL content; filename: original file name.
 export async function exportSingleSession(rawText, filename) {
-  var bundleText = await fetchBundleText();
+  var bundleGraph = await fetchBundleGraph();
 
   var metaPayload = jsonSafe({ filename: filename, live: false });
   var rawTextPayload = jsonSafe(rawText);
@@ -113,6 +215,7 @@ export async function exportSingleSession(rawText, filename) {
   var setupScript =
     "<script>\n" +
     "(function() {\n" +
+    "  window.__AGENTVIZ_STANDALONE__ = true;\n" +
     "  var _orig = window.fetch;\n" +
     "  var _meta = " + metaPayload + ";\n" +
     "  var _text = " + rawTextPayload + ";\n" +
@@ -130,17 +233,17 @@ export async function exportSingleSession(rawText, filename) {
     "</" + "script>";
 
   var exportName = filename.replace(/\.jsonl$/, "") + "-agentviz.html";
-  downloadHtml(buildHtml("AGENTVIZ - " + filename, setupScript, bundleText), exportName);
+  downloadHtml(buildHtml("AGENTVIZ - " + filename, setupScript, bundleGraph), exportName);
 }
 
 // Export a side-by-side comparison as a self-contained HTML file.
 export async function exportComparison(rawTextA, filenameA, rawTextB, filenameB) {
-  var bundleText = await fetchBundleText();
+  var bundleGraph = await fetchBundleGraph();
 
   var comparePayload = jsonSafe({ a: { name: filenameA, text: rawTextA }, b: { name: filenameB, text: rawTextB } });
 
   var setupScript =
-    "<script>window.__AGENTVIZ_COMPARE__ = " + comparePayload + ";</" + "script>";
+    "<script>window.__AGENTVIZ_STANDALONE__ = true; window.__AGENTVIZ_COMPARE__ = " + comparePayload + ";</" + "script>";
 
-  downloadHtml(buildHtml("AGENTVIZ - Comparison", setupScript, bundleText), "comparison-agentviz.html");
+  downloadHtml(buildHtml("AGENTVIZ - Comparison", setupScript, bundleGraph), "comparison-agentviz.html");
 }

--- a/src/lib/lazyImport.js
+++ b/src/lib/lazyImport.js
@@ -17,6 +17,7 @@ export default function lazyImport(loader) {
   return loader().catch(function (error) {
     if (!isStaleChunkError(error)) throw error;
     if (typeof window === "undefined" || typeof sessionStorage === "undefined") throw error;
+    if (window.__AGENTVIZ_STANDALONE__ || window.location.protocol === "file:") throw error;
     if (sessionStorage.getItem(RELOAD_KEY)) throw error;
     sessionStorage.setItem(RELOAD_KEY, "1");
     window.location.reload();


### PR DESCRIPTION
## Summary
- embed the complete Vite module graph in standalone HTML exports via import maps and data URLs
- embed worker assets referenced through import.meta.url
- prevent standalone file exports from entering stale-chunk reload recovery
- add regression coverage for lazy chunks, side-effect imports, worker assets, and reload behavior

## Root cause
The exporter embedded only the entry bundle. Lazy views such as Graph, Cost, Compare, and Coach still referenced separate Vite chunks that were not included with the shared HTML file. Missing chunk errors triggered stale-deploy recovery and could repeatedly reload the file.

## Validation
- npm run typecheck
- npm test (909 tests)
- npm run build
- opened a fresh export through file:// and loaded the Graph view using the reported trace