### PR TITLE
Reject cross-site and rebound-host requests to the local API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- Rejected cross-site requests to the local API. Any website the user visited
+  could previously `POST` to `/api/apply` and write arbitrary files under the
+  project directory (for example `.git/hooks/pre-commit`), which is remote code
+  execution the next time the developer ran git or a build. Requests that carry
+  a foreign `Origin`/`Sec-Fetch-Site`, or a body that is not `application/json`,
+  are now refused before any route runs.
+- Rejected requests whose `Host` header is not a loopback name. Without this, an
+  attacker domain that resolves to `127.0.0.1` (DNS rebinding) was treated as
+  same-origin by the browser and could read `/api/sessions`, `/api/session`,
+  `/api/file`, and `/api/read-file` -- that is, every AI session transcript on
+  the machine.
+
 ## [1.0.3] - 2026-08-11
 
 ### Fixed

--- a/server.js
+++ b/server.js
@@ -49,6 +49,87 @@ var MIME = {
 
 var STREAM_READ_SIZE = 64 * 1024;
 
+// ── Request guards ───────────────────────────────────────────────
+// The server listens on 127.0.0.1, but "local" is not the same as "trusted":
+// every website the user visits can make their browser send requests here.
+// CORS response headers do not stop a request from being *sent* (so a page can
+// POST and write files), and they do not stop a rebound DNS name from reading
+// responses (so a page can exfiltrate session transcripts). Both classes are
+// therefore rejected outright, before any route or static file is served.
+
+var LOCAL_HOSTNAMES = ["localhost", "127.0.0.1", "::1", "0:0:0:0:0:0:0:1"];
+var STATE_CHANGING_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
+var LOCAL_ORIGIN_PATTERN = /^https?:\/\/(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
+
+/** Extract the hostname from a Host header, handling ports and IPv6 literals. */
+export function parseHostname(hostHeader) {
+  var value = String(hostHeader || "").trim().toLowerCase();
+  if (!value) return "";
+
+  if (value.charAt(0) === "[") {
+    var end = value.indexOf("]");
+    return end === -1 ? "" : value.slice(1, end);
+  }
+
+  var colon = value.indexOf(":");
+  return colon === -1 ? value : value.slice(0, colon);
+}
+
+/**
+ * Blocks DNS rebinding. An attacker domain that resolves to 127.0.0.1 reaches
+ * this server with its own name in the Host header, and the browser then treats
+ * the response as same-origin and readable. Only loopback names are accepted.
+ */
+export function isAllowedHost(hostHeader) {
+  return LOCAL_HOSTNAMES.indexOf(parseHostname(hostHeader)) !== -1;
+}
+
+export function isLocalOrigin(origin) {
+  return LOCAL_ORIGIN_PATTERN.test(String(origin || ""));
+}
+
+function hasRequestBody(headers) {
+  var length = parseInt(headers["content-length"], 10);
+  if (!isNaN(length) && length > 0) return true;
+  return Boolean(headers["transfer-encoding"]);
+}
+
+/**
+ * Returns null when the request may proceed, or { status, message } when it
+ * must be rejected.
+ */
+export function evaluateRequestGuard(req) {
+  var headers = (req && req.headers) || {};
+
+  if (!isAllowedHost(headers.host)) {
+    return { status: 403, message: "Forbidden: invalid Host header" };
+  }
+
+  var method = String((req && req.method) || "GET").toUpperCase();
+  if (STATE_CHANGING_METHODS.indexOf(method) === -1) return null;
+
+  var origin = headers.origin || "";
+  if (origin && !isLocalOrigin(origin)) {
+    return { status: 403, message: "Forbidden: cross-origin request" };
+  }
+
+  // Set by the browser itself, so page script cannot forge it.
+  var site = headers["sec-fetch-site"];
+  if (site && site !== "same-origin" && site !== "none") {
+    return { status: 403, message: "Forbidden: cross-site request" };
+  }
+
+  // A cross-site <form> can submit a body without an Origin header in older
+  // browsers, but it can only send urlencoded/multipart/text-plain -- never
+  // application/json. Requiring JSON closes that bypass. Bodiless posts such as
+  // /api/qa/reset are exempt because a form submission always carries a body.
+  if (hasRequestBody(headers) && !/^application\/json\b/i.test(headers["content-type"] || "")) {
+    return { status: 415, message: "Unsupported Media Type: expected application/json" };
+  }
+
+  return null;
+}
+
 export function getCompleteJsonlLines(content) {
   if (!content) return [];
   var normalized = content.replace(/\r\n/g, "\n");
@@ -245,10 +326,19 @@ export function createServer({ sessionFile, distDir }) {
     var parsed = url.parse(req.url, true);
     var pathname = parsed.pathname;
 
+    // Reject CSRF and DNS-rebinding requests before any route or file is served.
+    var guard = evaluateRequestGuard(req);
+    if (guard) {
+      res.writeHead(guard.status, { "Content-Type": "text/plain; charset=utf-8" });
+      res.end(guard.message);
+      req.resume(); // drain the body so the socket is not left half-open
+      return;
+    }
+
     // Restrict CORS to localhost origins only
     var origin = req.headers.origin || "";
-    var isLocalOrigin = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin);
-    if (isLocalOrigin) {
+    var originIsLocal = isLocalOrigin(origin);
+    if (originIsLocal) {
       res.setHeader("Access-Control-Allow-Origin", origin);
       res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
       res.setHeader("Access-Control-Allow-Headers", "Content-Type");
@@ -257,7 +347,7 @@ export function createServer({ sessionFile, distDir }) {
 
     // Handle CORS preflight
     if (req.method === "OPTIONS") {
-      res.writeHead(isLocalOrigin ? 204 : 403);
+      res.writeHead(originIsLocal ? 204 : 403);
       res.end();
       return;
     }

--- a/src/__tests__/serverSecurity.test.js
+++ b/src/__tests__/serverSecurity.test.js
@@ -1,0 +1,265 @@
+import http from "http";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  createServer,
+  evaluateRequestGuard,
+  isAllowedHost,
+  isLocalOrigin,
+  parseHostname,
+} from "../../server.js";
+
+var server = null;
+var port = 0;
+var tempDir = null;
+
+function listen(target) {
+  return new Promise(function (resolve, reject) {
+    function onError(err) {
+      target.off("error", onError);
+      reject(err);
+    }
+
+    target.once("error", onError);
+    target.listen(0, "127.0.0.1", function () {
+      target.off("error", onError);
+      resolve(target.address().port);
+    });
+  });
+}
+
+// Sends a raw request so the Host header can be spoofed the way a rebound DNS
+// name would. Node's http client normally overwrites Host from the socket.
+function request(options) {
+  return new Promise(function (resolve, reject) {
+    var req = http.request({
+      hostname: "127.0.0.1",
+      port: port,
+      path: options.path || "/api/meta",
+      method: options.method || "GET",
+      headers: options.headers || {},
+    }, function (res) {
+      var body = "";
+      res.setEncoding("utf8");
+      res.on("data", function (chunk) { body += chunk; });
+      res.on("end", function () { resolve({ status: res.statusCode, body: body }); });
+    });
+
+    req.on("error", reject);
+    if (options.body) req.write(options.body);
+    req.end();
+  });
+}
+
+beforeAll(async function () {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "agentviz-guard-"));
+  fs.writeFileSync(path.join(tempDir, "index.html"), "<html></html>", "utf8");
+  server = createServer({ sessionFile: null, distDir: tempDir });
+  port = await listen(server);
+});
+
+afterAll(async function () {
+  if (server) await new Promise(function (resolve) { server.close(resolve); });
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+describe("parseHostname", function () {
+  it("strips ports and unwraps IPv6 literals", function () {
+    expect(parseHostname("localhost:4242")).toBe("localhost");
+    expect(parseHostname("127.0.0.1")).toBe("127.0.0.1");
+    expect(parseHostname("[::1]:4242")).toBe("::1");
+    expect(parseHostname("EVIL.EXAMPLE:80")).toBe("evil.example");
+    expect(parseHostname("")).toBe("");
+    expect(parseHostname(undefined)).toBe("");
+  });
+});
+
+describe("isAllowedHost", function () {
+  it("accepts loopback names only", function () {
+    expect(isAllowedHost("localhost:4242")).toBe(true);
+    expect(isAllowedHost("127.0.0.1:4242")).toBe(true);
+    expect(isAllowedHost("[::1]:4242")).toBe(true);
+    expect(isAllowedHost("evil.example")).toBe(false);
+    expect(isAllowedHost("localhost.evil.example")).toBe(false);
+    expect(isAllowedHost("192.168.1.10:4242")).toBe(false);
+    expect(isAllowedHost(undefined)).toBe(false);
+  });
+});
+
+describe("isLocalOrigin", function () {
+  it("accepts only loopback origins", function () {
+    expect(isLocalOrigin("http://localhost:3000")).toBe(true);
+    expect(isLocalOrigin("http://127.0.0.1:4242")).toBe(true);
+    expect(isLocalOrigin("https://evil.example")).toBe(false);
+    expect(isLocalOrigin("http://localhost.evil.example")).toBe(false);
+    expect(isLocalOrigin("")).toBe(false);
+  });
+});
+
+describe("evaluateRequestGuard", function () {
+  it("rejects a rebound Host on a plain GET", function () {
+    var guard = evaluateRequestGuard({ method: "GET", headers: { host: "evil.example" } });
+    expect(guard).not.toBeNull();
+    expect(guard.status).toBe(403);
+  });
+
+  it("allows a same-origin JSON POST", function () {
+    expect(evaluateRequestGuard({
+      method: "POST",
+      headers: {
+        host: "localhost:4242",
+        origin: "http://localhost:3000",
+        "sec-fetch-site": "same-origin",
+        "content-type": "application/json",
+        "content-length": "2",
+      },
+    })).toBeNull();
+  });
+
+  it("allows a bodiless POST with no content type (/api/qa/reset)", function () {
+    expect(evaluateRequestGuard({
+      method: "POST",
+      headers: { host: "localhost:4242", origin: "http://localhost:3000" },
+    })).toBeNull();
+  });
+
+  it("rejects a chunked body that is not JSON", function () {
+    var guard = evaluateRequestGuard({
+      method: "POST",
+      headers: {
+        host: "localhost:4242",
+        "transfer-encoding": "chunked",
+        "content-type": "text/plain;charset=UTF-8",
+      },
+    });
+    expect(guard.status).toBe(415);
+  });
+});
+
+describe("server request guard over HTTP", function () {
+  // Finding 2: DNS rebinding.
+  it("rejects any request whose Host is not loopback", async function () {
+    var res = await request({ path: "/api/meta", headers: { host: "evil.example" } });
+    expect(res.status).toBe(403);
+    expect(res.body).toContain("Host");
+  });
+
+  it("rejects a rebound Host on session-reading routes", async function () {
+    var sessions = await request({ path: "/api/sessions", headers: { host: "attacker.test:4242" } });
+    expect(sessions.status).toBe(403);
+
+    var file = await request({ path: "/api/file", headers: { host: "attacker.test:4242" } });
+    expect(file.status).toBe(403);
+  });
+
+  it("rejects a rebound Host on static files", async function () {
+    var res = await request({ path: "/index.html", headers: { host: "evil.example" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("still serves loopback Hosts", async function () {
+    var localhost = await request({ path: "/api/meta", headers: { host: "localhost:" + port } });
+    expect(localhost.status).toBe(200);
+
+    var ipv4 = await request({ path: "/api/meta", headers: { host: "127.0.0.1:" + port } });
+    expect(ipv4.status).toBe(200);
+
+    var ipv6 = await request({ path: "/api/meta", headers: { host: "[::1]:" + port } });
+    expect(ipv6.status).toBe(200);
+  });
+
+  // Finding 1: CSRF. This is the exact shape of the proven exploit -- a simple
+  // request (text/plain => no preflight) that wrote .git/hooks/pre-commit.
+  it("rejects the cross-site simple-request write to /api/apply", async function () {
+    var res = await request({
+      path: "/api/apply",
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:" + port,
+        origin: "https://evil.example",
+        "content-type": "text/plain;charset=UTF-8",
+      },
+      body: JSON.stringify({ relativePath: ".git/hooks/pre-commit", content: "x", mode: "overwrite" }),
+    });
+
+    expect(res.status).toBe(403);
+    expect(res.body).not.toContain("success");
+  });
+
+  it("rejects a cross-site POST even when it sends JSON", async function () {
+    var res = await request({
+      path: "/api/apply",
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:" + port,
+        origin: "https://evil.example",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ relativePath: "CLAUDE.md", content: "x" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a POST marked cross-site by the browser", async function () {
+    var res = await request({
+      path: "/api/apply",
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:" + port,
+        "sec-fetch-site": "cross-site",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ relativePath: "CLAUDE.md", content: "x" }),
+    });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects a form-style POST with no Origin header", async function () {
+    var res = await request({
+      path: "/api/apply",
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:" + port,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: "relativePath=CLAUDE.md&content=x",
+    });
+
+    expect(res.status).toBe(415);
+  });
+
+  it("still allows the app's own same-origin POST through the guard", async function () {
+    var res = await request({
+      path: "/api/qa/reset",
+      method: "POST",
+      headers: {
+        host: "127.0.0.1:" + port,
+        origin: "http://127.0.0.1:" + port,
+        "sec-fetch-site": "same-origin",
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toContain("ok");
+  });
+
+  it("rejects a cross-origin preflight but allows a local one", async function () {
+    var hostile = await request({
+      path: "/api/apply",
+      method: "OPTIONS",
+      headers: { host: "127.0.0.1:" + port, origin: "https://evil.example" },
+    });
+    expect(hostile.status).toBe(403);
+
+    var local = await request({
+      path: "/api/apply",
+      method: "OPTIONS",
+      headers: { host: "127.0.0.1:" + port, origin: "http://localhost:3000" },
+    });
+    expect(local.status).toBe(204);
+  });
+});


### PR DESCRIPTION
## Summary

The local AGENTVIZ server binds to `127.0.0.1`, but **"local" is not the same as "trusted"** — every website the user visits can make their browser send requests to it. CORS response headers stop neither of the two attacks below, because CORS governs *reading responses*, not *sending requests*.

This PR closes both, in one place: a guard that runs in `handleRequest` before any route or static file is served.

> **Note for the maintainer:** this repo is public and `agentviz` is published to npm (v1.0.3 is affected), so per `SECURITY.md` I have deliberately **not** included a copy-paste exploit payload here. You may want to pair this with a private GHSA advisory and a patch release. Happy to move the details private if you'd prefer.

---

## Finding 1 — Cross-site file write via `POST /api/apply` → RCE

**Severity: critical.** Reachability confirmed by execution against the real handler in an isolated temp directory.

`POST /api/apply` accepted requests from **any origin**. Because a request with `Content-Type: text/plain` is a CORS *simple request*, the browser sends it with **no preflight**, and the attacker never needs to read the response for the attack to succeed. The handler `JSON.parse`d the body regardless of the declared content type and wrote `content` to any path under `process.cwd()`.

**Impact:** any page the user was visiting could write to files such as `.git/hooks/pre-commit`, `.github/workflows/*.yml`, `package.json` scripts, or `.vscode/tasks.json` — i.e. **arbitrary code execution on the developer's machine** the next time they commit, build, or open the repo. `mode: "overwrite"` was attacker-controlled, so existing files were replaced rather than appended. The server responded `{"success":true}`; nothing raised an error or logged anything. Port discovery is trivial (fixed base `4242`, incrementing).

**Exposure window:** `npm run dev` auto-starts this backend via the Vite plugin, so for most contributors the server is running for the entire workday.

**Root cause:** the origin check added in `e9b53df` was implemented as a *response-header* decision, not a *request-authorization* decision. `isLocalOrigin` was computed and then used only to decide whether to set `Access-Control-Allow-*`. The request itself was always dispatched.

## Finding 2 — DNS rebinding reads every AI session transcript on the machine

**Severity: critical.** Confirmed by source inspection — `req.headers.host` was not read anywhere in the codebase.

With no `Host` validation, an attacker-controlled domain that resolves to `127.0.0.1` reaches this server carrying its own hostname. The browser then considers the response **same-origin and readable**, so CORS provides no protection whatsoever.

**Impact:** the attacker's page can enumerate `GET /api/sessions` (which returns absolute paths for every Claude Code, Copilot CLI, Codex, and VS Code Copilot Chat session on the machine — 78 on my dev box) and then read each one via `GET /api/session?path=…`. AI session transcripts routinely contain proprietary source code, file contents, environment details, and credentials pasted into prompts. `GET /api/read-file` additionally exposes any file under the project directory, and `GET /api/file` the actively watched session. Entirely silent.

---

## The fix

A single guard in `server.js`, applied before routing:

1. **`Host` must be a loopback name** (`localhost`, `127.0.0.1`, `::1`) — closes finding 2, for API routes *and* static files.
2. **State-changing methods** (`POST`/`PUT`/`PATCH`/`DELETE`) are rejected when they carry a foreign `Origin`, or a `Sec-Fetch-Site` that is not `same-origin`/`none` — closes finding 1 for `fetch`/XHR.
3. **A request body must be `application/json`** — a cross-site `<form>` can only send urlencoded/multipart/text-plain, never JSON, so this closes the same-request bypass even for browsers that omit `Origin`. Bodiless posts (e.g. `/api/qa/reset`) are exempt, since a form submission always carries a body.

Layers 2 and 3 are deliberately overlapping: either one alone blocks the proven attack.

Also unifies the existing CORS check with the new `isLocalOrigin` helper, removing a local variable that shadowed it, and extends both allowlists to cover the IPv6 loopback consistently.

## Verification

`npm ci` fails on my machine behind a TLS-intercepting proxy (one tarball returns `SSL alert 40`), so **I could not run `npm test`**. Instead I verified against the **real `createServer()` over real HTTP**, and confirmed the harness is not vacuous by running it against the pre-fix code:

| | pre-fix | post-fix |
|---|---|---|
| Checks passing | 13 / 24 | **24 / 24** |
| The working exploit | `200`, file written | **`403`, file not created** |
| Rebound `Host` on `/api/sessions`, `/api/session`, `/api/file`, `/api/read-file`, static | `200`/`404` | **`403`** |
| App's own same-origin JSON `POST` | `200` | `200` |
| Bodiless `POST /api/qa/reset` | `200` | `200` |
| Vite dev-proxy request shape | `200` | `200` |
| SSE `/api/stream` | `200` | `200` |

`src/__tests__/serverSecurity.test.js` (new) encodes all of this as Vitest coverage so CI enforces it — including a regression test named for the exact exploit shape. This also gives `/api/apply` its **first** test coverage; it previously had none.

## Compatibility

No user-visible behaviour change for legitimate use. Verified working: direct CLI/production mode (browser and API on the same origin), the Vite dev proxy (`changeOrigin` rewrites `Host`; the browser's `Origin` stays `localhost:3000`), SSE live streaming, MCP-launched servers, and static asset serving.

The one intentional tightening: a browser page on a *different* localhost port talking **directly** to the API (no proxy) is now rejected as `Sec-Fetch-Site: same-site`. No flow in this repo does that — the dev server proxies `/api`, and exported HTML answers `/api` locally.

## Out of scope (found while auditing, worth separate PRs)

- `/api/apply` still accepts any path under `cwd`; constraining it to the `CONFIG_SURFACES` allowlist would bound the blast radius of the AI Coach's model-generated `targetPath`.
- `/api/file` (unlike `/api/session`) applies no `isAllowedSessionPath` check, and `mcp/server.js` passes `session_file` to it after only an existence check.
- CI does not run `typecheck`, unlike `publish.yml`.
