### PR TITLE
Standardize filter and metric labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ Run `npx playwright install chromium` once before the first browser test run.
 - Shared session actions must remain available in both shells; single-session HTML export uses `ExportStatusButton` in the v2 and Classic headers.
 - Investigate search preserves timeline context; Enter and Shift+Enter, plus adjacent arrow controls, navigate next and previous matches.
 - User-only filtering uses the normalized `event.agent === "user"` field across every parser, and search operates on the filtered event set.
+- Filter chips and generic metric labels use sentence case; peer chips do not embed a count in only one label.
 - Codex Session Info distinguishes user threads from named subagent traces when rollout metadata provides `thread_source` and `source.subagent`.
 
 ## Planned features

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Investigate wraps the chronological replay stream with search, next/previous mat
 
 ### Analyze: Tracks
 
-DAW-style multi-track lanes for Reasoning, Tool Calls, Context, and Output. **Solo** isolates one track. **Mute** hides it. See at a glance how your agent's time was spent.
+DAW-style multi-track lanes for Reasoning, Tool calls, Context, and Output. **Solo** isolates one track. **Mute** hides it. See at a glance how your agent's time was spent.
 
 <div align="center">
 <img src="docs/screenshots/tracks-view.png" alt="Tracks View" width="800" />

--- a/docs/color-palette.html
+++ b/docs/color-palette.html
@@ -210,7 +210,7 @@
     </div>
     <h3 style="margin-top:16px">Dark: Track Bars</h3>
     <div class="track-bar" style="background:rgba(148,163,184,0.15);color:#94a3b8;width:60%">Reasoning</div>
-    <div class="track-bar" style="background:rgba(59,158,255,0.15);color:#3b9eff;width:90%">Tool Calls</div>
+    <div class="track-bar" style="background:rgba(59,158,255,0.15);color:#3b9eff;width:90%">Tool calls</div>
     <div class="track-bar" style="background:rgba(167,139,250,0.15);color:#a78bfa;width:40%">Context</div>
     <div class="track-bar" style="background:rgba(16,217,122,0.15);color:#10d97a;width:50%">Output</div>
     <div class="track-bar" style="background:rgba(6,182,212,0.15);color:#06b6d4;width:30%">Agents</div>
@@ -236,7 +236,7 @@
     </div>
     <h3 style="margin-top:16px;color:#141824">Light: Track Bars</h3>
     <div class="track-bar" style="background:rgba(100,116,139,0.1);color:#64748b;width:60%">Reasoning</div>
-    <div class="track-bar" style="background:rgba(37,99,235,0.1);color:#2563eb;width:90%">Tool Calls</div>
+    <div class="track-bar" style="background:rgba(37,99,235,0.1);color:#2563eb;width:90%">Tool calls</div>
     <div class="track-bar" style="background:rgba(139,92,246,0.1);color:#8b5cf6;width:40%">Context</div>
     <div class="track-bar" style="background:rgba(14,168,107,0.1);color:#0ea86b;width:50%">Output</div>
     <div class="track-bar" style="background:rgba(8,145,178,0.1);color:#0891b2;width:30%">Agents</div>

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -1100,6 +1100,8 @@ Percentages use `.toFixed(1)` (e.g. `85.3%`). Token counts use `.toLocaleString(
 - `Escape` clears evidence search and removes focus from the input.
 - The **User only** filter selects normalized `event.agent === "user"` events, so it behaves consistently across all supported trace formats.
 - Search indexing, match counts, and next/previous navigation operate on the filtered event set.
+- Filter chips and generic metric labels use sentence case, such as **User only**, **Errors only**, and **Tool calls**.
+- Do not append a count to only one chip in a peer filter group. Put counts in a separate status treatment when the whole group needs them.
 
 ### Command Palette Navigation
 

--- a/src/__tests__/appRegression.test.jsx
+++ b/src/__tests__/appRegression.test.jsx
@@ -456,11 +456,11 @@ describe("App browser regressions", function () {
 
     await click(findButtonByTitle(app.container, "Filter events"));
     await waitFor(function () {
-      return findClickableText(app.container, "Tool Calls");
+      return findClickableText(app.container, "Tool calls");
     }, "expected filter popover to open");
     expect(findClickableText(app.container, "User only")).toBeTruthy();
 
-    await click(findClickableText(app.container, "Tool Calls"));
+    await click(findClickableText(app.container, "Tool calls"));
     await waitFor(function () {
       return findButtonByTitle(app.container, "Filter events");
     }, "expected hidden filter count to update");

--- a/src/__tests__/pricing.test.js
+++ b/src/__tests__/pricing.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { estimateCost, estimateMultiModelCost, formatCost, hasModelPricing } from "../lib/pricing.js";
+import { estimateCost, estimateMultiModelCost, formatCost, getSessionCostLabel, hasModelPricing } from "../lib/pricing.js";
 
 describe("estimateCost", function () {
   it("returns 0 for null tokenUsage", function () {
@@ -108,6 +108,13 @@ describe("estimateMultiModelCost", function () {
 describe("formatCost", function () {
   it("formats zero", function () {
     expect(formatCost(0)).toBe("$0.00");
+  });
+
+  describe("getSessionCostLabel", function () {
+    it("uses sentence case for estimated cost", function () {
+      expect(getSessionCostLabel({}, true)).toBe("Est. cost");
+      expect(getSessionCostLabel({ totalCost: 1, totalCostUnit: "usd" }, false)).toBe("Cost");
+    });
   });
 
   it("formats sub-penny", function () {

--- a/src/__tests__/statsView.test.jsx
+++ b/src/__tests__/statsView.test.jsx
@@ -91,7 +91,7 @@ describe("StatsView theme updates", function () {
       root.render(<StatsView {...props} />);
     });
 
-    var totalEventsCard = findExactText(container, "Total Events").parentElement;
+    var totalEventsCard = findExactText(container, "Total events").parentElement;
     expect(totalEventsCard.style.background).toBe(lightSurface);
     expect(totalEventsCard.firstElementChild.style.color).toBe(lightTextPrimary);
     var modelCard = findExactText(container, "Model").parentElement;
@@ -102,7 +102,7 @@ describe("StatsView theme updates", function () {
       root.render(<StatsView {...props} />);
     });
 
-    totalEventsCard = findExactText(container, "Total Events").parentElement;
+    totalEventsCard = findExactText(container, "Total events").parentElement;
     expect(totalEventsCard.style.background).toBe(darkSurface);
     expect(totalEventsCard.firstElementChild.style.color).toBe(darkTextPrimary);
     modelCard = findExactText(container, "Model").parentElement;
@@ -148,8 +148,8 @@ describe("StatsView theme updates", function () {
       root.render(<StatsView {...props} />);
     });
 
-    expect(getCardValue(container, "Total Events")).toBe("1");
-    expect(getCardValue(container, "Tool Calls")).toBe("0");
+    expect(getCardValue(container, "Total events")).toBe("1");
+    expect(getCardValue(container, "Tool calls")).toBe("0");
     expect(getCardValue(container, "Errors")).toBe("0");
 
     await act(async function () {
@@ -165,8 +165,8 @@ describe("StatsView theme updates", function () {
       );
     });
 
-    expect(getCardValue(container, "Total Events")).toBe("2");
-    expect(getCardValue(container, "Tool Calls")).toBe("1");
+    expect(getCardValue(container, "Total events")).toBe("2");
+    expect(getCardValue(container, "Tool calls")).toBe("1");
     expect(getCardValue(container, "Errors")).toBe("1");
 
     await act(async function () {

--- a/src/__tests__/v2Shell.test.jsx
+++ b/src/__tests__/v2Shell.test.jsx
@@ -757,7 +757,7 @@ describe("V2 shell routing", function () {
       findExactButton(app.container, "Tracks").click();
     });
     expect(findExactButton(app.container, "Tracks").getAttribute("aria-pressed")).toBe("true");
-    expect(findExactText(app.container, "Tool Calls")).toBeTruthy();
+    expect(findExactText(app.container, "Tool calls")).toBeTruthy();
 
     await act(async function () {
       findExactButton(app.container, "Review token spend").click();
@@ -845,7 +845,7 @@ describe("V2 shell routing", function () {
     expect(findExactButton(app.container, "See in Waterfall")).toBeTruthy();
     expect(findExactButton(app.container, "Compare sessions")).toBeTruthy();
     expect(findExactButton(app.container, "Copy payload")).toBeTruthy();
-    expect(findExactButton(app.container, "Errors only (1)")).toBeTruthy();
+    expect(findExactButton(app.container, "Errors only")).toBeTruthy();
     expect(app.container.querySelector('input[aria-label="Search evidence events"]')).toBeTruthy();
     expect(findExactText(app.container, "subagent · guardian")).toBeTruthy();
 
@@ -876,7 +876,7 @@ describe("V2 shell routing", function () {
 
     expect(findExactText(app.container, "Plan work")).toBeTruthy();
     await act(async function () {
-      findExactButton(app.container, "Errors only (1)").click();
+      findExactButton(app.container, "Errors only").click();
     });
     expect(findExactText(app.container, "typecheck failed")).toBeTruthy();
     expect(findExactText(app.container, "Plan work")).toBeFalsy();
@@ -965,7 +965,7 @@ describe("V2 shell routing", function () {
     }, "expected targeted event selection");
     expect(findExactButton(app.container, "Coach in Improve")).toBeTruthy();
     expect(findExactButton(app.container, "User only").getAttribute("aria-pressed")).toBe("false");
-    expect(findExactButton(app.container, "Tool Calls").getAttribute("aria-pressed")).toBe("false");
+    expect(findExactButton(app.container, "Tool calls").getAttribute("aria-pressed")).toBe("false");
     await act(async function () {
       findExactButton(app.container, "User only").click();
     });

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -99,7 +99,7 @@ function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, toolEn
               (function () {
                 var cost = getSessionCost(metadata);
                 if (cost == null) return null;
-                var label = metadata.totalCost != null ? getSessionCostLabel(metadata) : "Est. Cost";
+                var label = metadata.totalCost != null ? getSessionCostLabel(metadata) : "Est. cost";
                 return [label, metadata.totalCost != null ? formatSessionCost(metadata) : formatCost(cost), theme.semantic.success];
               })(),
               metadata.warnings && metadata.warnings.length > 0 ? ["Warnings", metadata.warnings.length, theme.semantic.warning] : null,

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -406,10 +406,10 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
 
   var cards = useMemo(function () {
     return [
-      { label: "Total Events", value: events.length, color: theme.text.primary },
+      { label: "Total events", value: events.length, color: theme.text.primary },
       { label: "Turns", value: metadata ? metadata.totalTurns : (turns ? turns.length : 0), color: theme.accent.primary },
-      { label: "User Messages", value: userMsgs, color: theme.accent.primary },
-      { label: "Tool Calls", value: (trackStats.tool_call || {}).count || 0, color: theme.track.tool_call },
+      { label: "User messages", value: userMsgs, color: theme.accent.primary },
+      { label: "Tool calls", value: (trackStats.tool_call || {}).count || 0, color: theme.track.tool_call },
       { label: "Errors", value: errorCount, color: errorCount > 0 ? theme.semantic.error : theme.text.muted },
       { label: "Duration", value: formatDurationLong(totalTime), color: theme.track.context },
     ];
@@ -486,7 +486,7 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
       });
     }
     if (estimated > 0) {
-      usageCards.push({ label: "Est. Cost", value: formatCost(estimated), color: hasApiCost ? theme.text.muted : theme.semantic.success, sub: "based on " + modelLabel });
+      usageCards.push({ label: "Est. cost", value: formatCost(estimated), color: hasApiCost ? theme.text.muted : theme.semantic.success, sub: "based on " + modelLabel });
     }
     var allModelsEntries = Object.keys(metadata.models).length > 1
       ? Object.entries(metadata.models).sort(function (a, b) { return b[1] - a[1]; })

--- a/src/components/v2/InvestigateView.jsx
+++ b/src/components/v2/InvestigateView.jsx
@@ -102,8 +102,6 @@ export default function InvestigateView({ session, targetEventIndex, onNavigate 
     if (!pb.search.searchQuery) return null;
     return new Set(visibleMatches.map(function (entry) { return entry.index; }));
   }, [pb.search.searchQuery, visibleMatches]);
-  var errorCount = pb.errorEntries.length;
-
   var jumpToVisibleMatch = useCallback(function (direction) {
     var matches = pb.search.submitSearch();
     if (errorsOnly) {
@@ -242,7 +240,7 @@ export default function InvestigateView({ session, targetEventIndex, onNavigate 
             whiteSpace: "nowrap",
           }}
         >
-          Errors only {errorCount > 0 ? "(" + errorCount + ")" : ""}
+          Errors only
         </button>
 
         {Object.keys(TRACK_TYPES).map(function (track) {

--- a/src/lib/pricing.js
+++ b/src/lib/pricing.js
@@ -207,5 +207,5 @@ export function getSessionCostLabel(metadata, estimated) {
   if (metadata && metadata.totalCost != null) {
     return isAiCreditsUnit(metadata.totalCostUnit) ? "AI Credits" : "Cost";
   }
-  return estimated ? "Est. Cost" : "Cost";
+  return estimated ? "Est. cost" : "Cost";
 }

--- a/src/lib/theme.js
+++ b/src/lib/theme.js
@@ -329,7 +329,7 @@ function createTrackInfo(key, label, icon) {
 
 export const TRACK_TYPES = {
   reasoning: createTrackInfo("reasoning", "Reasoning", "reasoning"),
-  tool_call: createTrackInfo("tool_call", "Tool Calls", "tool_call"),
+  tool_call: createTrackInfo("tool_call", "Tool calls", "tool_call"),
   context: createTrackInfo("context", "Context", "context"),
   output: createTrackInfo("output", "Output", "output"),
   agent: createTrackInfo("agent", "Agents", "agent"),


### PR DESCRIPTION
## Summary
- standardize filter chips, shared track names, Stats metrics, and estimated-cost labels to sentence case
- keep official names such as AI Credits capitalized
- remove the one-off error count from the Errors only chip
- document the copy rule and update the color-palette reference

## Validation
- `npm run build`
- `npm run typecheck`
- `npm test` (917 tests)

Documentation screenshots were skipped by user request.