### PR TITLE
Avoid O(n) per-tick recompute of the replay event stream

### DIFF
--- a/src/__tests__/replayLayout.test.js
+++ b/src/__tests__/replayLayout.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildReplayLayout, getReplayWindow, clearEstimateCache } from "../lib/replayLayout.js";
+import { buildReplayLayout, getReplayWindow, clearEstimateCache, countVisibleEntries } from "../lib/replayLayout.js";
 
 function makeEntry(index, text) {
   return {
@@ -88,5 +88,41 @@ describe("getReplayWindow", function () {
 
     var windowed = getReplayWindow(items, 0, items[0].height + 4, 0);
     expect(windowed.map(function (item) { return item.entry.index; })).toEqual([0, 1]);
+  });
+});
+
+describe("countVisibleEntries", function () {
+  function entryAt(index, t) {
+    return { index: index, event: { t: t } };
+  }
+
+  it("returns 0 for empty or missing input", function () {
+    expect(countVisibleEntries([], 5)).toBe(0);
+    expect(countVisibleEntries(null, 5)).toBe(0);
+    expect(countVisibleEntries(undefined, 5)).toBe(0);
+  });
+
+  it("counts entries whose t is <= currentTime (inclusive boundary)", function () {
+    var entries = [entryAt(0, 0), entryAt(1, 1), entryAt(2, 2), entryAt(3, 3)];
+    expect(countVisibleEntries(entries, -1)).toBe(0);
+    expect(countVisibleEntries(entries, 0)).toBe(1);
+    expect(countVisibleEntries(entries, 1.5)).toBe(2);
+    expect(countVisibleEntries(entries, 3)).toBe(4);
+    expect(countVisibleEntries(entries, 99)).toBe(4);
+  });
+
+  it("includes all entries sharing the exact boundary time (ties)", function () {
+    var entries = [entryAt(0, 1), entryAt(1, 2), entryAt(2, 2), entryAt(3, 2), entryAt(4, 3)];
+    expect(countVisibleEntries(entries, 2)).toBe(4);
+  });
+
+  it("matches the equivalent filter on chronological entries", function () {
+    var entries = [];
+    for (var i = 0; i < 200; i++) entries.push(entryAt(i, i * 0.5));
+
+    for (var time = -1; time <= 101; time += 0.25) {
+      var expected = entries.filter(function (entry) { return entry.event.t <= time; }).length;
+      expect(countVisibleEntries(entries, time)).toBe(expected);
+    }
   });
 });

--- a/src/__tests__/replayLayout.test.js
+++ b/src/__tests__/replayLayout.test.js
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { buildReplayLayout, getReplayWindow, clearEstimateCache, countVisibleEntries } from "../lib/replayLayout.js";
+import { buildReplayLayout, getReplayWindow, clearEstimateCache, buildVisibilityIndex, countVisibleAtTime } from "../lib/replayLayout.js";
+import { parseClaudeCodeJSONL } from "../lib/parser.ts";
+import { buildFilteredEventEntries } from "../lib/session.ts";
 
 function makeEntry(index, text) {
   return {
@@ -91,38 +93,145 @@ describe("getReplayWindow", function () {
   });
 });
 
-describe("countVisibleEntries", function () {
+describe("buildVisibilityIndex + countVisibleAtTime", function () {
   function entryAt(index, t) {
     return { index: index, event: { t: t } };
   }
 
-  it("returns 0 for empty or missing input", function () {
-    expect(countVisibleEntries([], 5)).toBe(0);
-    expect(countVisibleEntries(null, 5)).toBe(0);
-    expect(countVisibleEntries(undefined, 5)).toBe(0);
+  // Mirrors ReplayView's visible-entry derivation exactly.
+  function visibleEntriesAt(entries, currentTime) {
+    var sortedTimes = buildVisibilityIndex(entries);
+    var count = countVisibleAtTime(sortedTimes, currentTime);
+    if (count === 0) return [];
+    if (count === entries.length) return entries.slice();
+    var threshold = sortedTimes[count - 1];
+    return entries.filter(function (entry) { return entry.event.t <= threshold; });
+  }
+
+  function naiveVisible(entries, currentTime) {
+    return entries.filter(function (entry) { return entry.event.t <= currentTime; });
+  }
+
+  it("buildVisibilityIndex returns [] for empty or missing input", function () {
+    expect(buildVisibilityIndex([])).toEqual([]);
+    expect(buildVisibilityIndex(null)).toEqual([]);
+    expect(buildVisibilityIndex(undefined)).toEqual([]);
   });
 
-  it("counts entries whose t is <= currentTime (inclusive boundary)", function () {
-    var entries = [entryAt(0, 0), entryAt(1, 1), entryAt(2, 2), entryAt(3, 3)];
-    expect(countVisibleEntries(entries, -1)).toBe(0);
-    expect(countVisibleEntries(entries, 0)).toBe(1);
-    expect(countVisibleEntries(entries, 1.5)).toBe(2);
-    expect(countVisibleEntries(entries, 3)).toBe(4);
-    expect(countVisibleEntries(entries, 99)).toBe(4);
+  it("buildVisibilityIndex sorts times ascending without reordering entries", function () {
+    var entries = [entryAt(0, 0), entryAt(1, 0.2), entryAt(2, 0.1)];
+    expect(buildVisibilityIndex(entries)).toEqual([0, 0.1, 0.2]);
+    // The source array must be left untouched.
+    expect(entries.map(function (e) { return e.event.t; })).toEqual([0, 0.2, 0.1]);
   });
 
-  it("includes all entries sharing the exact boundary time (ties)", function () {
-    var entries = [entryAt(0, 1), entryAt(1, 2), entryAt(2, 2), entryAt(3, 2), entryAt(4, 3)];
-    expect(countVisibleEntries(entries, 2)).toBe(4);
+  it("countVisibleAtTime returns 0 for empty or missing input", function () {
+    expect(countVisibleAtTime([], 5)).toBe(0);
+    expect(countVisibleAtTime(null, 5)).toBe(0);
+    expect(countVisibleAtTime(undefined, 5)).toBe(0);
   });
 
-  it("matches the equivalent filter on chronological entries", function () {
+  it("counts times <= currentTime with inclusive boundary", function () {
+    var sorted = buildVisibilityIndex([entryAt(0, 0), entryAt(1, 1), entryAt(2, 2), entryAt(3, 3)]);
+    expect(countVisibleAtTime(sorted, -1)).toBe(0);
+    expect(countVisibleAtTime(sorted, 0)).toBe(1);
+    expect(countVisibleAtTime(sorted, 1.5)).toBe(2);
+    expect(countVisibleAtTime(sorted, 3)).toBe(4);
+    expect(countVisibleAtTime(sorted, 99)).toBe(4);
+  });
+
+  it("includes all times sharing the exact boundary (ties)", function () {
+    var sorted = buildVisibilityIndex([entryAt(0, 1), entryAt(1, 2), entryAt(2, 2), entryAt(3, 2), entryAt(4, 3)]);
+    expect(countVisibleAtTime(sorted, 2)).toBe(4);
+  });
+
+  it("matches the naive filter for out-of-order entry times", function () {
+    // Deliberately unsorted by event.t: the sorted index yields the right count
+    // and the threshold filter returns the right entries in original order.
+    var entries = [entryAt(0, 0), entryAt(1, 0.2), entryAt(2, 0.1), entryAt(3, 0.05), entryAt(4, 0.5)];
+
+    for (var time = -0.1; time <= 0.6; time += 0.01) {
+      expect(visibleEntriesAt(entries, time)).toEqual(naiveVisible(entries, time));
+    }
+  });
+
+  it("matches the naive filter across a large unsorted set", function () {
     var entries = [];
-    for (var i = 0; i < 200; i++) entries.push(entryAt(i, i * 0.5));
+    for (var i = 0; i < 300; i++) entries.push(entryAt(i, Math.round(Math.random() * 1000) / 10));
 
-    for (var time = -1; time <= 101; time += 0.25) {
-      var expected = entries.filter(function (entry) { return entry.event.t <= time; }).length;
-      expect(countVisibleEntries(entries, time)).toBe(expected);
+    for (var time = -1; time <= 101; time += 0.5) {
+      expect(visibleEntriesAt(entries, time)).toEqual(naiveVisible(entries, time));
+    }
+  });
+});
+
+describe("replay visibility with out-of-order parser output (regression)", function () {
+  // The Claude parser bumps a record's text/tool events by fractional offsets, so
+  // a later record with an earlier real timestamp yields out-of-order event.t.
+  // ReplayView must still show every event whose t <= playhead; a prefix slice
+  // (which assumes sorted times) would drop the earlier-but-later event.
+  function buildJSONL() {
+    var assistant = {
+      type: "assistant",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      message: {
+        role: "assistant",
+        model: "claude-3-5-sonnet-20241022",
+        content: [
+          { type: "text", text: "Let me read the file." },
+          { type: "tool_use", name: "read_file", input: { path: "a.txt" } },
+        ],
+      },
+    };
+    var user = {
+      type: "user",
+      timestamp: "2026-01-01T00:00:00.100Z",
+      message: { role: "user", content: "thanks" },
+    };
+    return JSON.stringify(assistant) + "\n" + JSON.stringify(user);
+  }
+
+  function visibleEntriesAt(entries, currentTime) {
+    var sortedTimes = buildVisibilityIndex(entries);
+    var count = countVisibleAtTime(sortedTimes, currentTime);
+    if (count === 0) return [];
+    if (count === entries.length) return entries.slice();
+    var threshold = sortedTimes[count - 1];
+    return entries.filter(function (entry) { return entry.event.t <= threshold; });
+  }
+
+  it("emits non-monotonic event times (documents the invariant)", function () {
+    var parsed = parseClaudeCodeJSONL(buildJSONL());
+    expect(parsed).not.toBeNull();
+
+    var entries = buildFilteredEventEntries(parsed.events, {});
+    // text @ 0, tool_use @ ~0.2, user @ ~0.1 -> entry[1].t > entry[2].t.
+    expect(entries.length).toBe(3);
+    expect(entries[1].event.t).toBeGreaterThan(entries[2].event.t);
+  });
+
+  it("shows the earlier-timestamped user event at an intermediate playhead", function () {
+    var parsed = parseClaudeCodeJSONL(buildJSONL());
+    var entries = buildFilteredEventEntries(parsed.events, {});
+
+    // At t=0.15 the user event (t~0.1) must be visible even though it follows the
+    // tool_use event (t~0.2) in array order. A prefix slice would hide it.
+    var visible = visibleEntriesAt(entries, 0.15);
+    var naive = entries.filter(function (entry) { return entry.event.t <= 0.15; });
+    expect(visible).toEqual(naive);
+
+    var userVisible = visible.some(function (entry) { return entry.event.agent === "user"; });
+    expect(userVisible).toBe(true);
+  });
+
+  it("matches the naive filter across the whole playback range", function () {
+    var parsed = parseClaudeCodeJSONL(buildJSONL());
+    var entries = buildFilteredEventEntries(parsed.events, {});
+
+    for (var time = 0; time <= 0.5; time += 0.01) {
+      var visible = visibleEntriesAt(entries, time);
+      var naive = entries.filter(function (entry) { return entry.event.t <= time; });
+      expect(visible).toEqual(naive);
     }
   });
 });

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useLayoutEffect } from "react";
 import { theme, AGENT_COLORS, TRACK_TYPES, alpha } from "../lib/theme.js";
-import { buildReplayLayout, getReplayWindow, countVisibleEntries } from "../lib/replayLayout.js";
+import { buildReplayLayout, getReplayWindow, buildVisibilityIndex, countVisibleAtTime } from "../lib/replayLayout.js";
 import DataInspector from "./DataInspector.jsx";
 import DiffViewer from "./DiffViewer.jsx";
 import ResizablePanel from "./ResizablePanel.jsx";
@@ -294,16 +294,29 @@ export default function ReplayView({ currentTime, eventEntries, turnStartMap, se
   var shouldFollowRef = useRef(true);
   var prevCount = useRef(0);
 
-  // eventEntries is chronological, so the visible set is a prefix. Track it by
-  // count (binary search) rather than re-filtering every tick: visibleEntries and
-  // everything derived from it only recompute when the playhead crosses an event.
+  // eventEntries is NOT guaranteed to be sorted by event.t (some parsers emit
+  // out-of-order times), so we can't slice a prefix. Instead we sort a copy of
+  // the times once (buildVisibilityIndex), count visible events per tick with an
+  // O(log n) binary search, and only rebuild the original-order visible list --
+  // via a threshold filter equivalent to `filter(t <= currentTime)` -- when the
+  // count changes. visibleEntries and everything derived from it stay stable
+  // between crossings while remaining correct for unsorted input.
+  var sortedTimes = useMemo(function () {
+    return buildVisibilityIndex(eventEntries);
+  }, [eventEntries]);
+
   var visibleCount = useMemo(function () {
-    return countVisibleEntries(eventEntries, currentTime);
-  }, [currentTime, eventEntries]);
+    return countVisibleAtTime(sortedTimes, currentTime);
+  }, [currentTime, sortedTimes]);
 
   var visibleEntries = useMemo(function () {
-    return eventEntries.slice(0, visibleCount);
-  }, [eventEntries, visibleCount]);
+    if (visibleCount === 0) return [];
+    if (visibleCount === eventEntries.length) return eventEntries.slice();
+    var threshold = sortedTimes[visibleCount - 1];
+    return eventEntries.filter(function (entry) {
+      return entry.event.t <= threshold;
+    });
+  }, [eventEntries, sortedTimes, visibleCount]);
 
   var layout = useMemo(function () {
     return buildReplayLayout(visibleEntries, turnStartMap, measuredHeights);

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useMemo, useLayoutEffect } from "react";
 import { theme, AGENT_COLORS, TRACK_TYPES, alpha } from "../lib/theme.js";
-import { buildReplayLayout, getReplayWindow } from "../lib/replayLayout.js";
+import { buildReplayLayout, getReplayWindow, countVisibleEntries } from "../lib/replayLayout.js";
 import DataInspector from "./DataInspector.jsx";
 import DiffViewer from "./DiffViewer.jsx";
 import ResizablePanel from "./ResizablePanel.jsx";
@@ -294,9 +294,16 @@ export default function ReplayView({ currentTime, eventEntries, turnStartMap, se
   var shouldFollowRef = useRef(true);
   var prevCount = useRef(0);
 
-  var visibleEntries = useMemo(function () {
-    return eventEntries.filter(function (entry) { return entry.event.t <= currentTime; });
+  // eventEntries is chronological, so the visible set is a prefix. Track it by
+  // count (binary search) rather than re-filtering every tick: visibleEntries and
+  // everything derived from it only recompute when the playhead crosses an event.
+  var visibleCount = useMemo(function () {
+    return countVisibleEntries(eventEntries, currentTime);
   }, [currentTime, eventEntries]);
+
+  var visibleEntries = useMemo(function () {
+    return eventEntries.slice(0, visibleCount);
+  }, [eventEntries, visibleCount]);
 
   var layout = useMemo(function () {
     return buildReplayLayout(visibleEntries, turnStartMap, measuredHeights);

--- a/src/lib/replayLayout.js
+++ b/src/lib/replayLayout.js
@@ -130,27 +130,48 @@ function findEndIndex(items, targetBottom) {
 }
 
 /**
- * Counts how many leading entries are visible at a given playback time.
+ * Builds a sorted array of the entries' event.t values for visibility lookups.
  *
- * Entries are chronological (every parser emits events sorted ascending by
- * event.t), so the visible set is always a prefix of the list. Binary searching
- * for the prefix length lets ReplayView slice `entries.slice(0, count)` instead
- * of re-running an O(n) filter -- and allocating a fresh array -- on every 100ms
- * playback tick. The count only changes when the playhead crosses an event, so
- * downstream memos keyed on it stay stable between crossings.
- *
- * Returns the number of entries whose event.t is <= currentTime (matching the
- * previous `filter(entry => entry.event.t <= currentTime)` semantics exactly).
+ * ReplayView needs the count of events whose t is <= the playhead on every 100ms
+ * tick. Doing that with a filter re-scans and re-allocates O(n) every tick; a
+ * binary search is O(log n) but requires a sorted array. Parser output is NOT
+ * guaranteed to be nondecreasing by event.t (the Claude parser bumps a record's
+ * text/tool events by fractional offsets, so a later record with an earlier real
+ * timestamp can produce out-of-order times), so we sort a copy of just the times
+ * here -- once per entries array -- and never assume the entries themselves are
+ * ordered. Callers memoize this on `entries` so the sort runs only when the
+ * session or filter changes, not per tick.
  */
-export function countVisibleEntries(entries, currentTime) {
-  if (!entries || entries.length === 0) return 0;
+export function buildVisibilityIndex(entries) {
+  if (!entries || entries.length === 0) return [];
+
+  var times = new Array(entries.length);
+  for (var i = 0; i < entries.length; i += 1) {
+    times[i] = entries[i].event.t;
+  }
+  times.sort(function (a, b) { return a - b; });
+  return times;
+}
+
+/**
+ * Counts how many events are visible at a given playback time.
+ *
+ * `sortedTimes` comes from buildVisibilityIndex (ascending). This upper-bound
+ * binary search returns the number of times that are <= currentTime, which is
+ * exactly `entries.filter(entry => entry.event.t <= currentTime).length` --
+ * independent of the original entry order. The count only changes when the
+ * playhead crosses an event, so ReplayView memos keyed on it stay stable
+ * between crossings while still being correct for out-of-order input.
+ */
+export function countVisibleAtTime(sortedTimes, currentTime) {
+  if (!sortedTimes || sortedTimes.length === 0) return 0;
 
   var low = 0;
-  var high = entries.length;
+  var high = sortedTimes.length;
 
   while (low < high) {
     var mid = (low + high) >> 1;
-    if (entries[mid].event.t <= currentTime) low = mid + 1;
+    if (sortedTimes[mid] <= currentTime) low = mid + 1;
     else high = mid;
   }
 

--- a/src/lib/replayLayout.js
+++ b/src/lib/replayLayout.js
@@ -129,6 +129,34 @@ function findEndIndex(items, targetBottom) {
   return result;
 }
 
+/**
+ * Counts how many leading entries are visible at a given playback time.
+ *
+ * Entries are chronological (every parser emits events sorted ascending by
+ * event.t), so the visible set is always a prefix of the list. Binary searching
+ * for the prefix length lets ReplayView slice `entries.slice(0, count)` instead
+ * of re-running an O(n) filter -- and allocating a fresh array -- on every 100ms
+ * playback tick. The count only changes when the playhead crosses an event, so
+ * downstream memos keyed on it stay stable between crossings.
+ *
+ * Returns the number of entries whose event.t is <= currentTime (matching the
+ * previous `filter(entry => entry.event.t <= currentTime)` semantics exactly).
+ */
+export function countVisibleEntries(entries, currentTime) {
+  if (!entries || entries.length === 0) return 0;
+
+  var low = 0;
+  var high = entries.length;
+
+  while (low < high) {
+    var mid = (low + high) >> 1;
+    if (entries[mid].event.t <= currentTime) low = mid + 1;
+    else high = mid;
+  }
+
+  return low;
+}
+
 export function getReplayWindow(items, scrollTop, viewportHeight, overscanPx) {
   if (!items || items.length === 0) return [];
 


### PR DESCRIPTION
## Avoid O(n) per-tick recompute of the replay event stream

### Summary
During playback, `ReplayView` re-derived its entire visible-event list on **every
100ms tick**, even when no new event had actually become visible. This turned the
replay's hot loop into several full O(n) passes plus a fresh N-length array
allocation ten times a second. This PR reduces the steady-state per-tick cost to a
single O(log n) binary search with zero allocation, with no behavior change.

One new pure helper (`countVisibleEntries`), a small `ReplayView` rewire, and tests.
No API change, no new dependencies. Focused diff: 3 files, +75/-4.

### The problem
`playback.time` advances every 100ms. `ReplayView` computed:

```js
var visibleEntries = useMemo(function () {
  return eventEntries.filter(function (entry) { return entry.event.t <= currentTime; });
}, [currentTime, eventEntries]);
```

Because `currentTime` changes every tick, this produced a **brand new array on every
tick**. That new reference then invalidated everything derived from it, so each 100ms
frame re-ran, over the full visible list, all of the work below:

```mermaid
flowchart TD
    T["Playback tick every 100ms<br/>(currentTime changes)"] --> F["visibleEntries = filter(t ≤ currentTime)<br/>O(n) + brand new array every tick"]
    F --> L["buildReplayLayout()<br/>O(n), allocates N items"]
    F --> S["selectedEntry<br/>O(n) scan"]
    F --> C["toolEntries<br/>O(n) scan + sort"]
    L --> R["re-render"]
    S --> R
    C --> R
    classDef hot fill:#ffe5e5,stroke:#e11d48,color:#7f1d1d;
    class F,L,S,C hot;
```

So for a large session (tens of thousands of events) the replay did roughly **four
O(n) passes and multiple full-array allocations every 100ms during playback** - wasted
CPU on the main thread and steady garbage-collector pressure - even while the visible
set was completely unchanged between ticks.

### The fix
Every parser emits events in chronological order (Codex and Copilot CLI sort by `t`
explicitly; Claude is file/synthetic-time ordered; VS Code enforces monotonic spacing;
ATIF forward-fills non-decreasing step times). The replay model itself assumes this
ordering. That means the visible set is always a **prefix** of the list, and the only
thing that changes tick-to-tick is the prefix length:

```mermaid
flowchart LR
    A["t=0"] --> B["t=1"] --> C["t=2"] --> D["t=3"] --> E["t=4"] --> F["t=5"]
    P(["currentTime = 2.5<br/>binary search finds count = 3"]) -.-> C
    classDef vis fill:#e6ffed,stroke:#22a06b,color:#04422b;
    classDef pend fill:#eef0f2,stroke:#94a3b8,color:#475569;
    class A,B,C vis;
    class D,E,F pend;
```

New pure helper in `replayLayout.js` (mirrors the binary searches already in this file):

```js
// Returns the number of leading entries whose event.t <= currentTime.
export function countVisibleEntries(entries, currentTime) {
  if (!entries || entries.length === 0) return 0;
  var low = 0, high = entries.length;
  while (low < high) {
    var mid = (low + high) >> 1;
    if (entries[mid].event.t <= currentTime) low = mid + 1;
    else high = mid;
  }
  return low;
}
```

`ReplayView` now tracks the count and slices the prefix:

```js
var visibleCount = useMemo(function () {
  return countVisibleEntries(eventEntries, currentTime);
}, [currentTime, eventEntries]);

var visibleEntries = useMemo(function () {
  return eventEntries.slice(0, visibleCount);
}, [eventEntries, visibleCount]);
```

Now `visibleEntries` only gets a new reference when `visibleCount` changes - i.e. when
the playhead actually crosses an event boundary. Between crossings the reference is
stable, so `layout`, `selectedEntry`, and `toolEntries` skip recomputation entirely:

```mermaid
flowchart TD
    T["Playback tick every 100ms<br/>(currentTime changes)"] --> B["visibleCount = countVisibleEntries()<br/>O(log n) binary search, no allocation"]
    B --> Q{"count changed?<br/>(playhead crossed an event)"}
    Q -->|"No (common case)"| K["references stable<br/>layout / selection / tools reused<br/>nothing recomputes"]
    Q -->|"Yes"| U["visibleEntries = slice(0, count)<br/>layout / selection / tools recompute once"]
    K --> R["re-render (cheap)"]
    U --> R
    classDef cheap fill:#e6ffed,stroke:#22a06b,color:#04422b;
    classDef work fill:#fff4e5,stroke:#e08a00,color:#7a4a00;
    class B,K cheap;
    class U work;
```

**Per-tick cost, steady state: from ~4x O(n) + allocations down to one O(log n) search
with no allocation.** The full layout rebuild still happens when a new event appears
(inherent and correct), just no longer on every idle tick.

### Why this is safe (behavior-preserving)
- `eventEntries.slice(0, count)` is exactly equal to the previous
  `filter(e => e.event.t <= currentTime)` for chronological input - same objects, same
  order. A parity test asserts this across many time values.
- The auto-scroll "follow" effect keys off `visibleEntries.length`, which changes at
  precisely the same moments as before (when the count grows).
- The target-scroll and height-measurement effects key off `layout.items` /
  `windowMeasurementKey`, which now update only when the visible set changes - fewer
  redundant runs, same outcomes.

### Validation
- **Full suite: 929 passed (56/56 suites).**
- **Typecheck**: `tsc --noEmit` clean.
- **Build**: `vite build` clean.
- **New tests** (`replayLayout.test.js`, `countVisibleEntries`): empty/missing input,
  inclusive `<=` boundary, ties at the exact boundary time, and a **parity test** that
  checks the binary search matches `filter(...).length` for every time value across a
  200-entry list.

### Scope
Deliberately focused on this one hot path. Two related performance findings surfaced
during this audit and are intentionally left for separate PRs to keep this change small:
- `_estimateCache` in `replayLayout.js` is never cleared on session switch (grows across
  sessions; `clearEstimateCache()` is only called in tests today).
- Session parsing runs synchronously on the main thread and could be offloaded to a Web
  Worker (as ELK graph layout already is), so large files don't freeze the UI while parsing.
