### PR TITLE
perf: finish truly incremental live JSONL normalization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,11 @@ src/
     vscodeSessionParser.ts # parseVSCodeChatJSON() - VS Code Copilot Chat JSON parser
     atifParser.ts       # parseAtifJSON() - ATIF / Harbor trajectory JSON parser (schema_version ATIF-v1.6)
     liveSessionParser.ts # Incremental live JSONL parser for appended session text
+    liveNormalization.ts # Indexed aggregates, tool pairing, and affected-turn helpers
+    liveClaudeNormalizer.ts # Retained timestamps, cumulative usage, and duration boundaries
+    liveCopilotNormalizer.ts # Indexed tool/lifecycle dependencies and turn aggregates
+    liveCodexNormalizer.ts # Stateful emission, cumulative usage, and indexed turns
+    liveVSCodeNormalizer.ts # Owned patch tree with request and response-part caches
     liveSessionWorker.ts # Off-main-thread normalization with batch-parser parity
     liveParserClient.js # Single-flight worker backpressure, reset and disposal
     tracksLayout.js     # Bounded overview groups retaining original evidence indices
@@ -155,7 +160,8 @@ Run `npx playwright install chromium` once before the first browser test run.
 - Replay observes pane width and remeasures virtual rows; compact layouts stack. Separators support pointer capture, keyboard arrows/Home/End and restore body styles on cancellation.
 - Graph uses one tab stop with active-descendant tree navigation; Tracks uses one per lane and retains every event in persistent paginated detail.
 - Empty Find keeps real-session import primary and omits empty metrics.
-- Live parsing decodes new records and applies new VS Code patches incrementally; full normalization remains in a single-flight worker, not on the UI thread. Do not describe normalized output as incremental.
+- Live JSONL normalization retains format-specific state. Ordinary appends process new/affected records, not history; late tool completions update indexed aggregates without removing/reinserting unchanged turn membership. Batch parsers remain the parity oracle. See `docs/live-normalization.md` for invalidation boundaries and measurements.
+- Live parser state is a single-owner mutable accumulator. Published results are independent snapshots by default; only the worker uses `snapshot: false` because `postMessage` clones the result. Full snapshot copying, raw-text transfer, and rendering are still O(history), separate from normalization.
 - Tracks overview geometry is memoized and capped at 200 groups per lane, with every original event reachable through paginated detail.
 - Claude metadata preserves explicit sessionId, so appended snapshots update one library entry.
 - Evidence navigation carries original event indices, not just timestamps. Palette seeks retain their timestamp argument for Classic compatibility and add event identity as the second argument.

--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Evidence controls support keyboard and touch: Tracks uses one tab stop per lane 
 
 The header's explicit **Reading density** preference switches between normal and comfortable evidence text and spacing without enlarging all dashboard surfaces. Both themes now use readable small-text tokens (at least 4.5:1 on neutral surfaces). Empty Find prioritizes importing a real JSON/JSONL session; demos remain secondary.
 
-Live streams normalize in a dedicated worker with one in-flight batch and coalesced appends. JSON decoding and VS Code patch application are incremental; normalized output is still rebuilt for full batch-parser parity (including cross-record usage and tool pairing). Result transfer and rendering still scale with session size. Discovery uses asynchronous, eight-operation traversal, newest-first enrichment, and a bounded path/mtime/size preview cache, including companion metadata invalidation.
+Live streams normalize incrementally in a dedicated worker with one in-flight batch and coalesced appends. Claude Code, Copilot CLI, Codex, and VS Code JSONL retain normalization state and update new or affected records, including earlier tool results, cumulative usage, and lifecycle metadata. Ordinary appends do not traverse historical records or rebuild historical turns. Timestamp rebases and structural edits update the affected timeline; snapshot copying, worker transfer, and rendering still scale with session size. See [live normalization contracts and measurements](docs/live-normalization.md). Discovery uses asynchronous, eight-operation traversal, newest-first enrichment, and a bounded path/mtime/size preview cache, including companion metadata invalidation.
 
 Discovery preview reads are asynchronous and capped at 128 KiB (Codex), 64 KiB (CLI), or 2 KiB head plus tail (VS Code). Deep evidence jumps keep the selected row in view while measured heights settle, then yield to manual scrolling.
 
@@ -474,7 +474,12 @@ src/
     copilotCostParser.ts # Copilot prompt export JSON parser for token/cost analysis
     vscodeSessionParser.ts # VS Code Copilot Chat JSON parser
     atifParser.ts        # ATIF / Harbor trajectory JSON parser
-    liveSessionParser.ts # Incremental records and patches, parity-preserving normalization
+    liveSessionParser.ts # Incremental records, retained normalizers, immutable publication
+    liveNormalization.ts # Indexed aggregates, tool pairing, and affected-turn helpers
+    liveClaudeNormalizer.ts # Timestamp, cumulative usage, and boundary-duration state
+    liveCopilotNormalizer.ts # Indexed tool/lifecycle dependencies and turn aggregates
+    liveCodexNormalizer.ts # Stateful emission, cumulative usage, and indexed turns
+    liveVSCodeNormalizer.ts # Owned patch tree, request caches, and local part updates
     liveSessionWorker.ts # Off-main-thread live normalization
     liveParserClient.js  # Single-flight worker, coalescing, resets and disposal
     tracksLayout.js      # Bounded overview geometry retaining original evidence

--- a/docs/live-normalization.md
+++ b/docs/live-normalization.md
@@ -1,0 +1,64 @@
+# Incremental live normalization
+
+AGENTVIZ retains normalization state for Claude Code, Copilot CLI, Codex rollout JSONL, and VS Code base-plus-patch JSONL. This replaces the worker-only mitigation in PR #131. The batch `parseSession` path remains an independent oracle for complete normalized events, turns, and metadata.
+
+## Contracts
+
+- JSON decoding consumes complete new records. Blank lines and CRLF are accepted. An unfinished trailing record is buffered; no warning is emitted until an invalid line is complete. Complete JSON records without a trailing newline remain accepted for the existing SSE/client contract.
+- `createLiveSessionParser` creates a single-owner accumulator. Append calls consume that state; callers must not branch by appending independently to an old state handle.
+- Published results are independent snapshots by default, preserving prior render state even when an early event changes. The worker opts out of this extra copy with `{ snapshot: false }`; `postMessage` performs the required structured clone instead.
+- Initial loading visits the initial history once. Ordinary appends retain records, event indices, turns, model counts, usage totals, and indexed duration maxima. No full-history concatenation of record arrays or batch-parser invocation occurs on ordinary appends.
+- Sparse numeric indices have a fixed 32-level address space. Sorted timeline/turn lookups use binary search. Metadata publication also depends on the number of distinct models/reasoning efforts, not just the appended record count.
+- Reset or file truncation creates a fresh accumulator. The single-flight client discards pending pre-reset batches and their results. An empty normalized session is published as `null`, including VS Code removal of all requests.
+- An incompatible format declaration invalidates the format-dependent state. Static non-JSONL formats continue using their existing import parsers; this is not incremental support for arbitrary JSON documents.
+
+## Format-specific dependencies
+
+| Format | Retained state and affected updates |
+| --- | --- |
+| Claude Code | Synthetic and real timestamps, timestamp-majority decision, absolute-time minima, original event durations, deduplicated usage maxima, first usage-bearing event, session identity, and tool/result indices. A later usage fragment updates the first matching assistant event. An ordinary append recalculates only the previous boundary duration and new events. |
+| Copilot CLI | Completion records, tool/message dependency lists, task/subagent identity, reasoning-effort boundaries, explicit turns, and per-turn maxima/error/tool counts. Completion updates keep unchanged `eventIndices` membership in place. Shutdown usage/cost and session metadata use the latest applicable records. |
+| Codex | Current model/turn context, lifecycle records, cumulative token totals, web-search association indices, sorted events, explicit/unbound turn membership, and active turn aggregates. Late lifecycle and context changes update relevant turns and formerly unbound events. |
+| VS Code | An owned mutable patch tree, cached request offsets, response-part positions, and per-request error counts. Local tool-result/content patches remap the affected response part. Structural response edits recalculate the affected request's proportional timestamps and propagate minimum-spacing changes only until boundaries settle. |
+
+Global changes are not incorrectly treated as constant work. A changed timestamp origin or Claude timestamp-majority decision can affect the entire timeline. An out-of-order event or a structural request edit can shift an entire suffix of public evidence indices. New reasoning-effort or lifecycle information can affect earlier events. These changes explicitly invalidate affected state rather than leaving stale timestamps, memberships, totals, or tool outputs. They may require history-sized work when history-sized output changes.
+
+## Deterministic work and measurements
+
+`normalizationWork` reports records/requests examined, event visits or updates, and turn membership/aggregate updates for the last append. Counts include affected old records, not just newly decoded lines. A VS Code patch plus its normalized request counts as two record/request operations. Counts are instrumentation, not CPU instruction counts. Separate regressions intercept turn-array `splice` to ensure completion updates do not hide history-sized index shifts.
+
+Run the existing Vitest runner:
+
+```powershell
+npm test -- src\__tests__\liveNormalizationBenchmark.test.ts
+```
+
+The benchmark calls the retained normalizer directly, excluding JSON decoding and publication. It takes medians of 11 equal ten-record batches after 100 and 10,000 historical items. Copilot CLI and Codex retain a single large active turn; VS Code uses independent requests with a user message and response. Timing is observational, not a flaky test threshold. Equal deterministic work is asserted.
+
+Representative Windows results:
+
+| Format | Record/event/turn operations, both histories | Normalization ms, 100 / 10,000 | Snapshot clone ms, 100 / 10,000 |
+| --- | --- | --- | --- |
+| Claude Code | 10 / 22 / 11 | 0.052 / 0.076 | 0.518 / 40.226 |
+| Copilot CLI | 10 / 10 / 10 | 0.092 / 0.147 | 0.385 / 27.763 |
+| Codex | 10 / 20 / 12 | 0.105 / 0.178 | 0.483 / 32.735 |
+| VS Code | 20 / 30 / 10 | 0.073 / 0.230 | 0.802 / 68.288 |
+
+Snapshot cloning is deliberately measured separately. It is not constant-time, nor is full worker serialization, raw-text transfer, downstream rendering, or derived UI computation. The browser worker test additionally checks actual worker/client delivery and timer progress; main-thread append timings in the existing cleanup benchmark include snapshot copying.
+
+## Regression coverage
+
+- Batch/live parity at every completed fixture prefix, including the multi-agent fixture.
+- One-record, three-record, whole-batch, and seeded random byte partitions; blank/CRLF records and unfinished tails.
+- Seeded out-of-order records, changed origins, timestamp-majority transitions, late/repeated tool results, cumulative usage, model/effort changes, shutdown, and resume.
+- Late Codex lifecycle activation/deactivation and Copilot completion membership regressions found during self-review.
+- Bound checks after 100/5,000 historical records, including one VS Code tool-result patch in a request containing 5,000 sibling responses.
+- Real HTTP snapshot/SSE append and truncation-reset tests for every live format, plus cursor resume and partial UTF-8 regressions.
+- Actual browser worker append parity and queued-reset discard for every live format, alongside the existing v2 and cleanup browser suites.
+
+```powershell
+npm test
+npm run typecheck
+npm run build
+npx playwright test 'v2-smoke.spec.js' 'cleanup.spec.js' 'live-normalization.spec.js'
+```

--- a/src/__tests__/liveNormalization.test.ts
+++ b/src/__tests__/liveNormalization.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { appendLiveSessionText, createLiveSessionParser } from "../lib/liveSessionParser";
+import { parseSession } from "../lib/parseSession";
+
+const encode = (records: unknown[]) => records.map(record => JSON.stringify(record)).join("\n");
+const stamp = (i: number) => new Date(Date.UTC(2026, 0, 1) + i * 1000).toISOString();
+
+export function workload(format: string, size: number): unknown[] {
+  if (format === "claude-code") return Array.from({ length: size }, (_, i) => ({
+    type: "user", timestamp: stamp(i), message: { content: "message " + i },
+  }));
+  if (format === "copilot-cli") return [
+    { type: "session.start", timestamp: stamp(0), data: { producer: "copilot-agent", startTime: stamp(0) } },
+    ...Array.from({ length: size }, (_, i) => ({ type: "user.message", timestamp: stamp(i), data: { content: "message " + i } })),
+  ];
+  if (format === "codex") return [
+    { type: "session_meta", payload: { originator: "codex-cli" } },
+    ...Array.from({ length: size }, (_, i) => ({
+      type: "response_item", timestamp: stamp(i), payload: { type: "message", role: "user", content: "message " + i },
+    })),
+  ];
+  return [
+    { kind: 0, v: { version: 3, sessionId: "scaling", creationDate: Date.UTC(2026, 0, 1), requests: [] } },
+    ...Array.from({ length: size }, (_, i) => ({
+      kind: 2, k: ["requests"], v: [{ timestamp: Date.UTC(2026, 0, 1) + i * 1000, message: { text: "message " + i }, response: [] }],
+    })),
+  ];
+}
+
+  for (const format of ["claude-code", "copilot-cli", "codex", "vscode-chat"]) {
+    it(`${format}: equal deltas do not revisit unaffected history`, () => {
+      const work = [100, 5000].map(size => {
+        const records = workload(format, size + 5);
+        let state = createLiveSessionParser(encode(records.slice(0, -5)));
+        state = appendLiveSessionText(state, encode(records.slice(-5))).state;
+        expect(state.result).toEqual(parseSession(encode(records)));
+        expect(state.result).toEqual(parseSession(state.rawText));
+        return (state as any).normalizationWork;
+      });
+      expect(work[0]).toBeDefined();
+      expect(work[1].records).toBe(format === "vscode-chat" ? 10 : 5);
+      expect(work[1].events).toBeLessThanOrEqual(work[0].events + 5);
+      expect(work[1].turns).toBeLessThanOrEqual(work[0].turns + 5);
+    });
+  }
+
+    const claudeRecords = [
+      { type: "user", sessionId: "retained", message: { content: "first" } },
+      { type: "assistant", message: { id: "a", model: "first-model", content: [{ type: "tool_use", id: "tool", name: "read", input: {} }] } },
+      { type: "assistant", timestamp: stamp(4), message: { id: "a", model: "other-model", usage: { input_tokens: 10, output_tokens: 2 }, content: [{ type: "text", text: "partial" }] } },
+      { type: "tool_result", timestamp: stamp(5), tool_use_id: "tool", content: "first result" },
+      { type: "tool_result", timestamp: stamp(6), tool_use_id: "tool", content: "updated result" },
+      { type: "assistant", timestamp: stamp(7), message: { id: "a", usage: { input_tokens: 12, output_tokens: 9, cache_read_input_tokens: 4 }, content: [{ type: "text", text: "final" }] } },
+      { type: "user", timestamp: stamp(1), message: { content: "backdated user" } },
+      { type: "assistant", message: { content: [{ type: "thinking", thinking: "without timestamp" }] } },
+      ...Array.from({ length: 8 }, () => ({ type: "ignored" })),
+    ];
+
+    const copilotRecords = [
+      { type: "session.start", timestamp: stamp(0), data: { producer: "copilot-agent", startTime: stamp(0), sessionId: "retained" } },
+      { type: "user.message", timestamp: stamp(1), data: { content: "hello" } },
+      { type: "assistant.turn_start", timestamp: stamp(2) },
+      { type: "assistant.message", timestamp: stamp(3), data: { content: "working", toolRequests: [{ name: "read", toolCallId: "tool" }] } },
+      { type: "tool.execution_start", timestamp: stamp(4), data: { toolCallId: "tool", toolName: "read", parentToolCallId: "task", arguments: { path: "x" } } },
+      { type: "tool.execution_complete", timestamp: stamp(9), data: { toolCallId: "tool", model: "model-a", success: false, result: { content: "failed" } } },
+      { type: "tool.execution_start", timestamp: stamp(3), data: { toolCallId: "task", toolName: "task", arguments: { agent_type: "explore", description: "Explore" } } },
+      { type: "subagent.started", timestamp: stamp(3), data: { toolCallId: "task", agentName: "research", agentDisplayName: "Researcher" } },
+      { type: "subagent.completed", timestamp: stamp(11), data: { toolCallId: "task" } },
+      { type: "session.model_change", timestamp: stamp(5), data: { previousReasoningEffort: "low", reasoningEffort: "high" } },
+      { type: "assistant.turn_end", timestamp: stamp(12) },
+      { type: "tool.execution_complete", timestamp: stamp(6), data: { toolCallId: "tool", model: "model-b", success: true, result: { content: "ok" } } },
+      { type: "assistant.turn_start", timestamp: stamp(4) },
+      { type: "assistant.message", timestamp: stamp(8), data: { content: "earlier" } },
+      { type: "session.shutdown", timestamp: stamp(13), data: { shutdownType: "error", errorReason: "interrupted", totalNanoAiu: 1e9, modelMetrics: { "model-b": { usage: { inputTokens: 30, outputTokens: 5, cacheReadTokens: 10 }, requests: { count: 4 } } } } },
+      { type: "session.resume", timestamp: stamp(14), data: { producer: "copilot-agent", resumeTime: stamp(14), reasoningEffort: "medium" } },
+    ];
+
+    const codexRecords = [
+      { type: "session_meta", payload: { originator: "codex-cli", id: "retained" } },
+      { type: "response_item", timestamp: stamp(0), payload: { type: "message", role: "assistant", content: "before lifecycle" } },
+      { type: "event_msg", timestamp: stamp(1), payload: { type: "task_started", turn_id: "a" } },
+      { type: "turn_context", payload: { turn_id: "a", model: "model-a", effort: "low" } },
+      { type: "response_item", timestamp: stamp(2), payload: { type: "message", role: "user", content: "hello" } },
+      { type: "response_item", timestamp: stamp(3), payload: { type: "web_search_call", action: { query: "one" } } },
+      { type: "event_msg", timestamp: stamp(5), payload: { type: "web_search_end", call_id: "web", query: "one" } },
+      { type: "response_item", timestamp: stamp(6), payload: { type: "function_call", call_id: "read", name: "read", arguments: '{"path":"x"}' } },
+      { type: "response_item", timestamp: stamp(9), payload: { type: "function_call_output", call_id: "read", output: "ok" } },
+      { type: "event_msg", timestamp: stamp(10), payload: { type: "token_count", info: { total_token_usage: { input_tokens: 30, cached_input_tokens: 10, output_tokens: 5 } } } },
+      { type: "event_msg", timestamp: stamp(12), payload: { type: "task_complete", turn_id: "a" } },
+      { type: "event_msg", timestamp: stamp(4), payload: { type: "task_started", turn_id: "b" } },
+      { type: "turn_context", payload: { turn_id: "b", model: "model-b", effort: "high", summary: "new turn" } },
+      { type: "response_item", timestamp: stamp(7), payload: { type: "message", role: "assistant", content: "out of order" } },
+      { type: "response_item", timestamp: stamp(11), payload: { type: "function_call_output", call_id: "read", output: "updated" } },
+      { type: "turn_context", payload: { turn_id: "a", model: "changed", effort: "medium" } },
+      { type: "event_msg", timestamp: stamp(15), payload: { type: "token_count", info: { total_token_usage: { input_tokens: 40, output_tokens: 12 } } } },
+      { type: "response_item", timestamp: stamp(-2), payload: { type: "message", role: "user", content: "new origin" } },
+    ];
+
+    const request = (i: number) => ({ timestamp: Date.UTC(2026, 0, 1) + i * 1000, message: { text: "request " + i }, response: [{ value: "response" }] });
+    const vscodeRecords = [
+      { kind: 0, v: { version: 3, sessionId: "retained", requests: [request(1)] } },
+      { kind: 2, k: ["requests"], v: [request(10), request(20)] },
+      { kind: 2, k: ["requests", 0, "response"], v: [{ kind: "toolInvocationSerialized", toolId: "read", toolCallId: "tool", resultDetails: [{ value: "ok" }] }] },
+      { kind: 1, k: ["requests", 0, "response", 1, "resultDetails"], v: [{ value: "error" }] },
+      { kind: 1, k: ["requests", 0, "result"], v: { timings: { totalElapsed: 90000 } } },
+      { kind: 1, k: ["requests", 1, "response"], v: [] },
+      { kind: 1, k: ["selectedModel"], v: { identifier: "new-model" } },
+      { kind: 1, k: ["requests", 0, "timestamp"], v: Date.UTC(2026, 0, 1) - 30000 },
+      { kind: 1, k: ["customTitle"], v: "Title" },
+      { kind: 1, k: ["requests", "length"], v: 1 },
+      { kind: 1, k: ["requests"], v: [] },
+      { kind: 2, k: ["requests"], v: [request(30)] },
+    ];
+
+    describe("cross-record invalidation and delivery", () => {
+      for (const [format, records] of Object.entries({ claude: claudeRecords, copilot: copilotRecords, codex: codexRecords, vscode: vscodeRecords })) {
+        for (const partition of [1, 3, 100]) {
+          it(`${format}: batch oracle parity at every boundary, partition ${partition}`, () => {
+            let state = createLiveSessionParser("");
+            for (let i = 0; i < records.length; i += partition) {
+              const previous = state.result;
+              const saved = structuredClone(previous);
+              state = appendLiveSessionText(state, encode(records.slice(i, i + partition))).state;
+              expect(state.result).toEqual(parseSession(state.rawText));
+              expect(previous).toEqual(saved);
+            }
+          });
+        }
+        it(`${format}: deterministic random byte partitions, blank lines, CRLF, unfinished tails and reset`, () => {
+          const text = "\r\n" + records.map(record => JSON.stringify(record)).join("\r\n\r\n") + "\r\n";
+          let state = createLiveSessionParser("");
+          let seed = 12345;
+          for (let cursor = 0; cursor < text.length;) {
+            seed = (Math.imul(seed, 1664525) + 1013904223) >>> 0;
+            const length = seed % 73 + 1;
+            state = appendLiveSessionText(state, text.slice(cursor, cursor + length)).state;
+            cursor += length;
+          }
+          expect(state.result).toEqual(parseSession(encode(records)));
+          state = appendLiveSessionText(state, '{"unfinished":').state;
+          expect(state.pendingText).not.toBe("");
+          state = createLiveSessionParser(encode(records.slice(0, 2)));
+          expect(state.result).toEqual(parseSession(encode(records.slice(0, 2))));
+        });
+        if (format !== "vscode") {
+          it(`${format}: deterministic reordered-record parity`, () => {
+            for (let seed = 1; seed <= 12; seed++) {
+              const reordered = records.slice(1);
+              let random = seed;
+              for (let i = reordered.length - 1; i > 0; i--) {
+                random = (Math.imul(random, 1664525) + 1013904223) >>> 0;
+                const j = random % (i + 1);
+                [reordered[i], reordered[j]] = [reordered[j], reordered[i]];
+              }
+              let state = createLiveSessionParser(encode(records.slice(0, 1)));
+              for (let i = 0; i < reordered.length; i++) {
+                state = appendLiveSessionText(state, encode([reordered[i]])).state;
+                expect(state.result, `seed=${seed}, record=${i}, type=${(reordered[i] as any).type}`).toEqual(parseSession(state.rawText));
+              }
+            }
+          });
+        }
+      }
+    });
+
+  const fixtures = readdirSync(join(__dirname, "fixtures")).filter(name => name.endsWith(".jsonl"));
+  for (const name of fixtures) {
+    it(`${name}: every completed prefix agrees with the batch oracle`, () => {
+      const text = readFileSync(join(__dirname, "fixtures", name), "utf8");
+      let state = createLiveSessionParser("");
+      for (const record of text.split("\n").filter(line => line.trim())) {
+        state = appendLiveSessionText(state, record + "\n").state;
+        expect(state.result).toEqual(parseSession(state.rawText));
+      }
+      const lines = text.split("\n").filter(line => line.trim());
+      for (const partition of [3, lines.length]) {
+        state = createLiveSessionParser("\r\n \r\n");
+        for (let i = 0; i < lines.length; i += partition) {
+          state = appendLiveSessionText(state, lines.slice(i, i + partition).join("\r\n \r\n") + "\r\n").state;
+          expect(state.result).toEqual(parseSession(state.rawText));
+        }
+      }
+    });
+  }
+
+    describe("bounded late updates", () => {
+      for (const size of [100, 5000]) {
+        it(`Claude usage and tool results update early records directly after ${size} records`, () => {
+          const initial = [
+            { type: "assistant", timestamp: stamp(0), message: { id: "dedup", usage: { input_tokens: 1 }, content: [{ type: "tool_use", id: "old", name: "read", input: {} }] } },
+            ...workload("claude-code", size),
+          ];
+          const delta = [
+            { type: "assistant", timestamp: stamp(size + 1), message: { id: "dedup", usage: { input_tokens: 50, output_tokens: 10 }, content: [{ type: "text", text: "done" }] } },
+            { type: "tool_result", timestamp: stamp(size + 2), tool_use_id: "old", content: "completed" },
+          ];
+          const state = appendLiveSessionText(createLiveSessionParser(encode(initial)), encode(delta)).state;
+          expect(state.result).toEqual(parseSession(encode([...initial, ...delta])));
+          expect(state.normalizationWork.events).toBeLessThan(20);
+        });
+        it(`Copilot completion updates dependent tool/message and turn aggregates after ${size} records`, () => {
+          const initial = [
+            copilotRecords[0], copilotRecords[1], copilotRecords[2], copilotRecords[3], copilotRecords[4],
+            ...Array.from({ length: size }, (_, i) => ({ type: "assistant.message", timestamp: stamp(i + 20), data: { content: "message " + i } })),
+          ];
+          const delta = [copilotRecords[5]];
+          const state = appendLiveSessionText(createLiveSessionParser(encode(initial)), encode(delta)).state;
+          expect(state.result).toEqual(parseSession(encode([...initial, ...delta])));
+          expect(state.normalizationWork.records).toBeLessThan(5);
+          expect(state.normalizationWork.events).toBeLessThan(10);
+          expect(state.normalizationWork.turns).toBeLessThan(10);
+        });
+        it(`Codex lifecycle/model metadata and cumulative tokens avoid revisiting ${size} events`, () => {
+          const initial = [
+            codexRecords[0], codexRecords[2], codexRecords[3],
+            ...Array.from({ length: size }, (_, i) => ({ type: "response_item", timestamp: stamp(i + 20), payload: { type: "message", role: "assistant", content: "message " + i } })),
+          ];
+          const delta = [codexRecords[15], codexRecords[16], codexRecords[10]];
+          const state = appendLiveSessionText(createLiveSessionParser(encode(initial)), encode(delta)).state;
+          expect(state.result).toEqual(parseSession(encode([...initial, ...delta])));
+          expect(state.normalizationWork.events).toBeLessThan(10);
+          expect(state.normalizationWork.turns).toBeLessThan(10);
+        });
+        it(`VS Code patches one tool result without renormalizing ${size} sibling responses`, () => {
+          const initial = [{ kind: 0, v: { version: 3, sessionId: "parts", requests: [{
+            message: { text: "hello" }, response: [
+              { kind: "toolInvocationSerialized", toolId: "read", resultDetails: [{ value: "initial" }] },
+              ...Array.from({ length: size }, (_, i) => ({ value: "message " + i })),
+            ],
+          }] } }];
+          const delta = [{ kind: 1, k: ["requests", 0, "response", 0, "resultDetails"], v: [{ value: "failed" }] }];
+          const state = appendLiveSessionText(createLiveSessionParser(encode(initial)), encode(delta)).state;
+          expect(state.result).toEqual(parseSession(encode([...initial, ...delta])));
+          expect(state.normalizationWork.records).toBeLessThan(5);
+          expect(state.normalizationWork.events).toBeLessThan(5);
+        });
+      }
+    });

--- a/src/__tests__/liveNormalizationBenchmark.test.ts
+++ b/src/__tests__/liveNormalizationBenchmark.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from "vitest";
+import { createLiveSessionParser } from "../lib/liveSessionParser";
+import { parseSession } from "../lib/parseSession";
+
+const time = (i: number) => new Date(1700000000000 + i * 1000).toISOString();
+const encode = (records: unknown[]) => records.map(record => JSON.stringify(record)).join("\n");
+const median = (values: number[]) => values.sort((a, b) => a - b)[Math.floor(values.length / 2)];
+
+function records(format: string, start: number, count: number): Record<string, any>[] {
+  return Array.from({ length: count }, (_, offset) => {
+    const i = start + offset;
+    if (format === "claude-code") return { type: "user", timestamp: time(i), message: { content: "message " + i } };
+    if (format === "copilot-cli") return { type: "assistant.message", timestamp: time(i), data: { content: "message " + i } };
+    if (format === "codex") return { type: "response_item", timestamp: time(i), payload: { type: "message", role: "assistant", content: "message " + i } };
+    return { kind: 2, k: ["requests"], v: [{ timestamp: 1700000000000 + i * 1000, message: { text: "message " + i }, response: [{ value: "response" }] }] };
+  });
+}
+
+function header(format: string): Record<string, any>[] {
+  if (format === "copilot-cli") return [
+    { type: "session.start", timestamp: time(0), data: { producer: "copilot-agent", startTime: time(0) } },
+    { type: "assistant.turn_start", timestamp: time(0) },
+  ];
+  if (format === "codex") return [
+    { type: "session_meta", payload: { originator: "codex-cli" } },
+    { type: "event_msg", timestamp: time(0), payload: { type: "task_started", turn_id: "active" } },
+    { type: "turn_context", payload: { turn_id: "active", model: "model" } },
+  ];
+  if (format === "vscode-chat") return [{ kind: 0, v: { version: 3, sessionId: "benchmark", requests: [], creationDate: 1700000000000 } }];
+  return [];
+}
+
+for (const format of ["claude-code", "copilot-cli", "codex", "vscode-chat"]) {
+  it(`${format}: measures normalization separately from full snapshot cloning`, () => {
+    const measurements = [100, 10000].map(history => {
+      const all = [...header(format), ...records(format, 0, history)];
+      const state = createLiveSessionParser(encode(all), { snapshot: false });
+      const normalizer = state.normalizer!;
+      const normalization: number[] = [];
+      const snapshots: number[] = [];
+      let result = state.result;
+      for (let batch = 0; batch < 11; batch++) {
+        const delta = records(format, history + batch * 10, 10);
+        const start = performance.now();
+        result = normalizer.append(delta, 0);
+        normalization.push(performance.now() - start);
+        const deliveryStart = performance.now();
+        structuredClone(result);
+        snapshots.push(performance.now() - deliveryStart);
+        all.push(...delta);
+      }
+      expect(result).toEqual(parseSession(encode(all)));
+      return {
+        format, history, delta: 10, ...normalizer.work,
+        normalizationMedianMs: +median(normalization).toFixed(3),
+        snapshotCloneMedianMs: +median(snapshots).toFixed(3),
+      };
+    });
+    expect(measurements[1].records).toBe(measurements[0].records);
+    expect(measurements[1].events).toBe(measurements[0].events);
+    expect(measurements[1].turns).toBe(measurements[0].turns);
+    process.stdout.write("Retained normalization benchmark " + JSON.stringify(measurements) + "\n");
+  });
+}

--- a/src/__tests__/liveNormalizationReview.test.ts
+++ b/src/__tests__/liveNormalizationReview.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "vitest";
+import { createLiveSessionParser, appendLiveSessionText } from "../lib/liveSessionParser";
+import { parseSession } from "../lib/parseSession";
+
+const encode = (records: unknown[]) => records.map(record => JSON.stringify(record)).join("\n");
+const time = (i: number) => new Date(1700000000000 + i * 1000).toISOString();
+
+it("activates an earlier Codex turn and removes the old empty turn in one append", () => {
+  const records = [
+    { type: "session_meta", payload: { originator: "codex-cli" } },
+    { type: "response_item", timestamp: time(1), payload: { type: "message", role: "assistant", content: "unbound" } },
+    { type: "event_msg", timestamp: time(18), payload: { type: "task_started", turn_id: "b" } },
+    { type: "turn_context", payload: { turn_id: "a", model: "m1" } },
+    { type: "response_item", timestamp: time(12), payload: { type: "message", role: "user", content: "hello" } },
+  ];
+  let state = createLiveSessionParser("");
+  for (const record of records) {
+    state = appendLiveSessionText(state, encode([record])).state;
+    expect(state.result).toEqual(parseSession(state.rawText));
+  }
+  expect(state.result?.turns.map(turn => turn.turnId)).toEqual(["a"]);
+});
+
+for (const count of [100, 5000]) {
+  it(`does not shift ${count} turn indices to update one Copilot completion`, () => {
+    const initial = [
+      { type: "session.start", timestamp: time(0), data: { producer: "copilot-agent", startTime: time(0) } },
+      { type: "assistant.turn_start", timestamp: time(0) },
+      { type: "tool.execution_start", timestamp: time(1), data: { toolName: "read", toolCallId: "old" } },
+      ...Array.from({ length: count }, (_, i) => ({ type: "assistant.message", timestamp: time(i + 2), data: { content: "message " + i } })),
+    ];
+    let state = createLiveSessionParser(encode(initial), { snapshot: false });
+    const indices = state.result!.turns[0].eventIndices;
+    let shifted = 0;
+    Object.defineProperty(indices, "splice", { configurable: true, value(start: number, remove: number, ...items: number[]) {
+      shifted += indices.length - start - remove;
+      return Array.prototype.splice.call(indices, start, remove, ...items);
+    } });
+    const delta = { type: "tool.execution_complete", timestamp: time(count + 2), data: { toolCallId: "old", success: false, result: { content: "failed" } } };
+    state = appendLiveSessionText(state, encode([delta])).state;
+    expect(shifted).toBe(0);
+    expect(state.result).toEqual(parseSession(encode([...initial, delta])));
+  });
+}
+
+it("skips unaffected VS Code requests between distant patches without an explicit creation date", () => {
+  const initial = { kind: 0, v: { version: 3, sessionId: "sparse", requests: Array.from({ length: 5000 }, (_, i) => ({
+    timestamp: 1700000000000 + i * 1000, message: { text: "message " + i }, response: [],
+  })) } };
+  const delta = [0, 4999].map(i => ({ kind: 1, k: ["requests", i, "message", "text"], v: "changed " + i }));
+  let state = appendLiveSessionText(createLiveSessionParser(encode([initial])), encode(delta)).state;
+  expect(state.result).toEqual(parseSession(encode([initial, ...delta])));
+  expect(state.normalizationWork.records).toBe(4);
+  expect(state.normalizationWork.events).toBe(2);
+  const truncate = { kind: 1, k: ["requests", "length"], v: 4999 };
+  state = appendLiveSessionText(state, encode([truncate])).state;
+  expect(state.result).toEqual(parseSession(encode([initial, ...delta, truncate])));
+  expect(state.normalizationWork.records).toBe(1);
+  expect(state.normalizationWork.events).toBe(1);
+});

--- a/src/__tests__/liveProtocol.test.ts
+++ b/src/__tests__/liveProtocol.test.ts
@@ -31,6 +31,44 @@ function nextPayload(port: number, offset: string | null, connected: () => void,
 }
 
 describe("live snapshot and actual SSE contract", () => {
+  for (const format of ["test-claude-code.jsonl", "test-copilot.jsonl", "test-codex.jsonl", "test-vscode-chat.json"]) {
+    it(`${format}: actual SSE append and truncation reset match the batch oracle`, async () => {
+      const fixture = fs.readFileSync(path.join(__dirname, "fixtures", format), "utf8");
+      const lines = format.endsWith(".json")
+        ? [
+          JSON.stringify({ kind: 0, v: JSON.parse(fixture) }),
+          JSON.stringify({ kind: 1, k: ["customTitle"], v: "Streamed title" }),
+          JSON.stringify({ kind: 1, k: ["requests", 0, "message", "text"], v: "Streamed user text" }),
+        ]
+        : fixture.trim().split("\n");
+      const directory = fs.mkdtempSync(path.join(process.cwd(), ".live-protocol-"));
+      const file = path.join(directory, "session.jsonl");
+      fs.writeFileSync(file, lines[0] + "\n");
+      const server = createServer({ sessionFile: file, distDir: directory });
+      try {
+        await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+        const port = (server.address() as any).port;
+        const response = await fetch(`http://127.0.0.1:${port}/api/file?live=1`);
+        let state = createLiveSessionParser(await response.text());
+        let cursor = response.headers.get("X-Agentviz-Cursor");
+        for (const line of lines.slice(1)) {
+          const payload = await nextPayload(port, cursor, () => fs.appendFileSync(file, line + "\n"));
+          state = appendLiveSessionText(state, payload.lines).state;
+          cursor = payload.cursor;
+          expect(state.result).toEqual(parseSession(state.rawText));
+        }
+        fs.writeFileSync(file, lines[0] + "\n");
+        const payload = await nextPayload(port, cursor, () => {});
+        expect(payload.reset).toBe(true);
+        state = appendLiveSessionText(createLiveSessionParser(""), payload.lines).state;
+        expect(state.result).toEqual(parseSession(lines[0]));
+      } finally {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+        fs.rmSync(directory, { recursive: true, force: true });
+      }
+    });
+  }
+
   it("catches appends before subscription, resumes after disconnect, and resets after replacement", async () => {
     const directory = fs.mkdtempSync(path.join(process.cwd(), ".live-protocol-"));
     const file = path.join(directory, "session.jsonl");

--- a/src/__tests__/sessionLoadingRegression.test.jsx
+++ b/src/__tests__/sessionLoadingRegression.test.jsx
@@ -69,6 +69,21 @@ describe("session load completion", () => {
       });
       expect(loader.events[0].text).toBe("replacement evidence");
       expect(sources).toHaveLength(1);
+      const vscode = JSON.stringify({ kind: 0, v: {
+        version: 3, sessionId: "patch-delete", requests: [{ message: { text: "remove me" }, response: [] }],
+      } });
+      await act(async () => {
+        sources[0].onmessage({ data: JSON.stringify({ lines: vscode, reset: true }) });
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(loader.events).toHaveLength(1);
+      await act(async () => {
+        sources[0].onmessage({ data: JSON.stringify({ lines: JSON.stringify({ kind: 1, k: ["requests"], v: [] }) }) });
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(loader.events).toBeNull();
+      expect(loader.turns).toEqual([]);
+      expect(loader.metadata).toBeNull();
     } finally {
       await act(async () => root.unmount());
       vi.useRealTimers();

--- a/src/hooks/useSessionLoader.js
+++ b/src/hooks/useSessionLoader.js
@@ -178,12 +178,10 @@ export default function useSessionLoader(options) {
     if (updated.result && sourcePath) updated.result.metadata.sourcePath = sourcePath;
 
     if (!updated.result) {
-      if (reset) {
-        setEvents(null);
-        setTurns([]);
-        setMetadata(null);
-        setTotal(0);
-      }
+      setEvents(null);
+      setTurns([]);
+      setMetadata(null);
+      setTotal(0);
       return;
     }
 

--- a/src/lib/codexParser.ts
+++ b/src/lib/codexParser.ts
@@ -43,6 +43,7 @@ type ParseState = {
   currentModel: string | null;
   turnContexts: Record<string, CodexTurnContext>;
   turns: Record<string, CodexTurnLifecycle>;
+  turnCount?: number;
 };
 
 type ParsedRecords = {
@@ -248,6 +249,7 @@ function getEventTime(record: RawRecord, fallback: number): number {
 function ensureTurn(state: ParseState, turnId: string, startTime: number): CodexTurnLifecycle {
   if (!state.turns[turnId]) {
     state.turns[turnId] = { id: turnId, startTime, endTime: null, userMessage: null };
+    if (state.turnCount !== undefined) state.turnCount++;
   }
   return state.turns[turnId];
 }
@@ -383,7 +385,7 @@ function handleEventMessage(record: RawRecord, state: ParseState, events: Normal
   const payloadType = payload.type;
 
   if (payloadType === "task_started") {
-    const turnId = typeof payload.turn_id === "string" ? payload.turn_id : "turn-" + Object.keys(state.turns).length;
+    const turnId = typeof payload.turn_id === "string" ? payload.turn_id : "turn-" + (state.turnCount ?? Object.keys(state.turns).length);
     state.currentTurnId = turnId;
     ensureTurn(state, turnId, parseTimestamp(payload.started_at) || t);
     return;
@@ -588,10 +590,12 @@ function getLastTokenUsage(records: RawRecord[], warnings: string[]): TokenUsage
   return usage;
 }
 
-function buildMetadata(records: RawRecord[], events: NormalizedEvent[], turns: SessionTurn[], state: ParseState, malformedLines: number, warnings: string[]): SessionMetadata {
+function buildMetadata(records: RawRecord[], events: NormalizedEvent[], turns: SessionTurn[], state: ParseState, malformedLines: number, warnings: string[], summary?: {
+  models: Record<string, number>; totalToolCalls: number; errorCount: number; duration: number;
+}): SessionMetadata {
   const meta = getSessionMeta(records);
   const tokenUsage = getLastTokenUsage(records, warnings);
-  const models: Record<string, number> = {};
+  const models: Record<string, number> = { ...summary?.models };
   Object.keys(state.turnContexts).forEach(function (turnId) {
     const model = state.turnContexts[turnId].model;
     if (model) models[model] = (models[model] || 0) + 1;
@@ -606,9 +610,9 @@ function buildMetadata(records: RawRecord[], events: NormalizedEvent[], turns: S
   return {
     totalEvents: events.length,
     totalTurns: turns.length,
-    totalToolCalls: events.filter(function (event) { return event.track === "tool_call"; }).length,
-    errorCount: events.filter(function (event) { return event.isError; }).length,
-    duration: getSessionTotal(events),
+    totalToolCalls: summary?.totalToolCalls ?? events.filter(function (event) { return event.track === "tool_call"; }).length,
+    errorCount: summary?.errorCount ?? events.filter(function (event) { return event.isError; }).length,
+    duration: summary?.duration ?? getSessionTotal(events),
     models,
     primaryModel: modelEntries.length > 0 ? modelEntries[0][0] : null,
     tokenUsage,
@@ -646,3 +650,9 @@ export function parseCodexJSONL(text: string): ParsedSession | null {
   const parsed = parseRecords(text);
   return parseCodexRecords(parsed.records, parsed.malformedLines);
 }
+
+export const codexLive = {
+  getEventTime, updateTurnContext, handleEventMessage, pushMessageEvent,
+  pushReasoningEvent, pushToolCallEvent, pushToolOutputEvent, getWebSearchQuery,
+  buildMetadata, isRecord,
+};

--- a/src/lib/copilotCliParser.ts
+++ b/src/lib/copilotCliParser.ts
@@ -194,19 +194,23 @@ function attachReasoningEffort(events: NormalizedEvent[], records: RawRecord[], 
   }
 }
 
-function buildNormalizedEvents(records: RawRecord[], sessionStartSec: number, toolPairs: ToolPairs): NormalizedEvent[] {
+function buildNormalizedEvents(records: RawRecord[], sessionStartSec: number, toolPairs: ToolPairs, retained?: {
+  taskToolMap: Record<string, { agentType: string; description: string }>;
+  subagentStartTimes: Record<string, number>;
+  subagentLifecycle: Record<string, { agentName?: string; agentDisplayName?: string }>;
+}): NormalizedEvent[] {
   const events: NormalizedEvent[] = [];
   const seenToolStarts: Record<string, boolean> = {};
 
   // Build a map of task tool calls to their agent metadata
-  const taskToolMap: Record<string, { agentType: string; description: string }> = {};
-  const subagentStartTimes: Record<string, number> = {};
+  const taskToolMap: Record<string, { agentType: string; description: string }> = retained?.taskToolMap || {};
+  const subagentStartTimes: Record<string, number> = retained?.subagentStartTimes || {};
   // Lifecycle metadata from subagent.started events (preferred for display names)
-  const subagentLifecycle: Record<string, { agentName?: string; agentDisplayName?: string }> = {};
+  const subagentLifecycle: Record<string, { agentName?: string; agentDisplayName?: string }> = retained?.subagentLifecycle || {};
 
   // First pass: build taskToolMap from task tool execution_start events,
   // collect subagent.started timestamps and lifecycle metadata
-  for (let index = 0; index < records.length; index += 1) {
+  for (let index = 0; !retained && index < records.length; index += 1) {
     const record = records[index];
     const data = record.data || {};
 
@@ -641,6 +645,7 @@ function buildMetadata(
   events: NormalizedEvent[],
   turns: SessionTurn[],
   malformedLines: number,
+  summary?: { models: Record<string, number>; totalToolCalls: number; errorCount: number; duration: number },
 ): SessionMetadata {
   let sessionStart: Record<string, any> | null = null;
   let sessionResume: Record<string, any> | null = null;
@@ -653,9 +658,9 @@ function buildMetadata(
   }
 
   const sessionInfo = sessionStart || sessionResume;
-  let totalToolCalls = 0;
-  let errorCount = 0;
-  const models: Record<string, number> = {};
+  let totalToolCalls = summary?.totalToolCalls || 0;
+  let errorCount = summary?.errorCount || 0;
+  const models: Record<string, number> = { ...summary?.models };
 
   for (let index = 0; index < events.length; index += 1) {
     if (events[index].track === "tool_call") totalToolCalls += 1;
@@ -724,7 +729,7 @@ function buildMetadata(
   const reasoningEfforts = getReasoningEffortHistory(records);
   const reasoningEffort = getCurrentReasoningEffort(records);
 
-  const duration = getSessionTotal(events);
+  const duration = summary?.duration ?? getSessionTotal(events);
 
   const warnings: string[] = [];
   if (malformedLines > 0) warnings.push(malformedLines + " malformed line(s) skipped");
@@ -777,6 +782,7 @@ function buildMetadata(
 }
 
 export function detectCopilotCli(text: string): boolean {
+  text = text.trimStart();
   const firstNewline = text.indexOf("\n");
   const firstLine = firstNewline > 0 ? text.substring(0, firstNewline) : text;
 
@@ -825,3 +831,5 @@ export function parseCopilotCliJSONL(text: string): ParsedSession | null {
   const parsed = parseRawRecords(text);
   return parseCopilotCliRecords(parsed.records, parsed.malformedLines);
 }
+
+export const copilotLive = { parseTimestamp, buildNormalizedEvents, buildMetadata, getReasoningEffort };

--- a/src/lib/liveClaudeNormalizer.ts
+++ b/src/lib/liveClaudeNormalizer.ts
@@ -1,0 +1,102 @@
+import { claudeLive as helpers } from "./parser";
+import { computeCacheHitRate } from "./cacheMetrics";
+import { EventIndex, ToolResultIndex, buildUserTurns, type LiveNormalizer, type RawRecord } from "./liveNormalization";
+import type { NormalizedEvent, ParsedSession, SessionTurn, TokenUsage } from "./sessionTypes";
+
+export class LiveClaudeNormalizer implements LiveNormalizer {
+  private index = new EventIndex();
+  private pairs = new ToolResultIndex(this.index);
+  private originals: NormalizedEvent[] = [];
+  private turns: SessionTurn[] = [];
+  private recordCount = 0;
+  private timestampCount = 0;
+  private syntheticTime = 0;
+  private minimum = Infinity;
+  private realMinimum = Infinity;
+  private origin = Infinity;
+  private realTimestamps = false;
+  private usage = new Map<string, TokenUsage>();
+  private firstUsageEvent = new Map<string, number>();
+  private attached = new Set<string>();
+  private identity: string | undefined;
+  private issues = { malformedLines: 0, invalidEvents: 0 };
+  get work() { return this.index.work; }
+
+  append(records: RawRecord[], malformedLines: number): ParsedSession | null {
+    const index = this.index;
+    index.begin(records.length);
+    const start = this.originals.length;
+    const usageChanged = new Set<number>();
+    for (const record of records) {
+      this.recordCount++;
+      if (helpers.extractTimestamp(record) !== null) this.timestampCount++;
+      if (!this.identity && typeof record.sessionId === "string" && record.sessionId) this.identity = record.sessionId;
+      const key = helpers.getUsageDedupKey(record);
+      const usage = helpers.extractUsage(record);
+      if (key && usage) this.usage.set(key, helpers.mergeTokenUsage(this.usage.get(key), usage));
+      const events = helpers.extractEventsFromRecord(record, this.syntheticTime, this.issues, this.usage, this.attached);
+      this.syntheticTime += Math.max(1, events.length);
+      if (key && events.length && !this.firstUsageEvent.has(key)) this.firstUsageEvent.set(key, this.originals.length);
+      if (key && this.usage.has(key) && this.firstUsageEvent.has(key)) {
+        const first = this.firstUsageEvent.get(key)!;
+        const event = first < this.originals.length ? this.originals[first] : events[0];
+        event.tokenUsage = this.usage.get(key);
+        if (first < this.originals.length) {
+          // Usage may arrive after an earlier content record with the same id.
+          for (const next of events) delete next.tokenUsage;
+          usageChanged.add(first);
+        }
+        this.attached.add(key);
+      }
+      for (const event of events) {
+        this.minimum = Math.min(this.minimum, event.t);
+        if (event.t > 1e9) this.realMinimum = Math.min(this.realMinimum, event.t);
+        this.originals.push(event);
+      }
+    }
+    this.issues.malformedLines = malformedLines;
+    if (!this.originals.length) return null;
+    const real = this.timestampCount > this.recordCount * 0.5;
+    const origin = real && this.realMinimum !== Infinity ? this.realMinimum : this.minimum;
+    const rebase = origin !== this.origin || real !== this.realTimestamps;
+    this.origin = origin;
+    this.realTimestamps = real;
+    const changedFrom = rebase ? 0 : Math.max(0, start - 1);
+    for (let i = changedFrom; i < this.originals.length; i++) {
+      const original = this.originals[i];
+      const event = { ...original, t: Math.max(0, original.t - origin) };
+      if (real && i + 1 < this.originals.length) {
+        const gap = Math.max(0, this.originals[i + 1].t - origin) - event.t;
+        if (gap >= 0.1 && gap < 300) event.duration = gap;
+      }
+      if (i < start) event.turnIndex = index.events[i]?.turnIndex;
+      index.set(i, event);
+    }
+    for (const i of usageChanged) {
+      if (i < changedFrom) index.set(i, { ...index.events[i], tokenUsage: this.originals[i].tokenUsage });
+    }
+    if (rebase) {
+      this.turns = [];
+      buildUserTurns(index, this.turns, 0, false);
+    } else {
+      if (start > 0) {
+        const previous = index.events[start - 1];
+        this.turns[previous.turnIndex!].endTime = previous.t + previous.duration;
+        index.work.turns++;
+      }
+      buildUserTurns(index, this.turns, start, false);
+    }
+    // Re-normalizing a boundary event clears its paired output as well.
+    for (let i = changedFrom; i < index.events.length; i++) this.pairs.add(i);
+    const usage = index.usage;
+    const metadata = {
+      ...index.summary(this.turns),
+      tokenUsage: usage.inputTokens + usage.outputTokens + usage.cacheRead + usage.cacheWrite > 0
+        ? { ...usage, cacheHitRate: computeCacheHitRate(usage.inputTokens, usage.cacheWrite, usage.cacheRead) } : null,
+      warnings: helpers.buildWarnings(this.issues),
+      parseIssues: { ...this.issues }, format: "claude-code" as const,
+      ...(this.identity ? { sessionId: this.identity } : {}),
+    };
+    return { events: index.events, turns: this.turns, metadata };
+  }
+}

--- a/src/lib/liveCodexNormalizer.ts
+++ b/src/lib/liveCodexNormalizer.ts
@@ -1,0 +1,320 @@
+import { codexLive as helpers } from "./codexParser";
+import {
+  EventIndex, NumericIndex, ToolResultIndex, buildUserTurns, lowerBound, upperBound,
+  type LiveNormalizer, type RawRecord,
+} from "./liveNormalization";
+import type { NormalizedEvent, ParsedSession, SessionTurn } from "./sessionTypes";
+
+type State = Parameters<typeof helpers.updateTurnContext>[1];
+type Slot = { event: NormalizedEvent; ordinal: number; position: number };
+type Bucket = {
+  id: string; ordinal: number; turn: SessionTurn; ends: NumericIndex;
+  users: NumericIndex; errors: number; active: boolean;
+};
+
+export class LiveCodexNormalizer implements LiveNormalizer {
+  private index = new EventIndex();
+  private contexts = new EventIndex();
+  private contextPositions = new Map<string, number>();
+  private state: State = { currentTurnId: null, currentModel: null, turnContexts: {}, turns: {}, turnCount: 0 };
+  private slots: Slot[] = [];
+  private syntheticTime = 0;
+  private origin = Infinity;
+  private nextOrdinal = 0;
+  private meta: RawRecord | undefined;
+  private token: RawRecord | undefined;
+  private buckets = new Map<string, Bucket>();
+  private boundaries: Bucket[] = [];
+  private turns: SessionTurn[] = [];
+  private owners: (Bucket | undefined)[] = [];
+  private unresolved: number[] = [];
+  private byTurnId = new Map<string, Set<number>>();
+  private webCalls: Slot[] = [];
+  private webByQuery = new Map<string, Slot[]>();
+  private webBarrier = -1;
+  private pendingTurns = new Set<string>();
+  private turnOrder = new Map<string, number>();
+  private pairs = new ToolResultIndex(this.index);
+  get work() { return this.index.work; }
+
+  private target(event: NormalizedEvent): Bucket {
+    const explicit = typeof event.codexTurnId === "string" ? this.buckets.get(event.codexTurnId) : undefined;
+    if (explicit) return explicit;
+    return this.boundaries[Math.max(0, upperBound(this.boundaries, event.t, boundary => boundary.turn.startTime) - 1)];
+  }
+
+  private refresh(bucket: Bucket): void {
+    const lifecycle = this.state.turns[bucket.id];
+    const context = this.state.turnContexts[bucket.id];
+    const start = Math.max(0, lifecycle.startTime - this.origin);
+    const end = lifecycle.endTime === null ? start : Math.max(start, lifecycle.endTime - this.origin);
+    const turn = bucket.turn;
+    turn.startTime = start;
+    turn.endTime = Math.max(end, bucket.ends.max);
+    turn.userMessage = lifecycle.userMessage || context?.summary || "(continuation)";
+    if (turn.userMessage === "(continuation)" && bucket.users.max !== -Infinity) {
+      turn.userMessage = this.index.events[-bucket.users.max].text;
+    }
+    turn.model = context?.model || null;
+    turn.effort = context?.effort || null;
+    turn.hasError = bucket.errors > 0;
+    this.index.work.turns++;
+  }
+  private remove(position: number): void {
+    const bucket = this.owners[position];
+    const event = this.index.events[position];
+    if (bucket) {
+      const list = bucket.turn.eventIndices;
+      const offset = lowerBound(list, position, n => n);
+      if (list[offset] === position) list.splice(offset, 1);
+      bucket.ends.set(position, -Infinity);
+      bucket.users.set(position, -Infinity);
+      if (event.track === "tool_call") bucket.turn.toolCount!--;
+      if (event.isError) bucket.errors--;
+    }
+    if (typeof event.codexTurnId === "string") this.byTurnId.get(event.codexTurnId)?.delete(position);
+    const offset = lowerBound(this.unresolved, position, n => n);
+    if (this.unresolved[offset] === position) this.unresolved.splice(offset, 1);
+    this.owners[position] = undefined;
+  }
+  private assign(position: number, dirty: Set<Bucket>): void {
+    const event = this.index.events[position];
+    const bucket = this.target(event);
+    this.owners[position] = bucket;
+    const indices = bucket.turn.eventIndices;
+    indices.splice(lowerBound(indices, position, n => n), 0, position);
+    bucket.ends.set(position, event.t + event.duration);
+    if (event.agent === "user") bucket.users.set(position, -position);
+    if (event.track === "tool_call") bucket.turn.toolCount!++;
+    if (event.isError) bucket.errors++;
+    if (typeof event.codexTurnId === "string") {
+      if (!this.byTurnId.has(event.codexTurnId)) this.byTurnId.set(event.codexTurnId, new Set());
+      this.byTurnId.get(event.codexTurnId)!.add(position);
+    }
+    if (typeof event.codexTurnId !== "string" || !this.buckets.has(event.codexTurnId)) {
+      this.unresolved.splice(lowerBound(this.unresolved, position, n => n), 0, position);
+    }
+    dirty.add(bucket);
+    event.turnIndex = bucket.turn.index;
+    this.index.work.turns++;
+  }
+
+  append(records: RawRecord[], malformedLines: number): ParsedSession | null {
+    const index = this.index;
+    index.begin(records.length);
+    const additions: Slot[] = [];
+    const changedTurns = this.pendingTurns;
+    const newBuckets: Bucket[] = [];
+    const changedCalls = new Set<Slot>();
+    const hadLifecycle = this.buckets.size > 0;
+    for (const record of records) {
+      const payload = record.payload || {};
+      if (!this.meta && record.type === "session_meta" && helpers.isRecord(record.payload)) this.meta = record;
+      if (record.type === "event_msg" && payload.type === "token_count" && helpers.isRecord(payload.info?.total_token_usage)) this.token = record;
+      const time = helpers.getEventTime(record, this.syntheticTime++);
+      const events: NormalizedEvent[] = [];
+      if (record.type === "turn_context") {
+        helpers.updateTurnContext(record, this.state);
+        if (typeof payload.turn_id === "string") {
+          const id = payload.turn_id;
+          changedTurns.add(id);
+          if (!this.contextPositions.has(id)) this.contextPositions.set(id, this.contextPositions.size);
+          this.contexts.set(this.contextPositions.get(id)!, {
+            t: 0, duration: 0, agent: "system", track: "context", text: "", intensity: 0, isError: false,
+            model: this.state.turnContexts[id].model,
+          });
+          index.work.events++;
+        }
+      } else if (record.type === "event_msg") {
+        if (payload.type === "web_search_end") {
+          if (payload.call_id) {
+            const query = helpers.getWebSearchQuery(payload);
+            const candidates = query ? this.webByQuery.get(query) || [] : this.webCalls;
+            const slot = candidates[candidates.length - 1];
+            if (slot && slot.ordinal > this.webBarrier) {
+              slot.event.toolCallId = payload.call_id;
+              this.webBarrier = slot.ordinal;
+              changedCalls.add(slot);
+            }
+          }
+          helpers.pushToolOutputEvent(events, record, this.state, time);
+        } else {
+          helpers.handleEventMessage(record, this.state, events, time);
+        }
+        const id = typeof payload.turn_id === "string" ? payload.turn_id : this.state.currentTurnId;
+        if (id) changedTurns.add(id);
+      } else if (record.type === "response_item" && helpers.isRecord(record.payload)) {
+        if (payload.type === "message") helpers.pushMessageEvent(events, record, this.state, time);
+        else if (payload.type === "reasoning") helpers.pushReasoningEvent(events, record, this.state, time);
+        else if (["function_call", "custom_tool_call", "web_search_call"].includes(payload.type)) helpers.pushToolCallEvent(events, record, this.state, time);
+        else if (["function_call_output", "custom_tool_call_output"].includes(payload.type)) helpers.pushToolOutputEvent(events, record, this.state, time);
+        if (this.state.currentTurnId) changedTurns.add(this.state.currentTurnId);
+      }
+      for (const event of events) {
+        const slot: Slot = { event, ordinal: this.nextOrdinal++, position: -1 };
+        additions.push(slot);
+        if (event.toolName === "web_search") {
+          this.webCalls.push(slot);
+          const query = helpers.getWebSearchQuery((event.raw as RawRecord).payload);
+          if (!this.webByQuery.has(query)) this.webByQuery.set(query, []);
+          this.webByQuery.get(query)!.push(slot);
+          if (event.toolCallId) this.webBarrier = slot.ordinal;
+        }
+      }
+      const touched = typeof payload.turn_id === "string" ? payload.turn_id : this.state.currentTurnId;
+      if (touched && this.state.turns[touched] && !this.turnOrder.has(touched)) this.turnOrder.set(touched, this.turnOrder.size);
+    }
+    let insertion = this.slots.length;
+    for (const slot of additions) {
+      let low = 0;
+      let high = this.slots.length;
+      while (low < high) {
+        const mid = (low + high) >>> 1;
+        if (this.slots[mid].event.t <= slot.event.t) low = mid + 1;
+        else high = mid;
+      }
+      this.slots.splice(low, 0, slot);
+      insertion = Math.min(insertion, low);
+    }
+    if (!this.slots.length) return null;
+    const origin = this.slots[0].event.t;
+    const rebase = origin !== this.origin;
+    this.origin = origin;
+    if (rebase) {
+      insertion = 0;
+      for (const id of this.buckets.keys()) changedTurns.add(id);
+    }
+    const dirty = new Set<Bucket>();
+    for (const id of changedTurns) {
+      if (!this.state.turns[id]) continue;
+      let bucket = this.buckets.get(id);
+      if (!bucket) {
+        bucket = {
+          id, ordinal: this.turnOrder.get(id)!, active: false, ends: new NumericIndex(), users: new NumericIndex(), errors: 0,
+          turn: { index: 0, startTime: 0, endTime: 0, eventIndices: [], toolCount: 0, hasError: false, turnId: id },
+        };
+        this.buckets.set(id, bucket);
+        newBuckets.push(bucket);
+      }
+      this.refresh(bucket);
+      dirty.add(bucket);
+    }
+    for (const bucket of newBuckets) {
+      let position = lowerBound(this.boundaries, bucket.turn.startTime, item => item.turn.startTime);
+      while (position < this.boundaries.length && this.boundaries[position].turn.startTime === bucket.turn.startTime
+        && this.boundaries[position].ordinal < bucket.ordinal) position++;
+      this.boundaries.splice(position, 0, bucket);
+    }
+    if (rebase) this.boundaries.sort((a, b) => a.turn.startTime - b.turn.startTime || a.ordinal - b.ordinal);
+    if (!hadLifecycle && this.buckets.size) {
+      insertion = 0;
+      this.turns = [];
+    }
+    const previousLength = index.events.length;
+    for (let i = previousLength - 1; i >= insertion; i--) {
+      if (this.owners[i]) dirty.add(this.owners[i]!);
+      this.pairs.remove(i);
+      this.remove(i);
+    }
+    for (let i = insertion; i < this.slots.length; i++) {
+      const slot = this.slots[i];
+      slot.position = i;
+      index.set(i, { ...slot.event, t: Math.max(0, slot.event.t - origin) });
+      if (this.buckets.size) this.assign(i, dirty);
+    }
+    // A late lifecycle can capture earlier unbound events, without examining
+    // already-resolved events belonging to unrelated turns.
+    if (this.buckets.size && insertion > 0) {
+      const reconsider = new Set<number>();
+      for (const bucket of newBuckets) {
+        for (const position of this.byTurnId.get(bucket.id) || []) if (position < insertion) reconsider.add(position);
+        let boundary = lowerBound(this.boundaries, bucket.turn.startTime, item => item.turn.startTime);
+        while (this.boundaries[boundary] !== bucket) boundary++;
+        const first = boundary === 0 ? 0 : lowerBound(index.events, bucket.turn.startTime, event => event.t);
+        const next = this.boundaries[boundary + 1]?.turn.startTime ?? Infinity;
+        for (let j = lowerBound(this.unresolved, first, n => n); j < this.unresolved.length; j++) {
+          const position = this.unresolved[j];
+          if (position >= insertion || index.events[position].t >= next) break;
+          reconsider.add(position);
+        }
+      }
+      for (const position of reconsider) {
+        if (this.target(index.events[position]) === this.owners[position]) continue;
+        if (this.owners[position]) dirty.add(this.owners[position]!);
+        this.remove(position);
+        this.assign(position, dirty);
+      }
+    }
+    if (this.buckets.size) {
+      let renumber = this.turns.length;
+      // Remove using the old stable indices before insertions can shift them.
+      const inactive = [...dirty].filter(bucket => bucket.active && !bucket.turn.eventIndices.length)
+        .sort((a, b) => b.turn.index - a.turn.index);
+      for (const bucket of inactive) {
+        const position = bucket.turn.index;
+        this.turns.splice(position, 1);
+        renumber = Math.min(renumber, position);
+        bucket.active = false;
+      }
+      for (const bucket of dirty) {
+        this.refresh(bucket);
+        const active = bucket.turn.eventIndices.length > 0;
+        if (active !== bucket.active) {
+          if (active) {
+            let position = lowerBound(this.turns, bucket.turn.startTime, turn => turn.startTime);
+            while (position < this.turns.length && this.turns[position].startTime === bucket.turn.startTime
+              && this.buckets.get(String(this.turns[position].turnId))!.ordinal < bucket.ordinal) position++;
+            this.turns.splice(position, 0, bucket.turn);
+            renumber = Math.min(renumber, position);
+          }
+          bucket.active = active;
+        }
+      }
+      if (rebase) {
+        this.turns.sort((a, b) => a.startTime - b.startTime || this.buckets.get(String(a.turnId))!.ordinal - this.buckets.get(String(b.turnId))!.ordinal);
+        renumber = 0;
+      }
+      for (let i = renumber; i < this.turns.length; i++) {
+        const turn = this.turns[i];
+        turn.index = i;
+        index.work.turns++;
+        for (const position of turn.eventIndices) {
+          index.events[position].turnIndex = i;
+          index.work.events++;
+        }
+      }
+      // Existing active turns do not need their old event indices revisited.
+      for (let i = insertion; i < index.events.length; i++) index.events[i].turnIndex = this.owners[i]!.turn.index;
+    } else {
+      let from = insertion;
+      if (insertion < previousLength) {
+        let turn: SessionTurn | undefined;
+        for (let i = this.turns.length - 1; i >= 0; i--) {
+          index.work.turns++;
+          if (this.turns[i].eventIndices[0] <= insertion) { turn = this.turns[i]; break; }
+        }
+        from = turn?.eventIndices[0] || 0;
+        this.turns.length = turn?.index || 0;
+        // The affected turn is rebuilt from its first event, not appended twice.
+        if (from > 0) index.events[from - 1].turnIndex = this.turns.length - 1;
+      }
+      buildUserTurns(index, this.turns, from, true);
+    }
+    for (const slot of changedCalls) {
+      if (slot.position < insertion) index.set(slot.position, { ...index.events[slot.position], toolCallId: slot.event.toolCallId });
+    }
+    const pairStart = insertion;
+    for (let i = pairStart; i < index.events.length; i++) this.pairs.add(i);
+    for (const slot of changedCalls) if (slot.position < pairStart) this.pairs.add(slot.position);
+    const models = this.contexts.models;
+    for (const [model, count] of Object.entries(index.models)) models[model] = (models[model] || 0) + count;
+    const metadataRecords = [this.meta, this.token].filter((record): record is RawRecord => Boolean(record));
+    const metadata = helpers.buildMetadata(metadataRecords, [], [], { ...this.state, turnContexts: {} }, malformedLines, [], {
+      ...index.summary(this.turns), models,
+    });
+    metadata.totalEvents = index.events.length;
+    metadata.totalTurns = this.turns.length;
+    changedTurns.clear();
+    return { events: index.events, turns: this.turns, metadata };
+  }
+}

--- a/src/lib/liveCopilotNormalizer.ts
+++ b/src/lib/liveCopilotNormalizer.ts
@@ -1,0 +1,272 @@
+import { copilotLive as helpers } from "./copilotCliParser";
+import { EventIndex, NumericIndex, lowerBound, upperBound, type LiveNormalizer, type RawRecord } from "./liveNormalization";
+import type { NormalizedEvent, ParsedSession, SessionTurn } from "./sessionTypes";
+
+type Node = { record: RawRecord; positions: number[]; ordinal: number };
+type Slot = { node: Node; offset: number; event: NormalizedEvent };
+type Turn = { value: SessionTurn; ends: NumericIndex; errors: number; end: number };
+
+export class LiveCopilotNormalizer implements LiveNormalizer {
+  private index = new EventIndex();
+  private nodes: Node[] = [];
+  private slots: Slot[] = [];
+  private dependencies = new Map<string, Set<Node>>();
+  private completes: Record<string, RawRecord> = Object.create(null);
+  private retained = {
+    taskToolMap: Object.create(null), subagentStartTimes: Object.create(null), subagentLifecycle: Object.create(null),
+  };
+  private seenStarts = new Set<string>();
+  private start: number | null = null;
+  private foundStart = false;
+  private firstTimestamp = 0;
+  private info: Record<string, RawRecord> = {};
+  private turns: Turn[] = [];
+  private turnValues: SessionTurn[] = [];
+  private boundaries: { t: number; ordinal: number; winner: number }[] = [];
+  private lastUser: string | null = null;
+  private effortChanges: { t: number; effort: string }[] = [];
+  private effortHistory = new Set<string>();
+  private currentEffort: string | null = null;
+  private hasInitialEffort = false;
+  get work() { return this.index.work; }
+
+  private depend(id: unknown, node: Node): void {
+    if (typeof id !== "string") return;
+    if (!this.dependencies.has(id)) this.dependencies.set(id, new Set());
+    this.dependencies.get(id)!.add(node);
+  }
+  private effort(t: number): string | undefined {
+    return this.effortChanges[upperBound(this.effortChanges, t, change => change.t) - 1]?.effort;
+  }
+  private owner(t: number): number {
+    return this.boundaries[upperBound(this.boundaries, t, boundary => boundary.t) - 1]?.winner ?? (this.turns.length ? 0 : -1);
+  }
+  private remove(i: number, event: NormalizedEvent): void {
+    const turn = this.turns[event.turnIndex!];
+    if (!turn || !turn.value.eventIndices.length) return;
+    const position = lowerBound(turn.value.eventIndices, i, n => n);
+    if (turn.value.eventIndices[position] !== i) return;
+    turn.value.eventIndices.splice(position, 1);
+    turn.ends.set(i, -Infinity);
+    if (event.track === "tool_call") turn.value.toolCount!--;
+    if (event.isError) turn.errors--;
+    turn.value.hasError = turn.errors > 0;
+    turn.value.endTime = Math.max(turn.end, turn.ends.max);
+    this.index.work.turns++;
+  }
+  private assign(i: number): void {
+    const event = this.index.events[i];
+    const owner = this.owner(event.t);
+    event.turnIndex = Math.max(0, owner);
+    if (owner < 0) return;
+    const turn = this.turns[owner];
+    const position = lowerBound(turn.value.eventIndices, i, n => n);
+    turn.value.eventIndices.splice(position, 0, i);
+    turn.ends.set(i, event.t + event.duration);
+    if (event.track === "tool_call") turn.value.toolCount!++;
+    if (event.isError) turn.errors++;
+    turn.value.hasError = turn.errors > 0;
+    turn.value.endTime = Math.max(turn.end, turn.ends.max);
+    this.index.work.turns++;
+  }
+
+  private replace(position: number, event: NormalizedEvent): void {
+    const previous = this.index.events[position];
+    const owner = this.owner(event.t);
+    const indices = this.turns[owner]?.value.eventIndices;
+    const assigned = indices && indices[lowerBound(indices, position, i => i)] === position;
+    if (owner >= 0 && previous.turnIndex === owner && assigned) {
+      const turn = this.turns[owner];
+      turn.ends.set(position, event.t + event.duration);
+      turn.value.toolCount! += Number(event.track === "tool_call") - Number(previous.track === "tool_call");
+      turn.errors += Number(event.isError) - Number(previous.isError);
+      turn.value.hasError = turn.errors > 0;
+      turn.value.endTime = Math.max(turn.end, turn.ends.max);
+      event.turnIndex = owner;
+      this.index.set(position, event);
+      this.index.work.turns++;
+    } else if (owner < 0) {
+      this.index.set(position, event);
+    } else {
+      this.remove(position, previous);
+      this.index.set(position, event);
+      this.assign(position);
+    }
+  }
+
+  append(records: RawRecord[], malformedLines: number): ParsedSession | null {
+    const index = this.index;
+    index.begin(records.length);
+    const dirty = new Set<Node>();
+    const added: Node[] = [];
+    let effortFrom = Infinity;
+    let turnFrom = Infinity;
+    let rebase = false;
+    const mark = (id: unknown) => { for (const node of this.dependencies.get(String(id)) || []) dirty.add(node); };
+    for (const record of records) {
+      const data = record.data || {};
+      if (!this.nodes.length) this.firstTimestamp = helpers.parseTimestamp(record.timestamp) || 0;
+      const candidate = record.type === "session.start" ? data.startTime : record.type === "session.resume" ? data.resumeTime : null;
+      if (!this.foundStart && candidate) {
+        const next = helpers.parseTimestamp(candidate) ?? this.firstTimestamp;
+        rebase ||= this.start !== null && next !== this.start;
+        this.start = next;
+        this.foundStart = true;
+      }
+      this.start ??= this.firstTimestamp;
+      if (["session.start", "session.resume", "session.shutdown"].includes(record.type)) this.info[record.type] = record;
+      const node: Node = { record, positions: [], ordinal: this.nodes.length };
+      this.nodes.push(node);
+      added.push(node);
+      if (record.type === "tool.execution_complete" && data.toolCallId) {
+        this.completes[data.toolCallId] = record;
+        mark(data.toolCallId);
+      }
+      if (record.type === "tool.execution_start" && data.toolName === "task") {
+        const args = data.arguments || {};
+        this.retained.taskToolMap[data.toolCallId] = { agentType: args.agent_type || "task", description: args.description || args.name || "" };
+        mark(data.toolCallId);
+      }
+      if (record.type === "subagent.started") {
+        const timestamp = helpers.parseTimestamp(record.timestamp);
+        if (data.toolCallId && timestamp !== null) this.retained.subagentStartTimes[data.toolCallId] = timestamp;
+        this.retained.subagentLifecycle[data.toolCallId || ""] = {
+          agentName: data.agentName || data.agentType, agentDisplayName: data.agentDisplayName || data.agentName,
+        };
+        mark(data.toolCallId || "");
+      }
+      this.depend(data.toolCallId, node);
+      this.depend(data.parentToolCallId, node);
+      for (const request of Array.isArray(data.toolRequests) ? data.toolRequests : []) this.depend(request.toolCallId, node);
+
+      if (record.type === "user.message") this.lastUser = data.content || "";
+      if (record.type === "assistant.turn_start") {
+        const t = helpers.parseTimestamp(record.timestamp);
+        const start = t ? t - this.start : 0;
+        const ordinal = this.turns.length;
+        this.turns.push({
+          value: { index: ordinal, startTime: start, endTime: 0, eventIndices: [], userMessage: this.lastUser || "(continuation)", toolCount: 0, hasError: false },
+          ends: new NumericIndex(), errors: 0, end: 0,
+        });
+        this.turnValues.push(this.turns[ordinal].value);
+        this.lastUser = null;
+        const position = lowerBound(this.boundaries, start, item => item.t);
+        this.boundaries.splice(position, 0, { t: start, ordinal, winner: ordinal });
+        for (let i = position; i < this.boundaries.length; i++) {
+          this.boundaries[i].winner = Math.max(this.boundaries[i].ordinal, this.boundaries[i - 1]?.winner ?? -1);
+          index.work.turns++;
+        }
+        turnFrom = Math.min(turnFrom, ordinal === 0 ? -Infinity : start);
+      }
+      if (record.type === "assistant.turn_end" && this.turns.length) {
+        const t = helpers.parseTimestamp(record.timestamp);
+        const turn = this.turns[this.turns.length - 1];
+        if (t) turn.end = t - this.start;
+        turn.value.endTime = Math.max(turn.end, turn.ends.max);
+        index.work.turns++;
+      }
+      if (["session.start", "session.resume", "session.model_change"].includes(record.type)) {
+        const effort = helpers.getReasoningEffort(data);
+        const previous = record.type === "session.model_change" ? helpers.getReasoningEffort(data, "previousReasoningEffort") : null;
+        if (previous) this.effortHistory.add(previous);
+        if (effort) this.effortHistory.add(effort);
+        this.currentEffort = effort || this.currentEffort;
+        const changes: { t: number; effort: string }[] = [];
+        if (!this.hasInitialEffort && previous) {
+          changes.push({ t: 0, effort: previous });
+          this.hasInitialEffort = true;
+        }
+        const t = helpers.parseTimestamp(record.type === "session.start" ? data.startTime || record.timestamp
+          : record.type === "session.resume" ? data.resumeTime || record.timestamp : record.timestamp);
+        if (effort && t !== null) {
+          changes.push({ t: Math.max(t - this.start, 0), effort });
+          if (record.type !== "session.model_change") this.hasInitialEffort = true;
+        }
+        for (const change of changes) {
+          const position = upperBound(this.effortChanges, change.t, item => item.t);
+          this.effortChanges.splice(position, 0, change);
+          effortFrom = Math.min(effortFrom, change.t);
+        }
+      }
+    }
+    // An origin change alters every timestamp, including turn/effort boundaries.
+    if (rebase) return this.rebuild(malformedLines);
+    const newSlots: Slot[] = [];
+    for (const node of added) {
+      const data = node.record.data || {};
+      if (node.record.type === "tool.execution_start" && typeof data.toolCallId === "string" && data.toolCallId) {
+        if (this.seenStarts.has(data.toolCallId) && helpers.parseTimestamp(node.record.timestamp) !== null) continue;
+        if (helpers.parseTimestamp(node.record.timestamp) !== null) this.seenStarts.add(data.toolCallId);
+      }
+      const events = helpers.buildNormalizedEvents([node.record], this.start!, { completes: this.completes }, this.retained);
+      events.forEach((event, offset) => newSlots.push({ node, offset, event }));
+      dirty.delete(node);
+    }
+    for (const node of dirty) {
+      if (!node.positions.length) continue;
+      index.work.records++;
+      const events = helpers.buildNormalizedEvents([node.record], this.start!, { completes: this.completes }, this.retained);
+      node.positions.forEach((position, offset) => {
+        const event = events[offset];
+        delete event.reasoningEffort;
+        const effort = this.effort(event.t);
+        if (effort) event.reasoningEffort = effort;
+        this.slots[position].event = event;
+        this.replace(position, event);
+      });
+    }
+    newSlots.sort((a, b) => a.event.t - b.event.t || a.node.ordinal - b.node.ordinal || a.offset - b.offset);
+    let firstInsertion = index.events.length;
+    for (const slot of newSlots) {
+      let low = 0;
+      let high = this.slots.length;
+      while (low < high) {
+        const mid = (low + high) >>> 1;
+        const other = this.slots[mid];
+        if (other.event.t < slot.event.t || other.event.t === slot.event.t && other.node.ordinal <= slot.node.ordinal) low = mid + 1;
+        else high = mid;
+      }
+      firstInsertion = Math.min(firstInsertion, low);
+      this.slots.splice(low, 0, slot);
+    }
+    for (let i = index.events.length - 1; i >= firstInsertion; i--) this.remove(i, index.events[i]);
+    for (let i = firstInsertion; i < this.slots.length; i++) {
+      const slot = this.slots[i];
+      slot.node.positions[slot.offset] = i;
+      const event = { ...slot.event };
+      delete event.reasoningEffort;
+      const effort = this.effort(event.t);
+      if (effort) event.reasoningEffort = effort;
+      index.set(i, event);
+      this.assign(i);
+    }
+    for (let i = lowerBound(index.events, Math.min(turnFrom, effortFrom), event => event.t); i < firstInsertion; i++) {
+      if (index.events[i].t >= turnFrom) {
+        this.remove(i, index.events[i]);
+        this.assign(i);
+      }
+      if (index.events[i].t >= effortFrom) {
+        const event = { ...index.events[i] };
+        delete event.reasoningEffort;
+        const effort = this.effort(event.t);
+        if (effort) event.reasoningEffort = effort;
+        index.set(i, event);
+      }
+    }
+    if (!index.events.length) return null;
+    const turns = this.turnValues;
+    const summary = index.summary(turns);
+    const metadata = helpers.buildMetadata(Object.values(this.info), [], [], malformedLines, summary);
+    Object.assign(metadata, { totalEvents: index.events.length, totalTurns: turns.length, reasoningEffort: this.currentEffort, reasoningEfforts: [...this.effortHistory] });
+    return { events: index.events, turns, metadata };
+  }
+  private rebuild(malformedLines: number): ParsedSession | null {
+    const records = this.nodes.map(node => node.record);
+    const replacement = new LiveCopilotNormalizer();
+    replacement.start = this.start;
+    replacement.foundStart = true;
+    const result = replacement.append(records, malformedLines);
+    Object.assign(this, replacement);
+    return result;
+  }
+}

--- a/src/lib/liveNormalization.ts
+++ b/src/lib/liveNormalization.ts
@@ -1,0 +1,217 @@
+import type { NormalizedEvent, ParsedSession, SessionTurn } from "./sessionTypes";
+
+export type RawRecord = Record<string, any>;
+export interface NormalizationWork {
+  records: number;
+  events: number;
+  turns: number;
+}
+export interface LiveNormalizer {
+  work: NormalizationWork;
+  append(records: RawRecord[], malformedLines: number): ParsedSession | null;
+}
+
+// Sparse indexed maxima support replacements/decreases without rescanning history.
+// The fixed 32-level address space also avoids periodic history-wide tree rebuilds.
+export class NumericIndex {
+  private nodes = new Map<number, number>();
+  set(index: number, value: number): void {
+    let key = 2 ** 32 + index;
+    if (value === -Infinity) this.nodes.delete(key);
+    else this.nodes.set(key, value);
+    while (key > 1) {
+      key = Math.floor(key / 2);
+      const maximum = Math.max(this.nodes.get(key * 2) ?? -Infinity, this.nodes.get(key * 2 + 1) ?? -Infinity);
+      if (maximum === -Infinity) this.nodes.delete(key);
+      else this.nodes.set(key, maximum);
+    }
+  }
+  get max(): number { return this.nodes.get(1) ?? -Infinity; }
+}
+
+export class EventIndex {
+  events: NormalizedEvent[] = [];
+  work: NormalizationWork = { records: 0, events: 0, turns: 0 };
+  private ends = new NumericIndex();
+  private modelPositions = new Map<string, { count: number; positions: NumericIndex }>();
+  toolCount = 0;
+  errorCount = 0;
+  usage = { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0 };
+
+  begin(records: number): void { this.work = { records, events: 0, turns: 0 }; }
+
+  private account(event: NormalizedEvent, index: number, sign: number): void {
+    if (event.model) {
+      let model = this.modelPositions.get(event.model);
+      if (!model) {
+        model = { count: 0, positions: new NumericIndex() };
+        this.modelPositions.set(event.model, model);
+      }
+      model.count += sign;
+      model.positions.set(index, sign > 0 ? -index : -Infinity);
+    }
+    if (event.track === "tool_call") this.toolCount += sign;
+    if (event.isError) this.errorCount += sign;
+    for (const key of ["inputTokens", "outputTokens", "cacheRead", "cacheWrite"] as const) {
+      this.usage[key] += sign * (event.tokenUsage?.[key] || 0);
+    }
+  }
+
+  set(index: number, event: NormalizedEvent): void {
+    this.work.events++;
+    const previous = this.events[index];
+    if (previous) this.account(previous, index, -1);
+    this.events[index] = event;
+    this.account(event, index, 1);
+    this.ends.set(index, event.t + event.duration);
+  }
+
+  truncate(length: number): void {
+    for (let i = length; i < this.events.length; i++) {
+      this.work.events++;
+      this.account(this.events[i], i, -1);
+      this.ends.set(i, -Infinity);
+    }
+    this.events.length = length;
+  }
+
+  get duration(): number { return Math.max(0, this.ends.max); }
+  get models(): Record<string, number> {
+    return Object.fromEntries([...this.modelPositions.entries()]
+      .filter(([, value]) => value.count > 0)
+      .sort((a, b) => b[1].positions.max - a[1].positions.max)
+      .map(([name, value]) => [name, value.count]));
+  }
+  summary(turns: SessionTurn[]) {
+    const models = this.models;
+    return {
+      totalEvents: this.events.length, totalTurns: turns.length,
+      totalToolCalls: this.toolCount, errorCount: this.errorCount,
+      duration: this.duration, models,
+      primaryModel: Object.keys(models).sort((a, b) => models[b] - models[a])[0] || null,
+    };
+  }
+}
+
+export function lowerBound<T>(items: T[], value: number, key: (item: T) => number): number {
+  let low = 0;
+  let high = items.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (key(items[middle]) < value) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+export function upperBound<T>(items: T[], value: number, key: (item: T) => number): number {
+  let low = 0;
+  let high = items.length;
+  while (low < high) {
+    const middle = (low + high) >>> 1;
+    if (key(items[middle]) <= value) low = middle + 1;
+    else high = middle;
+  }
+  return low;
+}
+
+// Rebuild only the invalidated suffix. Timestamp rebases, out-of-order insertion,
+// and structural patches legitimately affect that suffix, unlike ordinary appends.
+export function buildUserTurns(index: EventIndex, turns: SessionTurn[], start: number, maximumEnd: boolean): void {
+  const events = index.events;
+  let current = start > 0 ? turns[events[start - 1].turnIndex!] : undefined;
+  if (current) turns.length = current.index + 1;
+  else turns.length = 0;
+  for (let i = start; i < events.length; i++) {
+    const event = events[i];
+    index.work.turns++;
+    if (!current || event.agent === "user") {
+      current = {
+        index: turns.length, startTime: event.t, endTime: event.t + event.duration,
+        eventIndices: [], userMessage: event.agent === "user" ? event.text : "(system)",
+        toolCount: 0, hasError: false,
+      };
+      turns.push(current);
+    }
+    event.turnIndex = current.index;
+    current.eventIndices.push(i);
+    current.endTime = maximumEnd ? Math.max(current.endTime, event.t + event.duration) : event.t + event.duration;
+    if (event.track === "tool_call") current.toolCount = (current.toolCount || 0) + 1;
+    if (event.isError) current.hasError = true;
+  }
+}
+
+function resultId(event: NormalizedEvent): string | undefined {
+  const raw = event.raw as RawRecord | undefined;
+  const candidates = raw
+    ? [event.toolCallId, raw.tool_use_id, raw.toolCallId, raw.tool_call_id, raw.source_call_id, raw.call_id, raw.payload?.call_id]
+    : [event.toolCallId];
+  return candidates.find(id => typeof id === "string" && id.length > 0);
+}
+
+export class ToolResultIndex {
+  private results = new Map<string, { positions: NumericIndex; text: Map<number, string> }>();
+  private resultKeys = new Map<number, string>();
+  private calls = new Map<string, Set<number>>();
+  private candidates = new Map<number, { ids: string[]; original: NormalizedEvent }>();
+  constructor(private index: EventIndex) {}
+  remove(position: number): void {
+    const candidate = this.candidates.get(position);
+    if (candidate) {
+      for (const id of candidate.ids) this.calls.get(id)?.delete(position);
+      this.candidates.delete(position);
+    }
+    const id = this.resultKeys.get(position);
+    if (id) {
+      const result = this.results.get(id)!;
+      result.positions.set(position, -Infinity);
+      result.text.delete(position);
+      this.resultKeys.delete(position);
+      for (const call of this.calls.get(id) || []) this.pair(call);
+    }
+  }
+  add(position: number): void {
+    const event = this.index.events[position];
+    this.index.work.events++;
+    if (event.track === "context" && event.text) {
+      const id = resultId(event);
+      if (id) {
+        if (!this.results.has(id)) this.results.set(id, { positions: new NumericIndex(), text: new Map() });
+        const result = this.results.get(id)!;
+        result.positions.set(position, position);
+        result.text.set(position, event.text);
+        this.resultKeys.set(position, id);
+        for (const call of this.calls.get(id) || []) this.pair(call);
+      }
+    }
+    if (event.track === "tool_call" && (!event.toolOutput || this.candidates.has(position))) {
+      const raw = event.raw as RawRecord | undefined;
+      const ids = [event.toolCallId, raw?.id, raw?.toolCallId, raw?.tool_call_id]
+        .filter((id): id is string => typeof id === "string");
+      this.candidates.set(position, { ids, original: this.candidates.get(position)?.original || event });
+      for (const id of ids) {
+        if (!this.calls.has(id)) this.calls.set(id, new Set());
+        this.calls.get(id)!.add(position);
+      }
+      this.pair(position);
+    }
+  }
+  private pair(position: number): void {
+    const candidate = this.candidates.get(position);
+    if (!candidate) return;
+    let output = candidate.original.toolOutput;
+    for (const id of candidate.ids) {
+      const result = this.results.get(id);
+      if (result && result.positions.max !== -Infinity) {
+        output = result.text.get(result.positions.max);
+        if (output) break;
+      }
+    }
+    const event = this.index.events[position];
+    if (event.toolOutput !== output) {
+      const paired = { ...event, toolOutput: output };
+      if (output === undefined && !("toolOutput" in candidate.original)) delete paired.toolOutput;
+      this.index.set(position, paired);
+    }
+  }
+}

--- a/src/lib/liveSessionParser.ts
+++ b/src/lib/liveSessionParser.ts
@@ -1,20 +1,13 @@
-import { detectFormat, parseSession, pairToolCallsWithResults } from "./parseSession";
-import { parseCopilotCliRecords } from "./copilotCliParser";
-import { parseClaudeCodeRecords } from "./parser";
-import { detectCodexRecords, parseCodexRecords } from "./codexParser";
-import {
-  applyVSCodeJsonlPatch,
-  parseVSCodeChatSession,
-  type VSCodeSession,
-} from "./vscodeSessionParser";
+import { detectFormat, parseSession } from "./parseSession";
+import { detectCodexRecords } from "./codexParser";
+import { LiveClaudeNormalizer } from "./liveClaudeNormalizer";
+import { LiveCopilotNormalizer } from "./liveCopilotNormalizer";
+import { LiveCodexNormalizer } from "./liveCodexNormalizer";
+import { LiveVSCodeNormalizer } from "./liveVSCodeNormalizer";
+import type { LiveNormalizer, NormalizationWork } from "./liveNormalization";
 import type { ParsedSession, SessionFormat } from "./sessionTypes";
 
 type RawRecord = Record<string, any>;
-
-interface ParseIssues {
-  malformedLines: number;
-  invalidEvents: number;
-}
 
 export interface LiveSessionParserState {
   rawText: string;
@@ -26,7 +19,9 @@ export interface LiveSessionParserState {
   format: SessionFormat | null;
   result: ParsedSession | null;
   records: RawRecord[];
-  vscodeSession: VSCodeSession | null;
+  normalizer: LiveNormalizer | null;
+  normalizationWork: NormalizationWork;
+  snapshot: boolean;
   initialFullParseCount: number;
   fallbackFullParseCount: number;
 }
@@ -36,7 +31,7 @@ export interface LiveSessionParserUpdate {
   result: ParsedSession | null;
 }
 
-function createEmptyState(): LiveSessionParserState {
+function createEmptyState(snapshot = true): LiveSessionParserState {
   return {
     rawText: "",
     pendingText: "",
@@ -47,14 +42,12 @@ function createEmptyState(): LiveSessionParserState {
     format: null,
     result: null,
     records: [],
-    vscodeSession: null,
+    normalizer: null,
+    normalizationWork: { records: 0, events: 0, turns: 0 },
+    snapshot,
     initialFullParseCount: 0,
     fallbackFullParseCount: 0,
   };
-}
-
-function cloneJson<T>(value: T): T {
-  return JSON.parse(JSON.stringify(value));
 }
 
 function appendRawText(previous: string, next: string): string {
@@ -144,47 +137,12 @@ function detectFormatFromRecords(records: RawRecord[]): SessionFormat | null {
   return detectExplicitFormatFromRecords(records) || (records.length > 0 ? "claude-code" : null);
 }
 
-function createIssues(malformedLineCount: number): ParseIssues {
-  return { malformedLines: malformedLineCount, invalidEvents: 0 };
-}
-
-function buildVSCodeSession(records: RawRecord[], existingSession: VSCodeSession | null): VSCodeSession | null {
-  let session = existingSession;
-
-  for (let index = 0; index < records.length; index += 1) {
-    const record = records[index];
-    if (isVSCodeBase(record)) {
-      session = cloneJson(record.v);
-    } else if (session) {
-      applyVSCodeJsonlPatch(session, record);
-    }
-  }
-
-  return session;
-}
-
-function deriveResult(
-  format: SessionFormat | null,
-  records: RawRecord[],
-  malformedLineCount: number,
-  vscodeSession: VSCodeSession | null,
-  appendedRecords?: RawRecord[],
-): { result: ParsedSession | null; vscodeSession: VSCodeSession | null } {
-  if (!format) return { result: null, vscodeSession };
-  if (format === "codex") {
-    return { result: parseCodexRecords(records, malformedLineCount), vscodeSession };
-  }
-  if (format === "copilot-cli") {
-    return { result: parseCopilotCliRecords(records, malformedLineCount), vscodeSession };
-  }
-  if (format === "vscode-chat") {
-    const session = buildVSCodeSession(appendedRecords || records, appendedRecords && vscodeSession ? cloneJson(vscodeSession) : null);
-    return { result: session ? parseVSCodeChatSession(session) : null, vscodeSession: session };
-  }
-  return {
-    result: parseClaudeCodeRecords(records, createIssues(malformedLineCount)),
-    vscodeSession,
-  };
+function createNormalizer(format: SessionFormat | null): LiveNormalizer | null {
+  if (format === "codex") return new LiveCodexNormalizer();
+  if (format === "copilot-cli") return new LiveCopilotNormalizer();
+  if (format === "vscode-chat") return new LiveVSCodeNormalizer();
+  if (format === "claude-code") return new LiveClaudeNormalizer();
+  return null;
 }
 
 function detectPlainVSCodeJson(text: string): boolean {
@@ -206,13 +164,15 @@ function rebuildStateFromRawText(
   rawText: string,
   initialFullParseCount: number,
   fallbackFullParseCount: number,
+  snapshot = true,
 ): LiveSessionParserState {
   const split = splitCompleteLines(rawText);
   const parsed = parseLines(split.lines);
-  const format = detectFormatFromRecords(parsed.records) || (rawText.trim() ? detectFormat(rawText) : null);
-  const derived = deriveResult(format, parsed.records, parsed.malformedLines, null);
-  const result = derived.result || (rawText.trim() ? parseSession(rawText) : null);
-  if (result) pairToolCallsWithResults(result);
+  const plain = detectPlainVSCodeJson(rawText);
+  if (plain) parsed.records = [JSON.parse(rawText)];
+  const format = plain ? "vscode-chat" : detectFormatFromRecords(parsed.records.slice(0, 8)) || (rawText.trim() ? detectFormat(rawText) : null);
+  const normalizer = createNormalizer(format);
+  const result = normalizer?.append(parsed.records, parsed.malformedLines) || (rawText.trim() ? parseSession(rawText) : null);
 
   return {
     rawText,
@@ -222,18 +182,20 @@ function rebuildStateFromRawText(
     malformedLineCount: parsed.malformedLines,
     lastAppendParsedLineCount: 0,
     format,
-    result,
+    result: snapshot && result ? structuredClone(result) : result,
     records: parsed.records,
-    vscodeSession: derived.vscodeSession,
+    normalizer,
+    normalizationWork: normalizer?.work || { records: 0, events: 0, turns: 0 },
+    snapshot,
     initialFullParseCount,
     fallbackFullParseCount,
   };
 }
 
-export function createLiveSessionParser(initialText: string): LiveSessionParserState {
-  if (!initialText.trim()) return createEmptyState();
+export function createLiveSessionParser(initialText: string, options: { snapshot?: boolean } = {}): LiveSessionParserState {
+  if (!initialText.trim()) return createEmptyState(options.snapshot);
 
-  const state = rebuildStateFromRawText(initialText, detectPlainVSCodeJson(initialText) ? 1 : 0, 0);
+  const state = rebuildStateFromRawText(initialText, detectPlainVSCodeJson(initialText) ? 1 : 0, 0, options.snapshot);
   if (!state.result && detectPlainVSCodeJson(initialText)) {
     return { ...state, result: parseSession(initialText), format: "vscode-chat" };
   }
@@ -250,22 +212,27 @@ export function appendLiveSessionText(
   const split = splitCompleteLines(previous.pendingText + newText);
   const parsed = parseLines(split.lines);
   const incomingFormat = detectExplicitFormatFromRecords(parsed.records);
+  const prefixFormat = detectFormatFromRecords(previous.records.slice(0, 8).concat(parsed.records.slice(0, Math.max(0, 8 - previous.records.length))));
 
-  if (previous.format && incomingFormat && incomingFormat !== previous.format) {
+  if (previous.format && ((incomingFormat && incomingFormat !== previous.format) || (prefixFormat && prefixFormat !== previous.format))) {
     const fallbackState = rebuildStateFromRawText(
       rawText,
       previous.initialFullParseCount,
       previous.fallbackFullParseCount + 1,
+      previous.snapshot,
     );
     return { state: fallbackState, result: fallbackState.result };
   }
 
-  const format = previous.format || incomingFormat || detectFormatFromRecords(parsed.records);
-  const records = previous.records.concat(parsed.records);
+  const format = previous.format || prefixFormat || incomingFormat || detectFormatFromRecords(parsed.records);
+  const records = previous.records;
+  for (const record of parsed.records) records.push(record);
   const malformedLineCount = previous.malformedLineCount + parsed.malformedLines;
-  const derived = deriveResult(format, records, malformedLineCount, previous.vscodeSession, parsed.records);
-  const result = derived.result || previous.result;
-  if (result) pairToolCallsWithResults(result);
+  const normalizer = previous.normalizer || createNormalizer(format);
+  const normalized = normalizer?.append(parsed.records, malformedLineCount) || null;
+  // Normalization retains mutable state. Publication is a separate O(history)
+  // snapshot cost; workers omit this copy because postMessage already clones.
+  const result = previous.snapshot && normalized ? structuredClone(normalized) : normalized;
 
   const state: LiveSessionParserState = {
     rawText,
@@ -277,7 +244,9 @@ export function appendLiveSessionText(
     format,
     result,
     records,
-    vscodeSession: derived.vscodeSession,
+    normalizer,
+    normalizationWork: normalizer?.work || { records: 0, events: 0, turns: 0 },
+    snapshot: previous.snapshot,
     initialFullParseCount: previous.initialFullParseCount,
     fallbackFullParseCount: previous.fallbackFullParseCount,
   };

--- a/src/lib/liveSessionWorker.ts
+++ b/src/lib/liveSessionWorker.ts
@@ -1,12 +1,12 @@
 import { appendLiveSessionText, createLiveSessionParser } from "./liveSessionParser";
 
-let state = createLiveSessionParser("");
+let state = createLiveSessionParser("", { snapshot: false });
 self.onmessage = ({ data }) => {
   try {
-    if (data.initial !== undefined) state = createLiveSessionParser(data.initial);
-    if (data.reset) state = createLiveSessionParser("");
+    if (data.initial !== undefined) state = createLiveSessionParser(data.initial, { snapshot: false });
+    if (data.reset) state = createLiveSessionParser("", { snapshot: false });
     if (data.text) state = appendLiveSessionText(state, data.text).state;
-    self.postMessage({ result: state.result, rawText: state.rawText });
+    self.postMessage({ result: state.result, rawText: state.rawText, normalizationWork: state.normalizationWork });
   } catch (error) {
     self.postMessage({ error: error instanceof Error ? error.message : String(error) });
   }

--- a/src/lib/liveVSCodeNormalizer.ts
+++ b/src/lib/liveVSCodeNormalizer.ts
@@ -1,0 +1,158 @@
+import { applyVSCodeJsonlPatch, vscodeLive as helpers, type VSCodeSession } from "./vscodeSessionParser";
+import { EventIndex, upperBound, type LiveNormalizer, type RawRecord } from "./liveNormalization";
+import type { ParsedSession, SessionTurn } from "./sessionTypes";
+
+export class LiveVSCodeNormalizer implements LiveNormalizer {
+  private index = new EventIndex();
+  private session: VSCodeSession | null = null;
+  private turns: SessionTurn[] = [];
+  private offsets: number[] = [];
+  private parts: Map<number, { position: number; kind: unknown; timestamp: unknown }>[] = [];
+  private errors: number[] = [];
+  get work() { return this.index.work; }
+
+  append(records: RawRecord[]): ParsedSession | null {
+    const index = this.index;
+    index.begin(records.length);
+    let from = Infinity;
+    let through = -1;
+    const previousOrigin = this.session?.creationDate || this.session?.requests?.[0]?.timestamp || 0;
+    const requested = new Set<number>();
+    let allRequests = false;
+    const localParts = new Map<number, Set<number>>();
+    for (const record of records) {
+      if (!this.session && (record.kind === 0 || helpers.isVSCodeSession(record))) {
+        // Own the mutable patch tree, not the retained raw JSONL record.
+        this.session = structuredClone(record.kind === 0 ? record.v : record);
+        from = 0;
+        allRequests = true;
+        through = (this.session?.requests?.length || 0) - 1;
+        continue;
+      }
+      if (!this.session) continue;
+      const count = this.session.requests?.length || 0;
+      if (!applyVSCodeJsonlPatch(this.session, record)) continue;
+      const key = record.k;
+      if (key[0] === "requests") {
+        if (key.length === 2 && key[1] === "length") {
+          from = Math.min(from, this.session.requests.length);
+          through = Math.max(through, this.session.requests.length - 1);
+          continue;
+        }
+        const request = key.length > 1 ? Number(key[1]) : record.kind === 2 ? count : 0;
+        if (key[2] === "response" && key.length >= 4 && Number.isInteger(Number(key[3]))) {
+          if (!localParts.has(request)) localParts.set(request, new Set());
+          localParts.get(request)!.add(Number(key[3]));
+          continue;
+        }
+        from = Math.min(from, Number.isInteger(request) && request >= 0 ? request : 0);
+        through = Math.max(through, key.length > 1 ? request : (this.session.requests?.length || 0) - 1);
+        if (key.length > 1 && Number.isInteger(request)) requested.add(request);
+        else if (key.length === 1 && record.kind === 2) {
+          for (let i = count; i < this.session.requests.length; i++) requested.add(i);
+        } else allRequests = true;
+      } else if (key[0] === "creationDate" || key[0] === "selectedModel") {
+        from = 0;
+        allRequests = true;
+        through = (this.session.requests?.length || 0) - 1;
+      }
+    }
+    if (!this.session || !helpers.isVSCodeSession(this.session)) return null;
+    const requests = this.session.requests;
+    for (const [ri, parts] of localParts) {
+      for (const pi of parts) {
+        index.work.records++;
+        const previous = this.parts[ri]?.get(pi);
+        const part = requests[ri]?.response?.[pi];
+        const timestamp = part?.toolSpecificData?.terminalCommandState?.timestamp;
+        const event = previous && index.events[previous.position];
+        const mapped = event && part && part.kind === previous.kind && timestamp === previous.timestamp
+          ? helpers.mapResponsePart(part, event.t, event.model || null) : null;
+        if (!mapped || !previous || !event) {
+          from = Math.min(from, ri);
+          through = Math.max(through, ri);
+          requested.add(ri);
+          continue;
+        }
+        this.errors[ri] += Number(mapped.isError) - Number(event.isError);
+        this.turns[ri].toolCount! += Number(mapped.track === "tool_call") - Number(event.track === "tool_call");
+        this.turns[ri].hasError = this.errors[ri] > 0;
+        index.set(previous.position, { ...mapped, turnIndex: ri });
+        index.work.turns++;
+      }
+    }
+    const origin = this.session.creationDate || requests[0]?.timestamp || 0;
+    if (origin !== previousOrigin) {
+      from = 0;
+      through = requests.length - 1;
+      allRequests = true;
+    }
+    const dirtyRequests = [...requested].sort((a, b) => a - b);
+    for (let ri = from; ri < requests.length; ri++) {
+      index.work.records++;
+      const position = this.offsets[ri] ?? index.events.length;
+      const previousEnd = this.offsets[ri + 1] ?? index.events.length;
+      const oldLast = index.events[previousEnd - 1];
+      const oldTime = oldLast?.t;
+      const oldCount = previousEnd - position;
+      const single = {
+        ...this.session,
+        creationDate: this.session.creationDate || requests[0]?.timestamp || 0,
+        requests: [requests[ri]],
+      };
+      const normalized = helpers.buildTimeline(single, index.events[position - 1]);
+      const changedCount = oldCount !== normalized.events.length;
+      if (changedCount) {
+        // A count change shifts all following public evidence indices.
+        index.truncate(position);
+        this.offsets.length = ri + 1;
+        this.turns.length = ri;
+        through = requests.length - 1;
+        allRequests = true;
+      }
+      this.offsets[ri] = position;
+      normalized.events.forEach((event, offset) => index.set(position + offset, { ...event, turnIndex: ri }));
+      const positions = new Map(normalized.events.map((event, offset) => [event.raw, position + offset]));
+      this.parts[ri] = new Map();
+      const response = requests[ri].response || [];
+      for (let pi = 0; pi < response.length; pi++) {
+        const part = response[pi];
+        const offset = positions.get(part);
+        if (offset !== undefined) this.parts[ri].set(pi, {
+          position: offset, kind: part.kind, timestamp: part.toolSpecificData?.terminalCommandState?.timestamp,
+        });
+        index.work.events++;
+      }
+      this.errors[ri] = normalized.events.reduce((sum, event) => sum + Number(event.isError), 0);
+      this.offsets[ri + 1] = position + normalized.events.length;
+      const turn = normalized.turns[0];
+      turn.index = ri;
+      turn.eventIndices = turn.eventIndices.map(i => i + position);
+      this.turns[ri] = turn;
+      index.work.turns++;
+      const newTime = index.events[this.offsets[ri + 1] - 1]?.t;
+      // Minimum spacing propagates only until the next request's boundary settles.
+      if (oldTime === newTime) {
+        if (ri >= through) break;
+        if (!allRequests) {
+          const next = dirtyRequests[upperBound(dirtyRequests, ri, i => i)];
+          if (next === undefined) break;
+          ri = next - 1;
+        }
+      }
+    }
+    if (this.turns.length > requests.length) {
+      index.truncate(this.offsets[requests.length] || 0);
+      this.turns.length = requests.length;
+      this.offsets.length = requests.length + 1;
+      this.parts.length = requests.length;
+      this.errors.length = requests.length;
+    }
+    if (!index.events.length) return null;
+    const metadata = {
+      ...helpers.buildMetadata([], [], this.session),
+      ...index.summary(this.turns),
+    };
+    return { events: index.events, turns: this.turns, metadata };
+  }
+}

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -712,7 +712,7 @@ export function parseClaudeCodeRecords(rawRecords: RawRecord[], issues?: ParseIs
 }
 
 export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
-  const lines = text.trim().split("\n").filter(Boolean);
+  const lines = text.trim().split("\n").filter(line => line.trim().length > 0);
   const rawRecords: RawRecord[] = [];
   const issues = createParseIssues();
 
@@ -726,3 +726,8 @@ export function parseClaudeCodeJSONL(text: string): ParsedSession | null {
 
   return parseClaudeCodeRecords(rawRecords, issues);
 }
+
+export const claudeLive = {
+  extractTimestamp, extractUsage, getUsageDedupKey, mergeTokenUsage,
+  extractEventsFromRecord, buildWarnings,
+};

--- a/src/lib/vscodeSessionParser.ts
+++ b/src/lib/vscodeSessionParser.ts
@@ -333,7 +333,7 @@ function mapResponsePart(
 
 // ── Timeline builder ─────────────────────────────────────────────────────────
 
-function buildTimeline(session: VSCodeSession): {
+function buildTimeline(session: VSCodeSession, previousEvent?: NormalizedEvent): {
   events: NormalizedEvent[];
   turns: SessionTurn[];
 } {
@@ -410,8 +410,9 @@ function buildTimeline(session: VSCodeSession): {
       }
 
       // Minimum event spacing
-      if (events.length > 0 && eventTime <= events[events.length - 1].t) {
-        eventTime = events[events.length - 1].t + 0.1;
+      const previous = events[events.length - 1] || previousEvent;
+      if (previous && eventTime <= previous.t) {
+        eventTime = previous.t + 0.1;
       }
 
       const mapped = mapResponsePart(part, eventTime, model);
@@ -512,6 +513,7 @@ export function parseVSCodeChatJSON(text: string): ParsedSession | null {
     } else {
       session = parsed;
     }
+
   } catch {
     // Try unwrap from JSONL wrapper
     session = unwrapJsonl(text);
@@ -520,3 +522,5 @@ export function parseVSCodeChatJSON(text: string): ParsedSession | null {
   if (!session) return null;
   return parseVSCodeChatSession(session);
 }
+
+export const vscodeLive = { buildTimeline, buildMetadata, isVSCodeSession, mapResponsePart };

--- a/tests/e2e/live-normalization.spec.js
+++ b/tests/e2e/live-normalization.spec.js
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+
+for (const name of ["test-claude-code.jsonl", "test-copilot.jsonl", "test-codex.jsonl", "test-vscode-chat.json"]) {
+  test(`${name}: worker snapshots preserve append parity and discard queued pre-reset history`, async ({ page }) => {
+    const fixture = fs.readFileSync(path.resolve("src", "__tests__", "fixtures", name), "utf8");
+    const lines = name.endsWith(".json")
+      ? [
+        JSON.stringify({ kind: 0, v: JSON.parse(fixture) }),
+        JSON.stringify({ kind: 1, k: ["customTitle"], v: "Worker title" }),
+        JSON.stringify({ kind: 1, k: ["requests", 0, "message", "text"], v: "Changed user message" }),
+      ]
+      : fixture.trim().split("\n");
+    await page.route("**/api/meta", route => route.fulfill({ json: {} }));
+    await page.route("**/api/sessions", route => route.fulfill({ json: [] }));
+    await page.goto("/?demo=empty");
+    const results = await page.evaluate(async lines => {
+      const { createLiveParserClient } = await import("/src/lib/liveParserClient.js");
+      const { parseSession } = await import("/src/lib/parseSession.ts");
+      const results = [];
+      let resolveNext;
+      let rejectNext;
+      const next = () => new Promise((resolve, reject) => { resolveNext = resolve; rejectNext = reject; });
+      let waiting = next();
+      const client = createLiveParserClient(new Worker("/src/lib/liveSessionWorker.ts", { type: "module" }), lines.join("\n"),
+        data => resolveNext(data), error => rejectNext(new Error(error)));
+      try {
+        client.append('{"type":"user","content":"discard this"}');
+        client.append(lines[0], true);
+        const reset = await waiting;
+        results.push({ actual: reset.result, expected: parseSession(lines[0]), text: reset.rawText, expectedText: lines[0] });
+        let raw = lines[0];
+        for (const line of lines.slice(1)) {
+          waiting = next();
+          client.append(line);
+          const data = await waiting;
+          raw += "\n" + line;
+          results.push({ actual: data.result, expected: parseSession(raw), text: data.rawText, expectedText: raw });
+        }
+      } finally { client.dispose(); }
+      return results;
+    }, lines);
+    for (const result of results) {
+      expect(result.actual).toEqual(result.expected);
+      expect(result.text).toBe(result.expectedText);
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Completes the explicitly remaining normalization limitation from merged PR #131. Ordinary live appends now normalize only new/affected records rather than reparsing retained history inside a worker.

- Retained format-specific state for Claude Code, Copilot CLI, Codex, and VS Code base-plus-patch JSONL.
- Indexed cumulative usage, tool/result dependencies, model/lifecycle information, durations, errors, and turn membership. Local VS Code result patches update one response part; sparse request patches skip unchanged requests.
- Batch `parseSession` remains the parity oracle. Global timestamp/structural changes explicitly update affected history rather than leaving stale values.
- Full immutable snapshot copying and worker serialization remain O(history), documented and measured separately. Worker avoids a redundant clone.
- Reset/truncation and empty patched sessions clear state, including the no-worker fallback.
- No visual styling changes; unchanged screenshots/palette were not regenerated.

## Deterministic normalization evidence
Equal ten-record batches after 100 versus 10,000 historical items have identical record/event/turn operation counts:

| Format | Operations at both sizes | Normalization median ms, small / large | Snapshot clone median ms, small / large |
| --- | --- | --- | --- |
| Claude Code | 10 / 22 / 11 | 0.052 / 0.076 | 0.518 / 40.226 |
| Copilot CLI | 10 / 10 / 10 | 0.092 / 0.147 | 0.385 / 27.763 |
| Codex | 10 / 20 / 12 | 0.105 / 0.178 | 0.483 / 32.735 |
| VS Code | 20 / 30 / 10 | 0.073 / 0.230 | 0.802 / 68.288 |

Timings are observations, not pass/fail thresholds. Work-count equality is asserted. Additional regressions cover historic usage/results after 5,000 records and intercept Copilot turn-array splice operations to detect concealed history-sized shifts. Full contracts and reproduction instructions: `docs/live-normalization.md`.

## Validation
- Initial scaling regressions failed before implementation (four absent retained-work contracts).
- `npm run typecheck`: passed.
- `npm test`: **1,027 passed, 66 files**.
- `npm run build`: passed (existing large-chunk warning only).
- `npx playwright test`: **28 passed**, including v2, cleanup, actual workers for all four formats, and Chromium/WebKit portable exports.
- Actual HTTP snapshot/SSE append, reconnect/UTF-8, and truncation/reset coverage.
- Fixture/prefix and multiple-partition parity, CRLF/blank lines/unfinished tails, seeded reordered-record tests, usage/model/tool/lifecycle changes.
- Read-only self-review found and resolved two blockers (Codex activation/deactivation ordering; unnecessary Copilot membership shifts). Follow-up review found no significant issues.

## Merge
Please preserve commit `1d6b967` with a merge commit, not squash. Wait for every CI check; no overrides.