### PR TITLE
Add cross-format user input filtering

### DIFF
--- a/.github/skills/sync-artifacts/SKILL.md
+++ b/.github/skills/sync-artifacts/SKILL.md
@@ -110,7 +110,7 @@ The style guide and color-palette.html must agree: if a token's hex value appear
 
 ### 2e. docs/screenshots/
 
-Screenshots need regeneration if **any visual change** occurred -- component changes, theme token changes, layout changes, new views, or view modifications.
+If **any visual change** occurred -- component changes, theme token changes, layout changes, new views, or view modifications -- identify the screenshots that may be stale. Before regenerating anything, ask the user whether they want all screenshots regenerated. Do not regenerate screenshots without explicit confirmation.
 
 The 8 required screenshots:
 - `landing.png` -- landing page (before loading a session)
@@ -160,9 +160,9 @@ For each artifact that needs updating, make the changes directly. Do not ask for
 - Verify the dark-mode and light-mode columns are updated separately (the file has a `.mode.dark` block and a `.mode.light` block)
 - Update the `<div class="banner">` summary at the top if you are documenting a batch of palette changes
 
-## Step 4: Regenerate Screenshots
+## Step 4: Confirm and Regenerate Screenshots
 
-If visual changes occurred, regenerate all 8 screenshots. Even if you think only one view changed, regenerate all of them -- theme changes affect everything.
+If visual changes occurred, use `ask_user` to ask whether the user wants all 8 screenshots regenerated. If they decline, skip screenshot generation and record "Skipped by user request" in the final report. If they approve, regenerate all 8 screenshots. Even if you think only one view changed, regenerate all of them because theme changes can affect everything.
 
 > **PRIVACY: Never capture personal session data.** Use `?demo=empty` for the landing page and "Load a demo session" for all session views. No real user sessions should appear in screenshots.
 
@@ -298,6 +298,7 @@ Present a summary of everything that was synced:
 
 ### docs/screenshots/
 - [which screenshots were regenerated, or "No changes needed"]
+- If regeneration was declined: "Skipped by user request"
 - Hero/replay match: [PASS/FAIL]
 
 ### Validation
@@ -330,7 +331,7 @@ If "just check" is requested, audit all five artifacts but only report drift -- 
 
 ## Important Principles
 
-- **Always regenerate ALL 8 screenshots**, not just the view that changed. Theme or layout changes ripple.
+- **Always ask before regenerating screenshots.** If approved, regenerate all 8 rather than only the visibly affected view because theme or layout changes can ripple.
 - **session-hero.png must equal replay-view.png**. This is the most common mistake.
 - **Use `?demo=empty`** for the landing page screenshot. Never capture with personal session data visible.
 - **Match existing style** when updating README/CLAUDE.md. Read the surrounding content before writing.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,9 @@ Run `npx playwright install chromium` once before the first browser test run.
 - Copilot CLI Session Info lists every explicit reasoning effort in first-seen order; selected events show the effective value, and effort is never inferred from reasoning text or token usage
 - The default UI is the v2 workflow shell. Classic UI remains available through the `agentviz:v2:enabled` preference and header toggle.
 - Shared session actions must remain available in both shells; single-session HTML export uses `ExportStatusButton` in the v2 and Classic headers.
+- Investigate search preserves timeline context; Enter and Shift+Enter, plus adjacent arrow controls, navigate next and previous matches.
+- User-only filtering uses the normalized `event.agent === "user"` field across every parser, and search operates on the filtered event set.
+- Codex Session Info distinguishes user threads from named subagent traces when rollout metadata provides `thread_source` and `source.subagent`.
 
 ## Planned features
 - Bookmarks and annotations (persisted to localStorage)

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ The default entry point is a session portfolio for import, demo loading, auto-di
 
 ### Investigate
 
-Investigate wraps the chronological replay stream with search, error-only mode, track filters, contextual Analyze/Compare/Improve actions, and a resizable inspector sidebar. Click any event to see full details plus a payload inspector with readable JSON or text, top-level keys, line and character counts, copy support, and expand or collapse controls.
+Investigate wraps the chronological replay stream with search, next/previous match navigation, user-only and error-only modes, track filters, contextual Analyze/Compare/Improve actions, and a resizable inspector sidebar. The user-only filter works across every supported trace format through the normalized `user` agent. Press Enter or Shift+Enter in evidence search, or use the adjacent arrow controls, to move between matches. Click any event to see full details plus a payload inspector with readable JSON or text, top-level keys, line and character counts, copy support, and expand or collapse controls. Codex Session Info identifies user threads and named subagent traces.
 
 <div align="center">
 <img src="docs/screenshots/replay-view.png" alt="Replay View" width="800" />

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -1092,6 +1092,15 @@ Percentages use `.toFixed(1)` (e.g. `85.3%`). Token counts use `.toLocaleString(
 | `Cmd+Shift+K` / `Ctrl+Shift+K` | Toggle Session Q&A drawer |
 | `?` | Toggle shortcuts modal |
 
+### Search Match Navigation
+
+- Evidence search keeps the full chronological stream visible and highlights matches in place.
+- `Enter` jumps to the next match; `Shift+Enter` jumps to the previous match.
+- Previous and next arrow buttons remain visible beside the match count for pointer users.
+- `Escape` clears evidence search and removes focus from the input.
+- The **User only** filter selects normalized `event.agent === "user"` events, so it behaves consistently across all supported trace formats.
+- Search indexing, match counts, and next/previous navigation operate on the filtered event set.
+
 ### Command Palette Navigation
 
 - `ArrowDown` / `ArrowUp`: Move selection.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -469,8 +469,10 @@ function AppSessionView({
         onToggleFilters={function () { setShowFilters(function (p) { return !p; }); }}
         activeFilterCount={pb.activeFilterCount}
         trackFilters={pb.trackFilters}
+        agentFilter={pb.agentFilter}
         activeTracks={activeTracks}
         onToggleTrackFilter={pb.toggleTrackFilter}
+        onToggleAgentFilter={pb.toggleAgentFilter}
         speed={pb.playback.speed}
         onCycleSpeed={pb.cycleSpeed}
         onStartCompare={function () { setCompareLanding(true); }}

--- a/src/__tests__/appRegression.test.jsx
+++ b/src/__tests__/appRegression.test.jsx
@@ -454,14 +454,15 @@ describe("App browser regressions", function () {
       return getSearchCount(app.container);
     }, "expected search count to appear")).toBe("1");
 
-    await click(findButtonByTitle(app.container, "Filter tracks"));
+    await click(findButtonByTitle(app.container, "Filter events"));
     await waitFor(function () {
       return findClickableText(app.container, "Tool Calls");
     }, "expected filter popover to open");
+    expect(findClickableText(app.container, "User only")).toBeTruthy();
 
     await click(findClickableText(app.container, "Tool Calls"));
     await waitFor(function () {
-      return findButtonByTitle(app.container, "Filter tracks");
+      return findButtonByTitle(app.container, "Filter events");
     }, "expected hidden filter count to update");
 
     await app.unmount();

--- a/src/__tests__/codexParser.test.ts
+++ b/src/__tests__/codexParser.test.ts
@@ -54,6 +54,51 @@ describe("parseCodexJSONL", function () {
     expect(assistantMessages).toHaveLength(1);
   });
 
+  it("identifies Codex Desktop subagent traces", function () {
+    const text = [
+      line({
+        type: "session_meta",
+        timestamp: "2026-05-25T12:00:00.000Z",
+        payload: {
+          id: "guardian-session",
+          parent_thread_id: "parent-session",
+          originator: "Codex Desktop",
+          source: { subagent: { other: "guardian" } },
+          thread_source: "subagent",
+          model_provider: "openai",
+        },
+      }),
+      line({ type: "response_item", timestamp: "2026-05-25T12:00:01.000Z", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Assess this action" }] } }),
+    ].join("\n");
+
+    const result = parseCodexJSONL(text);
+    expect(result?.metadata.threadSource).toBe("subagent");
+    expect(result?.metadata.parentThreadId).toBe("parent-session");
+    expect(result?.metadata.subagentName).toBe("guardian");
+  });
+
+  it("reads canonical Codex thread-spawn subagent names", function () {
+    const text = [
+      line({
+        type: "session_meta",
+        timestamp: "2026-05-25T12:00:00.000Z",
+        payload: {
+          id: "spawned-session",
+          parent_thread_id: "parent-session",
+          originator: "Codex Desktop",
+          agent_nickname: "reviewer",
+          source: { subagent: { thread_spawn: { parent_thread_id: "parent-session" } } },
+          thread_source: "subagent",
+          model_provider: "openai",
+        },
+      }),
+      line({ type: "response_item", timestamp: "2026-05-25T12:00:01.000Z", payload: { type: "message", role: "user", content: [{ type: "input_text", text: "Review this change" }] } }),
+    ].join("\n");
+
+    const result = parseCodexJSONL(text);
+    expect(result?.metadata.subagentName).toBe("reviewer");
+  });
+
   it("uses cumulative token_count totals for metadata token usage", function () {
     const result = parseCodexJSONL(FIXTURE);
     expect(result?.metadata.tokenUsage).toMatchObject({

--- a/src/__tests__/session.test.ts
+++ b/src/__tests__/session.test.ts
@@ -36,7 +36,7 @@ describe("buildFilteredEventEntries", function () {
   var events = [
     makeEvent(0, 1, "reasoning"),
     makeEvent(1, 1, "tool_call"),
-    makeEvent(2, 1, "output"),
+    makeEvent(2, 1, "output", "user"),
     makeEvent(3, 1, "reasoning"),
   ];
 
@@ -52,6 +52,13 @@ describe("buildFilteredEventEntries", function () {
     expect(entries).toHaveLength(2);
     expect(entries[0].event.track).toBe("tool_call");
     expect(entries[1].event.track).toBe("output");
+  });
+
+  it("filters by normalized agent across trace formats", function () {
+    var entries = buildFilteredEventEntries(events, {}, "user");
+    expect(entries).toHaveLength(1);
+    expect(entries[0].index).toBe(2);
+    expect(entries[0].event.agent).toBe("user");
   });
 
   it("returns empty for null events", function () {

--- a/src/__tests__/v2Shell.test.jsx
+++ b/src/__tests__/v2Shell.test.jsx
@@ -816,6 +816,8 @@ describe("V2 shell routing", function () {
   it("renders InvestigateView and exposes contextual event actions", async function () {
     var onNavigate = vi.fn();
     var session = makeAnalyzeSession();
+    session.metadata.threadSource = "subagent";
+    session.metadata.subagentName = "guardian";
     var app = await renderNode(
       <PlaybackProvider session={session}>
         <InvestigateView
@@ -845,6 +847,7 @@ describe("V2 shell routing", function () {
     expect(findExactButton(app.container, "Copy payload")).toBeTruthy();
     expect(findExactButton(app.container, "Errors only (1)")).toBeTruthy();
     expect(app.container.querySelector('input[aria-label="Search evidence events"]')).toBeTruthy();
+    expect(findExactText(app.container, "subagent · guardian")).toBeTruthy();
 
     await act(async function () {
       findExactButton(app.container, "See in Waterfall").click();
@@ -882,12 +885,71 @@ describe("V2 shell routing", function () {
     await waitFor(function () {
       return findExactText(app.container, "1 match");
     }, "expected search match count");
+    expect(app.container.querySelector('button[aria-label="Previous search match"]')).toBeTruthy();
+    expect(app.container.querySelector('button[aria-label="Next search match"]')).toBeTruthy();
+
+    await changeInput(app.container.querySelector('input[aria-label="Search evidence events"]'), "Plan work");
+    await waitFor(function () {
+      return findExactText(app.container, "0 matches");
+    }, "expected error-only search to exclude hidden non-errors");
+
+    await app.unmount();
+  });
+
+  it("filters Investigate to normalized user input events", async function () {
+    var session = makeAnalyzeSession();
+    session.events[0] = Object.assign({}, session.events[0], { agent: "user" });
+    var app = await renderNode(
+      <PlaybackProvider session={session}>
+        <InvestigateView
+          session={session}
+          onNavigate={vi.fn()}
+        />
+      </PlaybackProvider>,
+    );
+
+    await act(async function () {
+      findExactButton(app.container, "User only").click();
+    });
+    expect(findExactText(app.container, "Plan work")).toBeTruthy();
+    expect(findExactText(app.container, "Run tests")).toBeFalsy();
+    expect(findExactText(app.container, "typecheck failed")).toBeFalsy();
+
+    await changeInput(app.container.querySelector('input[aria-label="Search evidence events"]'), "tests");
+    await waitFor(function () {
+      return findExactText(app.container, "0 matches");
+    }, "expected search to respect the user filter");
+
+    await app.unmount();
+  });
+
+  it("jumps between Investigate search matches with Enter", async function () {
+    var session = makeAnalyzeSession();
+    var app = await renderNode(
+      <PlaybackProvider session={session}>
+        <InvestigateView
+          session={session}
+          onNavigate={vi.fn()}
+        />
+      </PlaybackProvider>,
+    );
+    var searchInput = app.container.querySelector('input[aria-label="Search evidence events"]');
+
+    await changeInput(searchInput, "Plan work");
+    await act(async function () {
+      searchInput.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    await waitFor(function () {
+      return findExactText(app.container, "Run tests") === null;
+    }, "expected replay to seek to the first match");
 
     await app.unmount();
   });
 
   it("selects a targeted Investigate event from evidence navigation", async function () {
     var session = makeAnalyzeSession();
+    window.localStorage.setItem("agentviz:agent-filter", JSON.stringify("user"));
+    window.localStorage.setItem("agentviz:track-filters", JSON.stringify({ tool_call: true }));
     var app = await renderNode(
       <PlaybackProvider session={session}>
         <InvestigateView
@@ -902,6 +964,12 @@ describe("V2 shell routing", function () {
       return findExactText(app.container, "Selected Event");
     }, "expected targeted event selection");
     expect(findExactButton(app.container, "Coach in Improve")).toBeTruthy();
+    expect(findExactButton(app.container, "User only").getAttribute("aria-pressed")).toBe("false");
+    expect(findExactButton(app.container, "Tool Calls").getAttribute("aria-pressed")).toBe("false");
+    await act(async function () {
+      findExactButton(app.container, "User only").click();
+    });
+    expect(findExactButton(app.container, "User only").getAttribute("aria-pressed")).toBe("true");
 
     await app.unmount();
   });

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -90,6 +90,10 @@ function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, toolEn
               })(),
               metadata.reasoningEfforts && metadata.reasoningEfforts.length > 0
                 ? ["Reasoning", metadata.reasoningEfforts.join(", "), theme.track.reasoning] : null,
+              metadata.threadSource
+                ? ["Thread", metadata.threadSource === "subagent" && metadata.subagentName
+                  ? "subagent · " + metadata.subagentName
+                  : metadata.threadSource, theme.track.context] : null,
               metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0
                 ? ["Tokens", (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens).toLocaleString(), theme.accent.primary] : null,
               (function () {

--- a/src/components/app/AppHeader.jsx
+++ b/src/components/app/AppHeader.jsx
@@ -24,8 +24,10 @@ export default function AppHeader({
   onToggleFilters,
   activeFilterCount,
   trackFilters,
+  agentFilter,
   activeTracks,
   onToggleTrackFilter,
+  onToggleAgentFilter,
   speed,
   onCycleSpeed,
   currentThemeMode,
@@ -230,8 +232,8 @@ export default function AppHeader({
           <div ref={filtersRef} style={{ position: "relative" }}>
             <ToolbarButton
               onClick={onToggleFilters}
-              title="Filter tracks"
-              aria-label="Filter tracks"
+              title="Filter events"
+              aria-label="Filter events"
               style={{
                 background: activeFilterCount > 0 ? alpha(theme.accent.primary, 0.08) : "transparent",
                 borderColor: activeFilterCount > 0 ? theme.accent.primary : theme.border.default,
@@ -293,6 +295,37 @@ export default function AppHeader({
                     </button>
                   );
                 })}
+                <div style={{ height: 1, background: theme.border.default, margin: "4px 6px" }} />
+                <button
+                className="av-interactive"
+                aria-pressed={agentFilter === "user"}
+                onClick={function () { onToggleAgentFilter("user"); }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 8,
+                  padding: "4px 10px",
+                  borderRadius: theme.radius.md,
+                  width: "100%",
+                  background: agentFilter === "user" ? alpha(theme.accent.primary, 0.08) : "transparent",
+                  border: "none",
+                  cursor: "pointer",
+                  textAlign: "left",
+                }}
+                >
+                <Icon name="agent" size={12} style={{ color: agentFilter === "user" ? theme.accent.primary : theme.text.muted }} />
+                <span style={{
+                  fontSize: theme.fontSize.xs,
+                  fontFamily: theme.font.mono,
+                  color: agentFilter === "user" ? theme.accent.primary : theme.text.secondary,
+                  flex: 1,
+                }}>
+                  User only
+                </span>
+                {agentFilter === "user" && (
+                  <span style={{ fontSize: theme.fontSize.xs, color: theme.accent.primary, fontFamily: theme.font.mono }}>active</span>
+                )}
+                </button>
               </div>
             )}
           </div>

--- a/src/components/v2/InvestigateView.jsx
+++ b/src/components/v2/InvestigateView.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { TRACK_TYPES, alpha, theme } from "../../lib/theme.js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { AGENT_COLORS, TRACK_TYPES, alpha, theme } from "../../lib/theme.js";
 import { usePlaybackContext } from "../../contexts/PlaybackContext.jsx";
 import ReplayView from "../ReplayView.jsx";
 import ToolbarButton from "../ui/ToolbarButton.jsx";
@@ -87,20 +87,47 @@ function buildEntryActions(entry, onNavigate) {
 export default function InvestigateView({ session, targetEventIndex, onNavigate }) {
   var pb = usePlaybackContext();
   var [errorsOnly, setErrorsOnly] = useState(false);
+  var handledTargetRef = useRef({ session: null, eventIndex: null });
   var visibleEntries = useMemo(function () {
     return errorsOnly
       ? pb.filteredEventEntries.filter(function (entry) { return entry.event.isError; })
       : pb.filteredEventEntries;
   }, [errorsOnly, pb.filteredEventEntries]);
+  var visibleMatches = useMemo(function () {
+    return errorsOnly
+      ? pb.search.matchedEntries.filter(function (entry) { return entry.event.isError; })
+      : pb.search.matchedEntries;
+  }, [errorsOnly, pb.search.matchedEntries]);
+  var visibleMatchSet = useMemo(function () {
+    if (!pb.search.searchQuery) return null;
+    return new Set(visibleMatches.map(function (entry) { return entry.index; }));
+  }, [pb.search.searchQuery, visibleMatches]);
   var errorCount = pb.errorEntries.length;
+
+  var jumpToVisibleMatch = useCallback(function (direction) {
+    var matches = pb.search.submitSearch();
+    if (errorsOnly) {
+      matches = matches.filter(function (entry) { return entry.event.isError; });
+    }
+    pb.jumpToEntries(matches, direction);
+  }, [errorsOnly, pb.jumpToEntries, pb.search.submitSearch]);
 
   useEffect(function () {
     if (targetEventIndex == null || !session || !session.events) return;
+    if (handledTargetRef.current.session === session
+      && handledTargetRef.current.eventIndex === targetEventIndex) return;
+    handledTargetRef.current = { session: session, eventIndex: targetEventIndex };
     var event = session.events[targetEventIndex];
+    if (event && pb.agentFilter && event.agent !== pb.agentFilter) {
+      pb.clearAgentFilter();
+    }
+    if (event && pb.trackFilters[event.track]) {
+      pb.clearTrackFilter(event.track);
+    }
     if (event && pb.playback && pb.playback.seek) {
       pb.playback.seek(event.t);
     }
-  }, [targetEventIndex, session, pb.playback.seek]);
+  }, [targetEventIndex, session, pb.agentFilter, pb.clearAgentFilter, pb.trackFilters, pb.clearTrackFilter, pb.playback.seek]);
 
   return (
     <main style={{
@@ -155,6 +182,16 @@ export default function InvestigateView({ session, targetEventIndex, onNavigate 
             placeholder="Search evidence"
             value={pb.search.searchInput}
             onChange={function (event) { pb.search.setSearchInput(event.target.value); }}
+            onKeyDown={function (event) {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                jumpToVisibleMatch(event.shiftKey ? "prev" : "next");
+              }
+              if (event.key === "Escape") {
+                event.currentTarget.blur();
+                pb.search.clearSearch();
+              }
+            }}
             style={{
               border: "none",
               outline: "none",
@@ -167,6 +204,26 @@ export default function InvestigateView({ session, targetEventIndex, onNavigate 
             }}
           />
         </div>
+
+        <button
+          type="button"
+          className="av-btn"
+          aria-pressed={pb.agentFilter === "user"}
+          onClick={function () { pb.toggleAgentFilter("user"); }}
+          style={{
+            border: "1px solid " + (pb.agentFilter === "user" ? AGENT_COLORS.user : theme.border.default),
+            borderRadius: theme.radius.md,
+            background: pb.agentFilter === "user" ? alpha(AGENT_COLORS.user, 0.08) : theme.bg.surface,
+            color: pb.agentFilter === "user" ? AGENT_COLORS.user : theme.text.muted,
+            padding: "5px 8px",
+            fontFamily: theme.font.mono,
+            fontSize: theme.fontSize.xs,
+            cursor: "pointer",
+            whiteSpace: "nowrap",
+          }}
+        >
+          User only
+        </button>
 
         <button
           type="button"
@@ -220,9 +277,27 @@ export default function InvestigateView({ session, targetEventIndex, onNavigate 
         })}
 
         {pb.search.searchQuery && (
-          <span style={{ color: theme.text.dim, fontFamily: theme.font.mono, fontSize: theme.fontSize.xs, whiteSpace: "nowrap" }}>
-            {pb.search.matchedEntries.length} match{pb.search.matchedEntries.length === 1 ? "" : "es"}
-          </span>
+          <>
+            <span style={{ color: theme.text.dim, fontFamily: theme.font.mono, fontSize: theme.fontSize.xs, whiteSpace: "nowrap" }}>
+              {visibleMatches.length} match{visibleMatches.length === 1 ? "" : "es"}
+            </span>
+            <ToolbarButton
+              aria-label="Previous search match"
+              title="Previous match (Shift+Enter)"
+              icon="chevron-up"
+              disabled={visibleMatches.length === 0}
+              onClick={function () { jumpToVisibleMatch("prev"); }}
+              style={{ padding: "3px 5px" }}
+            />
+            <ToolbarButton
+              aria-label="Next search match"
+              title="Next match (Enter)"
+              icon="chevron-down"
+              disabled={visibleMatches.length === 0}
+              onClick={function () { jumpToVisibleMatch("next"); }}
+              style={{ padding: "3px 5px" }}
+            />
+          </>
         )}
       </div>
 
@@ -246,7 +321,7 @@ export default function InvestigateView({ session, targetEventIndex, onNavigate 
             turns={session.turns}
             turnStartMap={pb.turnStartMap}
             searchQuery={pb.search.searchQuery}
-            matchSet={pb.search.matchSet}
+            matchSet={visibleMatchSet}
             metadata={session.metadata}
             targetEventIndex={targetEventIndex}
             renderSelectedActions={function (props) {

--- a/src/contexts/PlaybackContext.jsx
+++ b/src/contexts/PlaybackContext.jsx
@@ -6,7 +6,7 @@
  * longer force search/filter consumers to reconcile).
  *
  *   PlaybackTimeCtx -- playback object, cycleSpeed, navigation helpers
- *   FilterCtx       -- trackFilters, filtered entries, turnStartMap, timeMap
+ *   FilterCtx       -- track/agent filters, filtered entries, turnStartMap, timeMap
  *   SearchCtx       -- search object
  *
  * usePlaybackContext() still returns the combined shape for backward compat.
@@ -46,10 +46,11 @@ export function PlaybackProvider({ session, children }) {
 
   // ── filters ───────────────────────────────────────────────────────────────
   var [trackFilters, setTrackFilters] = usePersistentState("agentviz:track-filters", {});
+  var [agentFilter, setAgentFilter] = usePersistentState("agentviz:agent-filter", null);
 
   var filteredEventEntries = useMemo(function () {
-    return buildFilteredEventEntries(session.events, trackFilters);
-  }, [session.events, trackFilters]);
+    return buildFilteredEventEntries(session.events, trackFilters, agentFilter);
+  }, [session.events, trackFilters, agentFilter]);
 
   var filteredEvents = useMemo(function () {
     return filteredEventEntries.map(function (entry) { return entry.event; });
@@ -79,7 +80,26 @@ export function PlaybackProvider({ session, children }) {
     });
   }, [setTrackFilters]);
 
-  var activeFilterCount = Object.keys(trackFilters).length;
+  var clearTrackFilter = useCallback(function (track) {
+    setTrackFilters(function (current) {
+      if (!current[track]) return current;
+      var next = Object.assign({}, current);
+      delete next[track];
+      return next;
+    });
+  }, [setTrackFilters]);
+
+  var toggleAgentFilter = useCallback(function (agent) {
+    setAgentFilter(function (current) {
+      return current === agent ? null : agent;
+    });
+  }, [setAgentFilter]);
+
+  var clearAgentFilter = useCallback(function () {
+    setAgentFilter(null);
+  }, [setAgentFilter]);
+
+  var activeFilterCount = Object.keys(trackFilters).length + (agentFilter ? 1 : 0);
 
   var filterValue = useMemo(function () {
     return {
@@ -89,11 +109,16 @@ export function PlaybackProvider({ session, children }) {
       timeMap: timeMap,
       errorEntries: errorEntries,
       trackFilters: trackFilters,
+      agentFilter: agentFilter,
       activeFilterCount: activeFilterCount,
       toggleTrackFilter: toggleTrackFilter,
+      clearTrackFilter: clearTrackFilter,
+      toggleAgentFilter: toggleAgentFilter,
+      clearAgentFilter: clearAgentFilter,
     };
   }, [filteredEventEntries, filteredEvents, turnStartMap, timeMap,
-      errorEntries, trackFilters, activeFilterCount, toggleTrackFilter]);
+      errorEntries, trackFilters, agentFilter, activeFilterCount, toggleTrackFilter, clearTrackFilter,
+      toggleAgentFilter, clearAgentFilter]);
 
   // ── search ────────────────────────────────────────────────────────────────
   var search = useSearch(filteredEventEntries);
@@ -131,25 +156,27 @@ export function PlaybackProvider({ session, children }) {
   }, [errorEntries, jumpToEntries]);
 
   var jumpToMatch = useCallback(function (direction) {
-    jumpToEntries(search.matchedEntries, direction);
-  }, [jumpToEntries, search.matchedEntries]);
+    jumpToEntries(search.submitSearch(), direction);
+  }, [jumpToEntries, search.submitSearch]);
 
   var resetPlaybackState = useCallback(function () {
     playback.resetPlayback(0);
     search.clearSearch();
     setTrackFilters({});
-  }, [playback.resetPlayback, search.clearSearch, setTrackFilters]);
+    setAgentFilter(null);
+  }, [playback.resetPlayback, search.clearSearch, setTrackFilters, setAgentFilter]);
 
   // Navigation lives in PlaybackTimeCtx since it depends on playback.time
   var playbackValue = useMemo(function () {
     return {
       playback: playback,
       cycleSpeed: cycleSpeed,
+      jumpToEntries: jumpToEntries,
       jumpToError: jumpToError,
       jumpToMatch: jumpToMatch,
       resetPlaybackState: resetPlaybackState,
     };
-  }, [playback, cycleSpeed, jumpToError, jumpToMatch, resetPlaybackState]);
+  }, [playback, cycleSpeed, jumpToEntries, jumpToError, jumpToMatch, resetPlaybackState]);
 
   return React.createElement(PlaybackTimeCtx.Provider, { value: playbackValue },
     React.createElement(FilterCtx.Provider, { value: filterValue },

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -36,6 +36,12 @@ export default function useSearch(eventEntries) {
     return buildSearchData(matchedEntries, searchQuery);
   }, [matchedEntries, searchQuery]);
 
+  var submitSearch = useCallback(function () {
+    var nextQuery = normalizeSearchQuery(searchInput);
+    setSearchQuery(nextQuery);
+    return index.search(nextQuery);
+  }, [index, searchInput]);
+
   var clearSearch = useCallback(function () {
     setSearchInput("");
     setSearchQuery("");
@@ -48,6 +54,7 @@ export default function useSearch(eventEntries) {
     searchResults: searchData.results,
     matchSet: searchData.matchSet,
     matchedEntries: matchedEntries,
+    submitSearch: submitSearch,
     clearSearch: clearSearch,
   };
 }

--- a/src/lib/codexParser.ts
+++ b/src/lib/codexParser.ts
@@ -538,6 +538,25 @@ function getSessionMeta(records: RawRecord[]): Record<string, any> {
   return meta && meta.payload || {};
 }
 
+function getSubagentName(meta: Record<string, any>): string | null {
+  if (typeof meta.agent_nickname === "string") return meta.agent_nickname;
+  if (typeof meta.agent_role === "string") return meta.agent_role;
+  if (!isRecord(meta.source)) return null;
+  if (typeof meta.source.subagent === "string") return meta.source.subagent;
+  if (!isRecord(meta.source.subagent)) return null;
+  const subagent = meta.source.subagent;
+  if (typeof subagent.name === "string") return subagent.name;
+  if (typeof subagent.other === "string") return subagent.other;
+  if (isRecord(subagent.thread_spawn)) {
+    const spawn = subagent.thread_spawn;
+    if (typeof spawn.agent_nickname === "string") return spawn.agent_nickname;
+    if (typeof spawn.agent_role === "string") return spawn.agent_role;
+    if (typeof spawn.name === "string") return spawn.name;
+  }
+  const keys = Object.keys(subagent);
+  return keys.length === 1 && keys[0] !== "thread_spawn" ? keys[0] : null;
+}
+
 function getLastTokenUsage(records: RawRecord[], warnings: string[]): TokenUsage | null {
   let lastUsage: Record<string, any> | null = null;
   for (let index = 0; index < records.length; index += 1) {
@@ -599,6 +618,8 @@ function buildMetadata(records: RawRecord[], events: NormalizedEvent[], turns: S
     cliVersion: typeof meta.cli_version === "string" ? meta.cli_version : null,
     modelProvider: typeof meta.model_provider === "string" ? meta.model_provider : null,
     threadSource: typeof meta.thread_source === "string" ? meta.thread_source : null,
+    parentThreadId: typeof meta.parent_thread_id === "string" ? meta.parent_thread_id : null,
+    subagentName: getSubagentName(meta),
   };
 }
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -15,12 +15,13 @@ export function getSessionTotal(events: NormalizedEvent[] | null | undefined): n
 export function buildFilteredEventEntries(
   events: NormalizedEvent[] | null | undefined,
   hiddenTracks: Record<string, boolean | undefined>,
+  agentFilter: string | null = null,
 ): EventEntry[] {
   if (!events) return [];
 
   const entries: EventEntry[] = [];
   for (let i = 0; i < events.length; i += 1) {
-    if (!hiddenTracks[events[i].track]) {
+    if (!hiddenTracks[events[i].track] && (!agentFilter || events[i].agent === agentFilter)) {
       entries.push({ index: i, event: events[i] });
     }
   }

--- a/tests/e2e/v2-smoke.spec.js
+++ b/tests/e2e/v2-smoke.spec.js
@@ -88,6 +88,22 @@ test("v2 Review and Investigate route to evidence", async function ({ page }) {
   expect(failures).toEqual([]);
 });
 
+test("v2 Investigate filters normalized user inputs", async function ({ page }) {
+  var failures = captureFailures(page);
+  await openV2(page);
+  await importGoldenFixture(page);
+
+  await page.getByRole("button", { name: /Investigate/ }).click();
+  await page.getByRole("button", { name: "User only" }).click();
+  await expect(page.getByText("Can you add a hello world function to utils.js?")).toBeVisible();
+  await expect(page.getByText("I'll add that function.")).toHaveCount(0);
+
+  await page.getByRole("textbox", { name: "Search evidence events" }).fill("hello world function");
+  await expect(page.getByText("1 match", { exact: true })).toBeVisible();
+
+  expect(failures).toEqual([]);
+});
+
 test("v2 Analyze Cost and command palette routing work", async function ({ page }) {
   var failures = captureFailures(page);
   await openV2(page);


### PR DESCRIPTION
## Summary
- add a shared `User only` event filter for every normalized trace format in both default and Classic UIs
- make v2 evidence search support next/previous navigation while respecting active filters and immediate Enter submission
- identify Codex user versus named subagent threads in Session Info
- preserve targeted evidence navigation when filters were previously active
- update the screenshot-sync skill to ask before regeneration

## Validation
- `npm run build`
- `npm run typecheck`
- `npm test` (916 tests)
- `npm run test:e2e:v2 -- --grep "filters normalized user inputs"`

Documentation screenshots were skipped by user request.