### PR TITLE
Restrict npm publishing to repository owner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ permissions:
 
 jobs:
   publish:
+    if: github.actor == 'jayparikh'
+    environment: npm-publish
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- allow npm publication jobs only when initiated by jayparikh`n- require approval through the protected 
pm-publish environment before publishing