### PR TITLE
Make HTML exports portable over file URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ coverage/
 
 # Playwright MCP snapshots
 .playwright-mcp/
+test-results/
+playwright-report/
 
 # AGENTVIZ runtime artifacts
 agentviz-server.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to AGENTVIZ are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed shared HTML exports that only opened on the machine that produced them.
+  Exports no longer use an import map keyed by `http://127.0.0.1:<port>` URLs or
+  `data:` URL modules (which WebKit refuses to evaluate); every chunk is now
+  embedded as source and instantiated from a `blob:` URL at boot.
+- Exported files now answer every `/api/*` route locally, so session discovery,
+  config, and Coach requests return an explicit "Not available in exported view"
+  response instead of throwing `URL scheme "file" is not supported`.
+- Exported files no longer request a webfont from Google Fonts and now carry the
+  theme bootstrap tokens from `index.html`, so they render correctly offline in
+  both dark and light mode.
+
+### Added
+
+- Boot-failure fallback in exported files: a readable message with browser
+  compatibility hints replaces the previous blank page.
+- Export generation aborts loudly if the produced bundle still references the
+  exporting server's origin.
+- `npm run test:e2e:export` plus a `webkit-export` Playwright project that open a
+  real export from `file://` with the network blocked.
+
+### Changed
+
+- Exported HTML is gzip-compressed, cutting a typical shared file from about
+  3.7 MB to under 900 KB.
+
 ## [1.0.2] - 2026-06-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -233,6 +233,10 @@ Export is available in two places:
 
 > Export requires the production build (`npm run build`). It is not available in the Vite dev server.
 
+The exported file is fully portable: every chunk is embedded as source and instantiated from `blob:` URLs at boot, so nothing is fetched from the machine that produced it. The payload is gzip-compressed, fonts fall back to the local monospace stack, and all `/api/*` calls are answered inside the file (backend-only features such as Coach analysis return an explicit "Not available in exported view" response). If a browser cannot start the viewer, the file renders a readable failure message with compatibility hints instead of a blank page.
+
+Recipients need Chrome 80+, Edge 80+, Firefox 113+, or Safari 16.4+. Portability is enforced by `tests/e2e/export-portability.spec.js`, which opens a generated export from `file://` with all network access blocked (`npm run test:e2e:export`).
+
 ---
 
 ## Features
@@ -559,12 +563,14 @@ npm run build           # Production build to dist/
 npm test                # Run all tests via Vitest with stable worker cap
 npm run test:v2         # Run v2 golden data, UI, and v1 regression coverage
 npm run test:e2e:v2     # Run the Playwright v2 browser smoke test
+npm run test:e2e:export # Build, then verify a shared export boots from file://
 npm run test:watch      # Watch mode
 npm run typecheck       # Type-check with tsc --noEmit
 ```
 
 > `npm run dev` starts both the Vite frontend (port 3000) and the API backend (port 4242) automatically. Vite proxies `/api/*` to the backend.
 > `npm run test:e2e:v2` uses a hermetic Vite test server on port 3100. Run `npx playwright install chromium` once before the first browser test run.
+> `npm run test:e2e:export` serves `dist/` on an ephemeral port, downloads a real export, and reopens it from `file://` with the network blocked. Run `npx playwright install --with-deps webkit` to also run the `webkit-export` project, which guards against WebKit's refusal to evaluate module scripts from `data:` URLs.
 
 ### Design System
 

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -1167,7 +1167,9 @@ import KeyboardHint from "./ui/KeyboardHint.jsx";
 3. Use `Object.assign({}, baseStyle, overrideStyle)` for style composition.
 4. The only CSS lives in `index.html` (and is duplicated in `src/lib/exportHtml.js` for HTML export):
    global resets, scrollbar styles, utility classes (`.av-btn`, `.av-interactive`, `.av-search`),
-   keyframe animations, and focus styles.
+   keyframe animations, and focus styles. The export copy must keep the theme variable blocks and
+   theme bootstrap script in sync with `index.html`, but intentionally omits the Google Fonts link
+   (exports are opened offline) and adds `.av-export-status` for the boot-failure message.
 5. Never add new CSS classes. If a new shared style pattern is needed, create a component.
 6. Never add CSS files, CSS modules, styled-components, or any CSS-in-JS library.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "test:v2": "vitest run --maxWorkers=2 src/__tests__/v2Shell.test.jsx src/__tests__/v2GoldenData.test.js src/__tests__/v2GoldenFormats.test.js src/__tests__/v2GoldenUi.test.jsx src/__tests__/appRegression.test.jsx src/__tests__/tokenAccounting.test.js",
     "test:e2e": "playwright test",
     "test:e2e:v2": "playwright test tests/e2e/v2-smoke.spec.js",
+    "test:e2e:export": "npm run build && playwright test tests/e2e/export-portability.spec.js",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
   },

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -24,5 +24,12 @@ export default defineConfig({
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
+    // Shared exports must also boot in WebKit, which refuses module scripts
+    // served from data: URLs.
+    {
+      name: "webkit-export",
+      testMatch: /export-portability\.spec\.js/,
+      use: { ...devices["Desktop Safari"] },
+    },
   ],
 });

--- a/src/__tests__/exportHtml.test.js
+++ b/src/__tests__/exportHtml.test.js
@@ -1,8 +1,70 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
+import zlib from "node:zlib";
 
 // exportHtml.js relies on browser APIs (document, fetch, URL, Blob).
 // We test in the default node environment since jsdom is not configured;
 // the module loads fine but DOM calls throw, which we validate.
+
+var ENTRY_URL = "https://example.test/assets/index-abc.js";
+var CHUNK_URL = "https://example.test/assets/GraphView-def.js";
+var SIDE_EFFECT_URL = "https://example.test/assets/setup-jkl.js";
+var WORKER_URL = "https://example.test/assets/elk-worker-ghi.js";
+
+function buildResponses(overrides) {
+  var responses = {};
+  responses[ENTRY_URL] = new Response(
+    'import"./setup-jkl.js";import("./GraphView-def.js");'
+  );
+  responses[CHUNK_URL] = new Response(
+    'import{a}from"./index-abc.js";new URL("elk-worker-ghi.js",import.meta.url);'
+  );
+  responses[SIDE_EFFECT_URL] = new Response("globalThis.__setup=true;");
+  responses[WORKER_URL] = new Response("self.onmessage=function(){};", {
+    headers: { "Content-Type": "text/javascript" },
+  });
+  Object.keys(overrides || {}).forEach(function (key) {
+    responses[key] = overrides[key];
+  });
+  return responses;
+}
+
+function stubBrowser(responses) {
+  var captured = { blob: null };
+  var anchor = { click: vi.fn() };
+  vi.stubGlobal("document", {
+    querySelector: vi.fn(function () { return { src: ENTRY_URL }; }),
+    createElement: vi.fn(function () { return anchor; }),
+    body: { appendChild: vi.fn(), removeChild: vi.fn() },
+  });
+  vi.stubGlobal("fetch", vi.fn(function (url) {
+    if (!responses[url]) return Promise.reject(new Error("unexpected fetch: " + url));
+    return Promise.resolve(responses[url].clone());
+  }));
+  vi.stubGlobal("URL", Object.assign(URL, {
+    createObjectURL: vi.fn(function (blob) {
+      captured.blob = blob;
+      return "blob:export";
+    }),
+    revokeObjectURL: vi.fn(),
+  }));
+  vi.stubGlobal("btoa", function (value) {
+    return Buffer.from(value, "binary").toString("base64");
+  });
+  return captured;
+}
+
+// The boot script embeds the payload as a single string literal; decode it the
+// same way the exported file does at runtime.
+function readPayload(html) {
+  var compressed = /var COMPRESSED = (true|false);/.exec(html);
+  var raw = /var PAYLOAD = "([^"]*)";/.exec(html);
+  expect(compressed).toBeTruthy();
+  expect(raw).toBeTruthy();
+  if (compressed[1] === "true") {
+    return JSON.parse(zlib.gunzipSync(Buffer.from(raw[1], "base64")).toString("utf8"));
+  }
+  return JSON.parse(raw[1]);
+}
 
 describe("exportHtml module", function () {
   afterEach(function () {
@@ -28,67 +90,143 @@ describe("exportHtml module", function () {
     ).rejects.toThrow();
   });
 
-  it("embeds lazy chunks and worker assets in single-session exports", async function () {
-    var entryUrl = "https://example.test/assets/index-abc.js";
-    var chunkUrl = "https://example.test/assets/GraphView-def.js";
-    var sideEffectUrl = "https://example.test/assets/setup-jkl.js";
-    var workerUrl = "https://example.test/assets/elk-worker-ghi.js";
-    var responses = {};
-    responses[entryUrl] = new Response(
-      'import"./setup-jkl.js";import("./GraphView-def.js");'
-    );
-    responses[chunkUrl] = new Response(
-      'import{a}from"./index-abc.js";new URL("elk-worker-ghi.js",import.meta.url);'
-    );
-    responses[sideEffectUrl] = new Response('globalThis.__setup=true;');
-    responses[workerUrl] = new Response("self.onmessage=function(){};", {
-      headers: { "Content-Type": "text/javascript" },
-    });
+  it("embeds lazy chunks and worker assets without data: URL modules", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var html = await captured.blob.text();
 
-    var downloadedBlob = null;
-    var anchor = { click: vi.fn() };
-    vi.stubGlobal("document", {
-      querySelector: vi.fn(function () { return { src: entryUrl }; }),
-      createElement: vi.fn(function () { return anchor; }),
-      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+    expect(fetch).toHaveBeenCalledWith(ENTRY_URL);
+    expect(fetch).toHaveBeenCalledWith(CHUNK_URL);
+    expect(fetch).toHaveBeenCalledWith(SIDE_EFFECT_URL);
+    expect(fetch).toHaveBeenCalledWith(WORKER_URL);
+
+    // WebKit refuses module scripts from data: URLs, and import maps keyed by
+    // the exporting server's URLs only resolve on the author's machine.
+    expect(html).not.toContain('<script type="importmap">');
+    expect(html).not.toContain("data:text/javascript");
+    expect(html).toContain("window.__AGENTVIZ_STANDALONE__ = true");
+  });
+
+  it("never references the exporting origin in the generated file", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var html = await captured.blob.text();
+    var payload = readPayload(html);
+
+    expect(html).not.toContain("https://example.test");
+    expect(JSON.stringify(payload.modules)).not.toContain("https://example.test");
+    expect(JSON.stringify(payload.assets)).not.toContain("https://example.test");
+  });
+
+  it("rewrites static imports to tokens and dynamic imports to a runtime lookup", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var payload = readPayload(await captured.blob.text());
+
+    var moduleIds = Object.keys(payload.modules);
+    expect(moduleIds).toHaveLength(3);
+    expect(payload.order).toHaveLength(3);
+
+    var entrySource = payload.modules[payload.entry];
+    expect(entrySource).toContain('import(window.__AGENTVIZ_MODULE_URLS__[');
+    expect(entrySource).not.toContain('import("./GraphView-def.js")');
+    expect(entrySource).toMatch(/import"__AGENTVIZ_MODULE_m\d+__"/);
+
+    var chunkId = payload.order.filter(function (id) {
+      return payload.modules[id].indexOf("import.meta.url") !== -1;
+    })[0];
+    expect(payload.modules[chunkId]).toMatch(/from"__AGENTVIZ_MODULE_m\d+__"/);
+    expect(payload.modules[chunkId]).toMatch(/new URL\("__AGENTVIZ_ASSET_a\d+__",import\.meta\.url\)/);
+    expect(payload.modules[chunkId]).not.toContain("elk-worker-ghi.js");
+
+    // Text assets are embedded as text so gzip can compress them.
+    var assetIds = Object.keys(payload.assets);
+    expect(assetIds).toHaveLength(1);
+    expect(payload.assets[assetIds[0]].text).toBe("self.onmessage=function(){};");
+  });
+
+  it("orders modules so static dependencies are created first", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var payload = readPayload(await captured.blob.text());
+
+    var chunkId = payload.order.filter(function (id) {
+      return payload.modules[id].indexOf("import.meta.url") !== -1;
+    })[0];
+    expect(payload.order.indexOf(payload.entry)).toBeLessThan(payload.order.indexOf(chunkId));
+  });
+
+  it("embeds the session payload for the offline /api shim", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var html = await captured.blob.text();
+    var payload = readPayload(html);
+
+    expect(payload.session).toEqual({ filename: "trace.jsonl", text: '{"type":"session.start"}' });
+    expect(html).toContain("/api/meta");
+    expect(html).toContain("/api/file");
+    expect(html).toContain("/api/sessions");
+    expect(html).toContain("/api/config");
+    expect(html).toContain("Not available in exported view");
+  });
+
+  it("embeds both sessions for a comparison export", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportComparison("text-a", "a.jsonl", "text-b", "b.jsonl");
+    var payload = readPayload(await captured.blob.text());
+
+    expect(payload.compare).toEqual({
+      a: { name: "a.jsonl", text: "text-a" },
+      b: { name: "b.jsonl", text: "text-b" },
     });
-    vi.stubGlobal("fetch", vi.fn(function (url) {
-      return Promise.resolve(responses[url].clone());
-    }));
-    vi.stubGlobal("URL", Object.assign(URL, {
-      createObjectURL: vi.fn(function (blob) {
-        downloadedBlob = blob;
-        return "blob:export";
-      }),
-      revokeObjectURL: vi.fn(),
-    }));
-    vi.stubGlobal("btoa", function (value) {
-      return Buffer.from(value, "binary").toString("base64");
+    expect(payload.session).toBeUndefined();
+  });
+
+  it("renders a boot-failure fallback and no webfont request", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
+    var html = await captured.blob.text();
+
+    expect(html).toContain("This AGENTVIZ export failed to load");
+    expect(html).toContain('window.addEventListener("error"');
+    expect(html).toContain('window.addEventListener("unhandledrejection"');
+    expect(html).toContain("<noscript>");
+    expect(html).not.toContain("fonts.googleapis.com");
+    expect(html).toContain('--av-bg-base');
+    expect(html).toContain('data-theme="light"');
+  });
+
+  it("fails loudly when a bundle source still references the exporting origin", async function () {
+    var responses = buildResponses();
+    responses[SIDE_EFFECT_URL] = new Response('globalThis.__api="https://example.test/api";');
+    var captured = stubBrowser(responses);
+    vi.stubGlobal("window", {
+      location: { origin: "https://example.test", host: "example.test" },
     });
 
     var mod = await import("../lib/exportHtml.js");
-    await mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl");
-    var html = await downloadedBlob.text();
+    await expect(
+      mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl")
+    ).rejects.toThrow(/only work on this machine/);
+    expect(captured.blob).toBeNull();
+  });
 
-    expect(fetch).toHaveBeenCalledWith(entryUrl);
-    expect(fetch).toHaveBeenCalledWith(chunkUrl);
-    expect(fetch).toHaveBeenCalledWith(sideEffectUrl);
-    expect(fetch).toHaveBeenCalledWith(workerUrl);
-    expect(html).toContain('<script type="importmap">');
-    expect(html).toContain("window.__AGENTVIZ_STANDALONE__ = true");
-    expect(html).not.toContain('import("./GraphView-def.js")');
+  it("fails loudly when the bundle has a static import cycle", async function () {
+    var responses = buildResponses({});
+    responses[ENTRY_URL] = new Response('import"./setup-jkl.js";');
+    responses[SIDE_EFFECT_URL] = new Response('import"./index-abc.js";');
+    stubBrowser(responses);
 
-    var importMapText = html.match(/<script type="importmap">(.*?)<\/script>/)[1];
-    var importMap = JSON.parse(importMapText);
-    expect(importMap.imports[entryUrl]).toMatch(/^data:text\/javascript;base64,/);
-    expect(importMap.imports[chunkUrl]).toMatch(/^data:text\/javascript;base64,/);
-    expect(importMap.imports[sideEffectUrl]).toMatch(/^data:text\/javascript;base64,/);
-
-    var chunkSource = Buffer.from(
-      importMap.imports[chunkUrl].split(",")[1],
-      "base64"
-    ).toString("utf8");
-    expect(chunkSource).toContain("data:text/javascript;base64,");
-    expect(chunkSource).not.toContain("elk-worker-ghi.js");
+    var mod = await import("../lib/exportHtml.js");
+    await expect(
+      mod.exportSingleSession('{"type":"session.start"}', "trace.jsonl")
+    ).rejects.toThrow(/static import cycle/);
   });
 });

--- a/src/lib/exportHtml.js
+++ b/src/lib/exportHtml.js
@@ -1,23 +1,109 @@
 // Builds a self-contained single-file HTML export for sharing sessions.
-// Single session: overrides window.fetch to serve embedded JSONL via the
-//   existing /api/meta + /api/file endpoints that useSessionLoader already
-//   calls on startup.
+//
+// Portability rules this file must keep:
+//   1. The exported HTML never references the exporting machine's origin.
+//      Module sources are embedded as strings and turned into blob: URLs at
+//      boot, so nothing is fetched from http://127.0.0.1:<port> on the
+//      recipient's machine.
+//   2. Modules are loaded from blob: URLs rather than data: URLs, because
+//      WebKit refuses to evaluate module scripts served from data: URLs.
+//   3. Every network dependency is either embedded or stubbed. Fonts fall back
+//      to the local monospace stack and all /api/* calls are answered locally.
+//
+// Single session: the embedded fetch shim serves the session through the
+//   existing /api/meta + /api/file endpoints that useSessionLoader calls on
+//   startup.
 // Comparison: sets window.__AGENTVIZ_COMPARE__ which App.jsx reads on mount.
 
+var THEME_BOOTSTRAP = `
+  (function () {
+    var storageKey = "agentviz:theme-mode";
+    var preference = "dark";
+    try {
+      var raw = localStorage.getItem(storageKey);
+      if (raw) {
+        try { raw = JSON.parse(raw); } catch (e) { /* use as-is */ }
+        if (raw === "light" || raw === "dark" || raw === "system") preference = raw;
+      }
+    } catch (error) {
+      preference = "dark";
+    }
+    var isLight = window.matchMedia && window.matchMedia("(prefers-color-scheme: light)").matches;
+    var resolved = preference === "light" || preference === "dark" ? preference : (isLight ? "light" : "dark");
+    var tokens = resolved === "light" ? {
+      bgBase: "#f6f7fb",
+      bgSurface: "#ffffff",
+      bgHover: "#e5e9f2",
+      bgActive: "#d8deea",
+      focus: "#6475e8",
+      border: "#d8deea",
+      borderStrong: "#c2cad8",
+      textPrimary: "#141824",
+      textSecondary: "#4f5669"
+    } : {
+      bgBase: "#000000",
+      bgSurface: "#0f0f16",
+      bgHover: "#20202e",
+      bgActive: "#26263a",
+      focus: "#6475e8",
+      border: "#232333",
+      borderStrong: "#2e2e42",
+      textPrimary: "#f0f0f2",
+      textSecondary: "#a1a1a8"
+    };
+    var root = document.documentElement;
+    root.dataset.theme = resolved;
+    root.dataset.themePreference = preference;
+    root.style.colorScheme = resolved;
+    root.style.setProperty("--av-bg-base", tokens.bgBase);
+    root.style.setProperty("--av-bg-surface", tokens.bgSurface);
+    root.style.setProperty("--av-bg-hover", tokens.bgHover);
+    root.style.setProperty("--av-bg-active", tokens.bgActive);
+    root.style.setProperty("--av-focus", tokens.focus);
+    root.style.setProperty("--av-border", tokens.border);
+    root.style.setProperty("--av-border-strong", tokens.borderStrong);
+    root.style.setProperty("--av-text-primary", tokens.textPrimary);
+    root.style.setProperty("--av-text-secondary", tokens.textSecondary);
+  }());
+`;
+
+// The font stack intentionally has no webfont link: an exported file is often
+// opened offline, so it falls back to whatever monospace the reader has.
 var INLINE_STYLES = `
   :root {
+    --av-bg-base: #000000;
+    --av-bg-surface: #0f0f16;
     --av-bg-hover: #20202e;
     --av-bg-active: #26263a;
     --av-focus: #6475e8;
-    --av-border: #2c2c30;
-    --av-border-strong: #3a3a3f;
+    --av-border: #232333;
+    --av-border-strong: #2e2e42;
+    --av-text-primary: #f0f0f2;
+    --av-text-secondary: #a1a1a8;
+  }
+  :root[data-theme="light"] {
+    --av-bg-base: #f6f7fb;
+    --av-bg-surface: #ffffff;
+    --av-bg-hover: #e5e9f2;
+    --av-bg-active: #d8deea;
+    --av-focus: #6475e8;
+    --av-border: #d8deea;
+    --av-border-strong: #c2cad8;
+    --av-text-primary: #141824;
+    --av-text-secondary: #4f5669;
   }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body { background: #000000; overflow: hidden; font-family: 'JetBrains Mono', monospace; }
+  html { background: var(--av-bg-base); }
+  body {
+    background: var(--av-bg-base);
+    color: var(--av-text-primary);
+    overflow: hidden;
+    font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
   ::-webkit-scrollbar { width: 6px; height: 6px; }
   ::-webkit-scrollbar-track { background: transparent; }
-  ::-webkit-scrollbar-thumb { background: #3a3a3f; border-radius: 3px; }
-  ::-webkit-scrollbar-thumb:hover { background: #45454b; }
+  ::-webkit-scrollbar-thumb { background: var(--av-border-strong); border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: var(--av-text-secondary); }
   *:focus-visible { outline: 2px solid var(--av-focus); outline-offset: 2px; }
   *:focus:not(:focus-visible) { outline: none; }
   .av-btn { cursor: pointer; transition: background 80ms ease-out, border-color 80ms ease-out, color 80ms ease-out; }
@@ -27,6 +113,18 @@ var INLINE_STYLES = `
   .av-interactive:hover { background: var(--av-bg-hover); }
   .av-search:focus { border-color: var(--av-focus) !important; outline: none !important; }
   .av-search-wrap:focus-within { border-color: var(--av-focus) !important; }
+  .av-export-status {
+    display: flex; flex-direction: column; gap: 12px; align-items: flex-start;
+    padding: 32px; max-width: 720px; overflow: auto; height: 100vh;
+  }
+  .av-export-status h1 { font-size: 13px; letter-spacing: 0.12em; text-transform: uppercase; }
+  .av-export-status p { font-size: 12px; line-height: 1.7; color: var(--av-text-secondary); }
+  .av-export-status pre {
+    font-size: 11px; line-height: 1.6; color: var(--av-text-secondary);
+    background: var(--av-bg-surface); border: 1px solid var(--av-border);
+    border-radius: 4px; padding: 12px; white-space: pre-wrap; word-break: break-word;
+    max-width: 100%;
+  }
   @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
   @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
   @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
@@ -38,72 +136,263 @@ var INLINE_STYLES = `
   }
 `;
 
+// Runs before any module code: decodes the embedded payload, installs the
+// offline /api shim, materializes every chunk as a blob: URL, and imports the
+// entry module. Any failure before the app mounts renders a readable message
+// instead of leaving a blank page behind.
+var BOOT_SCRIPT = `
+(function () {
+  window.__AGENTVIZ_STANDALONE__ = true;
+
+  var PAYLOAD = "__AGENTVIZ_PAYLOAD__";
+  var COMPRESSED = __AGENTVIZ_COMPRESSED__;
+  var booted = false;
+
+  function showFailure(detail) {
+    if (booted) return;
+    var root = document.getElementById("root");
+    if (!root) return;
+    while (root.firstChild) root.removeChild(root.firstChild);
+    var box = document.createElement("div");
+    box.className = "av-export-status";
+    var heading = document.createElement("h1");
+    heading.textContent = "This AGENTVIZ export failed to load";
+    var intro = document.createElement("p");
+    intro.textContent = "The session data is embedded in this file, but your browser could not start the viewer.";
+    var hint = document.createElement("p");
+    hint.textContent = "Exports need a browser with blob URL modules, dynamic import, and DecompressionStream: Chrome 80+, Edge 80+, Firefox 113+, or Safari 16.4+. Try opening this file in an up-to-date Chrome or Firefox, and make sure it is opened as a local file rather than previewed inside a mail or chat client.";
+    box.appendChild(heading);
+    box.appendChild(intro);
+    box.appendChild(hint);
+    if (detail) {
+      var pre = document.createElement("pre");
+      pre.textContent = String(detail);
+      box.appendChild(pre);
+    }
+    root.appendChild(box);
+  }
+
+  window.addEventListener("error", function (event) {
+    showFailure(event && event.message ? event.message : "Script error");
+  });
+  window.addEventListener("unhandledrejection", function (event) {
+    var reason = event && event.reason;
+    showFailure(reason && reason.message ? reason.message : String(reason));
+  });
+
+  function decodeBase64(value) {
+    var binary = atob(value);
+    var bytes = new Uint8Array(binary.length);
+    for (var i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return bytes;
+  }
+
+  function readPayload() {
+    if (!COMPRESSED) return Promise.resolve(JSON.parse(PAYLOAD));
+    if (typeof DecompressionStream === "undefined") {
+      return Promise.reject(new Error("DecompressionStream is not supported by this browser."));
+    }
+    var stream = new Blob([decodeBase64(PAYLOAD)]).stream().pipeThrough(new DecompressionStream("gzip"));
+    return new Response(stream).text().then(function (text) { return JSON.parse(text); });
+  }
+
+  function jsonResponse(body, status) {
+    return Promise.resolve(new Response(JSON.stringify(body), {
+      status: status || 200,
+      headers: { "Content-Type": "application/json" }
+    }));
+  }
+
+  // Everything under /api/* is answered locally. Unhandled routes get an
+  // explicit 501 so features that need the CLI backend fail with a message
+  // instead of throwing "URL scheme file: is not supported".
+  function installFetchShim(payload) {
+    var session = payload.session || null;
+    var originalFetch = window.fetch ? window.fetch.bind(window) : null;
+    window.fetch = function (input, init) {
+      var target = String(input && input.url ? input.url : input);
+      var apiIndex = target.indexOf("/api/");
+      if (apiIndex === -1) {
+        if (originalFetch) return originalFetch(input, init);
+        return Promise.reject(new Error("Network requests are unavailable in this exported view."));
+      }
+      var route = target.slice(apiIndex);
+      if (session && route.indexOf("/api/meta") === 0) {
+        return jsonResponse({ filename: session.filename, live: false });
+      }
+      if (session && route.indexOf("/api/file") === 0) {
+        return Promise.resolve(new Response(session.text, {
+          status: 200,
+          headers: { "Content-Type": "text/plain" }
+        }));
+      }
+      if (route.indexOf("/api/sessions") === 0) return jsonResponse([]);
+      if (route.indexOf("/api/config") === 0) return jsonResponse([]);
+      return jsonResponse({
+        error: "Not available in exported view",
+        exported: true,
+        route: route
+      }, 501);
+    };
+  }
+
+  function materialize(payload) {
+    var assetUrls = {};
+    Object.keys(payload.assets).forEach(function (id) {
+      var asset = payload.assets[id];
+      var parts = asset.text != null ? [asset.text] : [decodeBase64(asset.base64)];
+      assetUrls[id] = URL.createObjectURL(new Blob(parts, { type: asset.mime }));
+    });
+
+    var moduleUrls = {};
+    window.__AGENTVIZ_MODULE_URLS__ = moduleUrls;
+    payload.order.forEach(function (id) {
+      var source = payload.modules[id].replace(
+        /__AGENTVIZ_(MODULE|ASSET)_([A-Za-z0-9]+)__/g,
+        function (full, kind, key) {
+          var url = kind === "MODULE" ? moduleUrls[key] : assetUrls[key];
+          return url || full;
+        }
+      );
+      moduleUrls[id] = URL.createObjectURL(new Blob([source], { type: "text/javascript" }));
+    });
+    return moduleUrls[payload.entry];
+  }
+
+  readPayload().then(function (payload) {
+    if (payload.compare) window.__AGENTVIZ_COMPARE__ = payload.compare;
+    installFetchShim(payload);
+    return import(materialize(payload));
+  }).then(function () {
+    booted = true;
+  }).catch(function (error) {
+    showFailure(error && error.message ? error.message : String(error));
+  });
+}());
+`;
+
 // JSON-serialize a value so it is safe to embed inside a <script> block.
 // Escapes <, >, and & to prevent HTML parser from seeing </script> etc.
 function jsonSafe(value) {
   return JSON.stringify(value)
     .replace(/</g, "\\u003c")
     .replace(/>/g, "\\u003e")
-    .replace(/&/g, "\\u0026");
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
 }
 
 function escapeHtmlAttr(str) {
   return str.replace(/&/g, "&amp;").replace(/"/g, "&quot;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
-function bytesToDataUrl(bytes, mimeType) {
+function bytesToBase64(bytes) {
   var binary = "";
   var chunkSize = 0x8000;
   for (var i = 0; i < bytes.length; i += chunkSize) {
     binary += String.fromCharCode.apply(null, bytes.subarray(i, i + chunkSize));
   }
-  return "data:" + mimeType + ";base64," + btoa(binary);
+  return btoa(binary);
 }
 
-function textToDataUrl(text, mimeType) {
-  return bytesToDataUrl(new TextEncoder().encode(text), mimeType);
+function isTextAsset(mimeType) {
+  return /^text\//.test(mimeType) || /(javascript|json|xml|\+xml)/.test(mimeType);
 }
 
-function findModuleSpecifiers(source) {
-  var specifiers = [];
-  var pattern = /(?:\bfrom\s*|\bimport\s*\(\s*|\bimport\s*)(["'])([^"']+)\1/g;
+var DYNAMIC_IMPORT_PATTERN = /\bimport\s*\(\s*(["'])([^"']+)\1\s*\)/g;
+var STATIC_IMPORT_PATTERN = /(\bfrom\s*|\bimport\s*)(["'])([^"']+)\2/g;
+var ASSET_URL_PATTERN = /new URL\(\s*(["'])([^"'\\\s+]+)\1\s*,\s*import\.meta\.url\s*\)/g;
+
+function collectMatches(source, pattern, groupIndex) {
+  var found = [];
+  var scoped = new RegExp(pattern.source, pattern.flags);
   var match;
-  while ((match = pattern.exec(source)) !== null) {
-    specifiers.push(match[2]);
+  while ((match = scoped.exec(source)) !== null) {
+    found.push(match[groupIndex]);
   }
-  return specifiers;
+  return found;
+}
+
+function isRelative(specifier) {
+  return specifier.startsWith(".");
+}
+
+function findStaticSpecifiers(source) {
+  return collectMatches(source, STATIC_IMPORT_PATTERN, 3).filter(isRelative);
+}
+
+function findDynamicSpecifiers(source) {
+  return collectMatches(source, DYNAMIC_IMPORT_PATTERN, 2).filter(isRelative);
 }
 
 function findAssetSpecifiers(source) {
-  var specifiers = [];
-  var pattern = /new URL\(\s*(["'])([^"'\\\s+]+)\1\s*,\s*import\.meta\.url\s*\)/g;
-  var match;
-  while ((match = pattern.exec(source)) !== null) {
-    specifiers.push(match[2]);
-  }
-  return specifiers;
+  return collectMatches(source, ASSET_URL_PATTERN, 2);
 }
 
-function rewriteModuleSpecifiers(source, moduleUrl) {
-  return source.replace(
-    /(\bfrom\s*|\bimport\s*\(\s*|\bimport\s*)(["'])([^"']+)\2/g,
-    function (full, prefix, quote, specifier) {
-      if (!specifier.startsWith(".")) return full;
-      return prefix + quote + new URL(specifier, moduleUrl).href + quote;
-    }
-  );
+function moduleToken(id) {
+  return "__AGENTVIZ_MODULE_" + id + "__";
 }
 
-function rewriteAssetSpecifiers(source, moduleUrl, assetDataUrls) {
-  return source.replace(
-    /new URL\(\s*(["'])([^"'\\\s+]+)\1\s*,\s*import\.meta\.url\s*\)/g,
+function assetToken(id) {
+  return "__AGENTVIZ_ASSET_" + id + "__";
+}
+
+// Rewrites a chunk so it no longer refers to any URL on the exporting server.
+// Static imports and asset URLs become placeholder tokens that the boot script
+// swaps for blob: URLs; dynamic imports resolve through a runtime lookup so a
+// chunk can reference modules that are created after it.
+function rewriteSource(source, moduleUrl, moduleIds, assetIds) {
+  var rewritten = source.replace(
+    DYNAMIC_IMPORT_PATTERN,
     function (full, quote, specifier) {
-      var assetUrl = new URL(specifier, moduleUrl).href;
-      var dataUrl = assetDataUrls[assetUrl];
-      if (!dataUrl) return full;
-      return "new URL(" + quote + dataUrl + quote + ",import.meta.url)";
+      if (!isRelative(specifier)) return full;
+      var id = moduleIds[new URL(specifier, moduleUrl).href];
+      if (!id) return full;
+      return "import(window.__AGENTVIZ_MODULE_URLS__[" + quote + id + quote + "])";
     }
   );
+
+  rewritten = rewritten.replace(
+    STATIC_IMPORT_PATTERN,
+    function (full, prefix, quote, specifier) {
+      if (!isRelative(specifier)) return full;
+      var id = moduleIds[new URL(specifier, moduleUrl).href];
+      if (!id) return full;
+      return prefix + quote + moduleToken(id) + quote;
+    }
+  );
+
+  return rewritten.replace(
+    ASSET_URL_PATTERN,
+    function (full, quote, specifier) {
+      var id = assetIds[new URL(specifier, moduleUrl).href];
+      if (!id) return full;
+      return "new URL(" + quote + assetToken(id) + quote + ",import.meta.url)";
+    }
+  );
+}
+
+// Dependencies first, so each blob: URL exists before the modules that
+// statically import it are created.
+function topologicalOrder(moduleIds, staticDeps) {
+  var order = [];
+  var state = {};
+
+  function visit(moduleUrl) {
+    if (state[moduleUrl] === "done") return;
+    if (state[moduleUrl] === "visiting") {
+      throw new Error(
+        "Export failed: the production bundle contains a static import cycle involving " + moduleUrl + "."
+      );
+    }
+    state[moduleUrl] = "visiting";
+    (staticDeps[moduleUrl] || []).forEach(visit);
+    state[moduleUrl] = "done";
+    order.push(moduleIds[moduleUrl]);
+  }
+
+  Object.keys(moduleIds).forEach(visit);
+  return order;
 }
 
 async function fetchBundleGraph() {
@@ -117,19 +406,23 @@ async function fetchBundleGraph() {
 
   var entryUrl = scriptEl.src;
   var moduleSources = {};
-  var assetDataUrls = {};
+  var assetPayloads = {};
   var pendingModules = {};
   var pendingAssets = {};
 
   async function fetchAsset(assetUrl) {
-    if (assetDataUrls[assetUrl]) return;
+    if (assetPayloads[assetUrl]) return;
     if (pendingAssets[assetUrl]) return pendingAssets[assetUrl];
 
     pendingAssets[assetUrl] = fetch(assetUrl).then(async function (resp) {
       if (!resp.ok) throw new Error("Failed to fetch export asset: HTTP " + resp.status);
       var mimeType = resp.headers.get("Content-Type") || "application/octet-stream";
+      if (isTextAsset(mimeType)) {
+        assetPayloads[assetUrl] = { mime: mimeType, text: await resp.text() };
+        return;
+      }
       var buffer = await resp.arrayBuffer();
-      assetDataUrls[assetUrl] = bytesToDataUrl(new Uint8Array(buffer), mimeType);
+      assetPayloads[assetUrl] = { mime: mimeType, base64: bytesToBase64(new Uint8Array(buffer)) };
     });
     return pendingAssets[assetUrl];
   }
@@ -143,8 +436,8 @@ async function fetchBundleGraph() {
       var source = await resp.text();
       moduleSources[moduleUrl] = source;
 
-      var moduleUrls = findModuleSpecifiers(source)
-        .filter(function (specifier) { return specifier.startsWith("."); })
+      var moduleUrls = findStaticSpecifiers(source)
+        .concat(findDynamicSpecifiers(source))
         .map(function (specifier) { return new URL(specifier, moduleUrl).href; });
       var assetUrls = findAssetSpecifiers(source)
         .map(function (specifier) { return new URL(specifier, moduleUrl).href; });
@@ -158,36 +451,120 @@ async function fetchBundleGraph() {
 
   await fetchModule(entryUrl);
 
-  var imports = {};
-  Object.keys(moduleSources).forEach(function (moduleUrl) {
-    var source = rewriteModuleSpecifiers(moduleSources[moduleUrl], moduleUrl);
-    source = rewriteAssetSpecifiers(source, moduleUrl, assetDataUrls);
-    imports[moduleUrl] = textToDataUrl(source, "text/javascript");
+  var moduleIds = {};
+  Object.keys(moduleSources).forEach(function (moduleUrl, index) {
+    moduleIds[moduleUrl] = "m" + index;
+  });
+  var assetIds = {};
+  Object.keys(assetPayloads).forEach(function (assetUrl, index) {
+    assetIds[assetUrl] = "a" + index;
   });
 
-  return { entryUrl: entryUrl, imports: imports };
+  var modules = {};
+  var assets = {};
+  var staticDeps = {};
+
+  Object.keys(moduleSources).forEach(function (moduleUrl) {
+    staticDeps[moduleUrl] = findStaticSpecifiers(moduleSources[moduleUrl])
+      .map(function (specifier) { return new URL(specifier, moduleUrl).href; })
+      .filter(function (depUrl) { return Boolean(moduleIds[depUrl]); });
+    modules[moduleIds[moduleUrl]] = rewriteSource(moduleSources[moduleUrl], moduleUrl, moduleIds, assetIds);
+  });
+  Object.keys(assetPayloads).forEach(function (assetUrl) {
+    assets[assetIds[assetUrl]] = assetPayloads[assetUrl];
+  });
+
+  return {
+    entry: moduleIds[entryUrl],
+    order: topologicalOrder(moduleIds, staticDeps),
+    modules: modules,
+    assets: assets,
+  };
 }
 
-function buildHtml(title, setupScript, bundleGraph) {
-  var importMap = jsonSafe({ imports: bundleGraph.imports });
+// A single origin reference would make the export work only on the machine
+// that produced it, so this fails the export instead of shipping the file.
+function assertNoOriginReferences(bundleGraph) {
+  var origin = typeof window !== "undefined" && window.location ? window.location.origin : null;
+  var host = typeof window !== "undefined" && window.location ? window.location.host : null;
+  var candidates = [origin, host].filter(function (value) {
+    return Boolean(value) && value !== "null";
+  });
+  if (candidates.length === 0) return;
+
+  var serialized = JSON.stringify({ modules: bundleGraph.modules, assets: bundleGraph.assets });
+  candidates.forEach(function (needle) {
+    if (serialized.indexOf(needle) !== -1) {
+      throw new Error(
+        "Export aborted: the generated bundle still references " + needle + ", " +
+        "so the file would only work on this machine. Please report this as an AGENTVIZ bug."
+      );
+    }
+  });
+}
+
+async function encodePayload(payload) {
+  var json = JSON.stringify(payload);
+  if (typeof CompressionStream === "undefined") {
+    return { compressed: false, data: json };
+  }
+  var stream = new Blob([json]).stream().pipeThrough(new CompressionStream("gzip"));
+  var buffer = await new Response(stream).arrayBuffer();
+  return { compressed: true, data: bytesToBase64(new Uint8Array(buffer)) };
+}
+
+function buildBootScript(encoded) {
+  // Function replacements keep `$` sequences inside minified sources literal.
+  var body = BOOT_SCRIPT
+    .replace('"__AGENTVIZ_PAYLOAD__"', function () { return jsonSafe(encoded.data); })
+    .replace("__AGENTVIZ_COMPRESSED__", function () { return encoded.compressed ? "true" : "false"; });
+  return "<script>" + body + "</" + "script>";
+}
+
+function buildHtml(title, bootScript) {
   return "<!DOCTYPE html>\n" +
     '<html lang="en">\n' +
     "<head>\n" +
     '  <meta charset="UTF-8" />\n' +
     '  <meta name="viewport" content="width=device-width, initial-scale=1.0" />\n' +
     "  <title>" + escapeHtmlAttr(title) + "</title>\n" +
-    '  <link rel="preconnect" href="https://fonts.googleapis.com" />\n' +
-    '  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />\n' +
-    '  <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />\n' +
+    "  <script>" + THEME_BOOTSTRAP + "  </" + "script>\n" +
     "  <style>" + INLINE_STYLES + "  </style>\n" +
     "</head>\n" +
     "<body>\n" +
-    '  <div id="root"></div>\n' +
-    (setupScript ? "  " + setupScript + "\n" : "") +
-    '  <script type="importmap">' + importMap + "</" + "script>\n" +
-    '  <script type="module">import(' + jsonSafe(bundleGraph.entryUrl) + ");</" + "script>\n" +
+    '  <div id="root">\n' +
+    '    <div class="av-export-status">\n' +
+    "      <h1>AGENTVIZ</h1>\n" +
+    "      <p>Loading the embedded session...</p>\n" +
+    "    </div>\n" +
+    "  </div>\n" +
+    "  <noscript>\n" +
+    "    <div class=\"av-export-status\">\n" +
+    "      <h1>JavaScript required</h1>\n" +
+    "      <p>This AGENTVIZ export renders its session with JavaScript. Enable JavaScript and reload this file.</p>\n" +
+    "    </div>\n" +
+    "  </noscript>\n" +
+    "  " + bootScript + "\n" +
     "</body>\n" +
     "</html>";
+}
+
+async function buildExportHtml(title, extraPayload) {
+  var bundleGraph = await fetchBundleGraph();
+  assertNoOriginReferences(bundleGraph);
+
+  var payload = {
+    entry: bundleGraph.entry,
+    order: bundleGraph.order,
+    modules: bundleGraph.modules,
+    assets: bundleGraph.assets,
+  };
+  Object.keys(extraPayload).forEach(function (key) {
+    payload[key] = extraPayload[key];
+  });
+
+  var encoded = await encodePayload(payload);
+  return buildHtml(title, buildBootScript(encoded));
 }
 
 function downloadHtml(html, filename) {
@@ -205,45 +582,17 @@ function downloadHtml(html, filename) {
 // Export a single session as a self-contained HTML file.
 // rawText: the full JSONL content; filename: original file name.
 export async function exportSingleSession(rawText, filename) {
-  var bundleGraph = await fetchBundleGraph();
-
-  var metaPayload = jsonSafe({ filename: filename, live: false });
-  var rawTextPayload = jsonSafe(rawText);
-
-  // Runs synchronously before the module, overriding fetch for the two API
-  // endpoints that useSessionLoader calls during its initFromUrl effect.
-  var setupScript =
-    "<script>\n" +
-    "(function() {\n" +
-    "  window.__AGENTVIZ_STANDALONE__ = true;\n" +
-    "  var _orig = window.fetch;\n" +
-    "  var _meta = " + metaPayload + ";\n" +
-    "  var _text = " + rawTextPayload + ";\n" +
-    "  window.fetch = function(url, opts) {\n" +
-    "    var s = String(url);\n" +
-    '    if (s.indexOf("/api/meta") !== -1) {\n' +
-    '      return Promise.resolve(new Response(JSON.stringify(_meta), { status: 200, headers: { "Content-Type": "application/json" } }));\n' +
-    "    }\n" +
-    '    if (s.indexOf("/api/file") !== -1) {\n' +
-    '      return Promise.resolve(new Response(_text, { status: 200, headers: { "Content-Type": "text/plain" } }));\n' +
-    "    }\n" +
-    "    return _orig.apply(window, arguments);\n" +
-    "  };\n" +
-    "})();\n" +
-    "</" + "script>";
-
+  var html = await buildExportHtml("AGENTVIZ - " + filename, {
+    session: { filename: filename, text: rawText },
+  });
   var exportName = filename.replace(/\.jsonl$/, "") + "-agentviz.html";
-  downloadHtml(buildHtml("AGENTVIZ - " + filename, setupScript, bundleGraph), exportName);
+  downloadHtml(html, exportName);
 }
 
 // Export a side-by-side comparison as a self-contained HTML file.
 export async function exportComparison(rawTextA, filenameA, rawTextB, filenameB) {
-  var bundleGraph = await fetchBundleGraph();
-
-  var comparePayload = jsonSafe({ a: { name: filenameA, text: rawTextA }, b: { name: filenameB, text: rawTextB } });
-
-  var setupScript =
-    "<script>window.__AGENTVIZ_STANDALONE__ = true; window.__AGENTVIZ_COMPARE__ = " + comparePayload + ";</" + "script>";
-
-  downloadHtml(buildHtml("AGENTVIZ - Comparison", setupScript, bundleGraph), "comparison-agentviz.html");
+  var html = await buildExportHtml("AGENTVIZ - Comparison", {
+    compare: { a: { name: filenameA, text: rawTextA }, b: { name: filenameB, text: rawTextB } },
+  });
+  downloadHtml(html, "comparison-agentviz.html");
 }

--- a/tests/e2e/export-portability.spec.js
+++ b/tests/e2e/export-portability.spec.js
@@ -1,0 +1,128 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { expect, test } from "@playwright/test";
+
+import { createServer } from "../../server.js";
+
+// Regression guard for shared exports. The exported HTML must render on a
+// machine that has never run AGENTVIZ: no origin URLs, no data: URL modules,
+// and no live /api backend. Everything here runs from file:// with all network
+// access blocked, which is how a recipient opens the file.
+
+var __dirname = path.dirname(fileURLToPath(import.meta.url));
+var repoRoot = path.resolve(__dirname, "..", "..");
+var distDir = path.join(repoRoot, "dist");
+var fixturePath = path.join(repoRoot, "src", "__tests__", "fixtures", "test-copilot.jsonl");
+
+var server = null;
+var origin = null;
+var exportPath = null;
+
+test.beforeAll(async function ({ browser }) {
+  if (!fs.existsSync(path.join(distDir, "index.html"))) {
+    throw new Error(
+      "dist/ is missing. Run `npm run build` first, or use `npm run test:e2e:export`."
+    );
+  }
+
+  server = createServer({ sessionFile: null, distDir: distDir });
+  await new Promise(function (resolve) {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  origin = "http://127.0.0.1:" + server.address().port;
+
+  var context = await browser.newContext({ acceptDownloads: true });
+  var page = await context.newPage();
+  await page.goto(origin + "/");
+  await page.locator('input[type="file"]').setInputFiles(fixturePath);
+  await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+
+  var downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Export", exact: true }).first().click();
+  var download = await downloadPromise;
+
+  var dir = fs.mkdtempSync(path.join(os.tmpdir(), "agentviz-export-"));
+  exportPath = path.join(dir, "shared-session.html");
+  await download.saveAs(exportPath);
+  await context.close();
+});
+
+test.afterAll(async function () {
+  if (server) {
+    await new Promise(function (resolve) { server.close(resolve); });
+    server = null;
+  }
+});
+
+async function openOffline(browser) {
+  var context = await browser.newContext();
+  var attempted = [];
+  await context.route("**/*", function (route) {
+    var url = route.request().url();
+    if (url.startsWith("file://") || url.startsWith("blob:") || url.startsWith("data:")) {
+      return route.continue();
+    }
+    attempted.push(url);
+    return route.abort("connectionrefused");
+  });
+
+  var page = await context.newPage();
+  var failures = [];
+  page.on("pageerror", function (error) { failures.push("pageerror: " + error.message); });
+  page.on("console", function (message) {
+    if (message.type() === "error") failures.push("console: " + message.text());
+  });
+
+  await page.goto(pathToFileURL(exportPath).href);
+  return { context: context, page: page, attempted: attempted, failures: failures };
+}
+
+test("exported HTML has no reference to the exporting origin", async function () {
+  var html = fs.readFileSync(exportPath, "utf8");
+  expect(html).not.toContain(origin);
+  expect(html).not.toContain("127.0.0.1");
+  expect(html).not.toContain('<script type="importmap">');
+  expect(html).not.toContain("data:text/javascript");
+  expect(html).not.toContain("fonts.googleapis.com");
+});
+
+test("exported HTML renders the session from file:// with the network blocked", async function ({ browser }) {
+  var opened = await openOffline(browser);
+
+  await expect(opened.page.getByText("Ready", { exact: true })).toBeVisible({ timeout: 20000 });
+  await expect(opened.page.getByText("This AGENTVIZ export failed to load")).toHaveCount(0);
+
+  await opened.page.getByRole("button", { name: /Investigate/ }).click();
+  await expect(
+    opened.page.getByText("Can you add a hello world function to utils.js?")
+  ).toBeVisible();
+
+  expect(opened.attempted).toEqual([]);
+  expect(opened.failures).toEqual([]);
+  await opened.context.close();
+});
+
+test("exported HTML answers /api routes locally instead of failing on file://", async function ({ browser }) {
+  var opened = await openOffline(browser);
+  await expect(opened.page.getByText("Ready", { exact: true })).toBeVisible({ timeout: 20000 });
+
+  var stub = await opened.page.evaluate(async function () {
+    var coach = await fetch("/api/coach/analyze", { method: "POST" });
+    var sessions = await fetch("/api/sessions");
+    return {
+      coachStatus: coach.status,
+      coachBody: await coach.json(),
+      sessionsStatus: sessions.status,
+      sessionsBody: await sessions.json(),
+    };
+  });
+
+  expect(stub.coachStatus).toBe(501);
+  expect(stub.coachBody.error).toBe("Not available in exported view");
+  expect(stub.sessionsStatus).toBe(200);
+  expect(stub.sessionsBody).toEqual([]);
+  expect(opened.failures).toEqual([]);
+  await opened.context.close();
+});


### PR DESCRIPTION
Exported session reports should open directly from disk without requiring a local web server. Browser restrictions around `file://` module loading previously prevented the generated HTML from running as a truly portable artifact.

This change rewrites the export bootstrap to package its runtime assets into the document and load them through generated blob URLs. It preserves single-session and comparison exports while keeping the output self-contained, updates the export documentation, and adds Playwright coverage that opens a generated report through `file://` and verifies the interactive UI initializes.

## Testing

- Expanded unit coverage for generated HTML and loader behavior
- Added an end-to-end portability test for direct filesystem opening