### PR TITLE
perf: memoize Analyze summary calculations

### DIFF
--- a/src/__tests__/analyzeShellPerformance.test.jsx
+++ b/src/__tests__/analyzeShellPerformance.test.jsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+
+import React from "react";
+import { act } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../lib/costAnalysis.js", async function (importOriginal) {
+  var original = await importOriginal();
+  return Object.assign({}, original, {
+    buildCostAnalysis: vi.fn(original.buildCostAnalysis),
+  });
+});
+
+import AnalyzeShell from "../components/v2/AnalyzeShell.jsx";
+import { PlaybackProvider, usePlaybackTime } from "../contexts/PlaybackContext.jsx";
+import { buildCostAnalysis } from "../lib/costAnalysis.js";
+
+function SeekButton() {
+  var playbackContext = usePlaybackTime();
+  return (
+    <button type="button" onClick={function () { playbackContext.playback.seek(5); }}>
+      Seek
+    </button>
+  );
+}
+
+function makeSession(events, metadata) {
+  return {
+    events: events,
+    turns: [],
+    total: 10,
+    isLive: false,
+    metadata: metadata,
+  };
+}
+
+function renderApp(root, session) {
+  root.render(
+    <PlaybackProvider session={session}>
+      <SeekButton />
+      <AnalyzeShell session={session} autonomyMetrics={{}} onNavigate={vi.fn()} />
+    </PlaybackProvider>,
+  );
+}
+
+describe("AnalyzeShell summary performance", function () {
+  beforeEach(function () {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    window.localStorage.clear();
+  });
+
+  afterEach(function () {
+    vi.clearAllMocks();
+    document.body.innerHTML = "";
+  });
+
+  it("reuses the summary across playback ticks and recomputes when its inputs change", async function () {
+    var events = [{
+      t: 0,
+      duration: 1,
+      agent: "assistant",
+      track: "output",
+      text: "Response",
+      model: "gpt-4o",
+      tokenUsage: { inputTokens: 1000, outputTokens: 100, cacheRead: 0, cacheWrite: 0 },
+    }];
+    var metadata = {
+      totalEvents: 1,
+      totalTurns: 0,
+      totalToolCalls: 0,
+      errorCount: 0,
+      duration: 10,
+      primaryModel: "gpt-4o",
+      models: { "gpt-4o": 1 },
+      tokenUsage: { inputTokens: 1000, outputTokens: 100, cacheRead: 0, cacheWrite: 0 },
+    };
+    var session = makeSession(events, metadata);
+    var container = document.createElement("div");
+    document.body.appendChild(container);
+    var root = createRoot(container);
+
+    await act(async function () {
+      renderApp(root, session);
+    });
+    expect(buildCostAnalysis).toHaveBeenCalledTimes(1);
+
+    await act(async function () {
+      Array.from(container.querySelectorAll("button")).find(function (button) {
+        return button.textContent === "Seek";
+      }).click();
+    });
+    expect(buildCostAnalysis).toHaveBeenCalledTimes(1);
+
+    var nextEvents = events.concat({
+      t: 1,
+      duration: 0,
+      agent: "assistant",
+      track: "tool_call",
+      text: "Run tool",
+      toolName: "grep",
+    });
+    session = makeSession(nextEvents, metadata);
+    await act(async function () {
+      renderApp(root, session);
+    });
+    expect(buildCostAnalysis).toHaveBeenCalledTimes(2);
+
+    session = makeSession(nextEvents, Object.assign({}, metadata, { totalToolCalls: 1 }));
+    await act(async function () {
+      renderApp(root, session);
+    });
+    expect(buildCostAnalysis).toHaveBeenCalledTimes(3);
+
+    await act(async function () {
+      root.unmount();
+    });
+  });
+});

--- a/src/components/v2/AnalyzeShell.jsx
+++ b/src/components/v2/AnalyzeShell.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useMemo } from "react";
 import { theme } from "../../lib/theme.js";
 import usePersistentState from "../../hooks/usePersistentState.js";
 import useBreakpoint from "../../hooks/useBreakpoint.js";
@@ -109,9 +109,7 @@ function renderPanel(panelId, session, pb, autonomyMetrics, onNavigate) {
   );
 }
 
-function getAnalyzeSummary(session, pb) {
-  var events = pb.filteredEvents || [];
-  var metadata = session.metadata || {};
+function getAnalyzeSummary(events, metadata) {
   var cost = buildCostAnalysis(events, metadata);
   return [
     { label: "Events", value: events.length },
@@ -184,7 +182,9 @@ export default function AnalyzeShell({ session, autonomyMetrics, targetPanelId, 
     if (isValidPanel(targetPanelId)) setPanelId(targetPanelId);
   }, [targetPanelId, setPanelId]);
 
-  var summary = getAnalyzeSummary(session, pb);
+  var summary = useMemo(function () {
+    return getAnalyzeSummary(pb.filteredEvents || [], session.metadata || {});
+  }, [pb.filteredEvents, session.metadata]);
 
   function selectPanel(nextPanelId) {
     if (!isValidPanel(nextPanelId)) return;


### PR DESCRIPTION
## Summary\n- Memoize Analyze summary calculations across playback ticks\n- Recompute only when filtered events or session metadata change\n- Add regression coverage for playback reuse and input changes\n\n## Validation\n- 
pm run typecheck\n- 
pm test (953 tests passed)\n- git diff --check\n\nThis keeps the existing UI behavior unchanged while avoiding repeated uildCostAnalysis() work during playback.