### PR TITLE
Release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-09-06
+
+### Fixed
+
+- Preserve exact event identity when navigating from the command palette or
+  Waterfall, and keep deep Replay targets anchored while measured rows settle.
+  Manual scrolling cancels automatic correction. (#131)
+- Share session-scoped playback and search across v2 zones. Session loading is
+  transactional: failed imports preserve the previous session, superseded
+  requests are ignored, and FileReader errors remain recoverable. (#131)
+- Resume live streams at snapshot/SSE byte boundaries, handle reconnects and
+  truncation resets, and keep growing sessions in a stable library entry. (#131)
+- Preserve batch-parser parity for late tool results, cumulative usage,
+  model/lifecycle changes, reordered records, and empty patched sessions,
+  including the no-worker fallback. (#132)
+
+### Changed
+
+- Retain incremental normalization state for Claude Code, Copilot CLI, Codex,
+  and VS Code base-plus-patch JSONL. Ordinary appends process only new or
+  affected records, with indexed tool dependencies, usage, and turn membership.
+  Global timestamp or structural changes still update affected history. (#132)
+- Keep live normalization off the main thread with single-flight backpressure.
+  Full immutable snapshot copying and worker serialization remain O(history);
+  this is not a zero-history-processing pipeline. (#131, #132)
+- Make discovery IO asynchronous with bounded format-specific previews,
+  newest-first enrichment, and a bounded preview cache. Discovery still
+  enumerates and stats candidates for correct ordering. (#131)
+- Memoize Tracks geometry and cap overview groups at 200 per lane while keeping
+  every original event accessible through paginated detail. Memoize Analyze
+  summaries and avoid rebuilding Replay event streams on every tick. (#127,
+  #129, #131)
+- Improve dark/light text contrast, add persisted normal/comfortable reading
+  density, stack compact Replay inspectors, and support keyboard/pointer
+  resizing plus keyboard/touch evidence navigation in Graph and Tracks.
+  Empty Find prioritizes importing real sessions. (#131)
+- Update dependencies and add restricted, provenance-enabled npm publishing
+  through GitHub Actions. (#111, #125, #126, #130)
+
+### Tests
+
+- Validate incremental work counts after 100 versus 10,000 historical items,
+  late historic results, parser partition parity, and real HTTP/worker streams.
+  The release baseline passes 1,027 tests across 66 files and 28 browser tests,
+  including Chromium/WebKit portable exports. (#131, #132)
+
 ### Security
 
 - Rejected cross-site requests to the local API. Any website the user visited

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentviz",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Session replay visualizer for AI agent workflows (Claude Code, VS Code, Copilot CLI)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary
Release the accumulated fixes through merged PR #132 as AGENTVIZ v1.0.4, following the metadata-only release convention used in #124.

- Bump package.json and both package-lock.json root versions with `npm version 1.0.4 --no-git-tag-version --ignore-scripts`; no dependency or lifecycle changes.
- Document correctness, bounded discovery/Tracks, readable and accessible UI from #131, and retained incremental normalization for Claude Code, Copilot CLI, Codex, and VS Code from #132.
- Explicitly retain the limitation that full snapshot cloning and worker serialization remain O(history).
- Include the local API protections, memoization, dependency updates, and established npm publishing workflow shipped since v1.0.3.

## Validation
- `npm run typecheck`: passed.
- `npm test`: 1,027 tests / 66 files passed.
- `npm run build`: passed; existing large-chunk warning only.
- `npm pack --dry-run --ignore-scripts --json`: 80 files; version 1.0.4 verified against both manifests; required CLI, MCP, server, all four incremental normalizers, production entrypoint and built live worker present; excluded private/generated directories checked.
- PR #132 baseline: 28 browser tests passed; this release changes no runtime/UI code.
- Release diff review: CLEAN. Only changelog and three version values change; no duplicate/dead code, architecture changes, missing runtime tests, or UI artifact drift introduced.

## Release procedure
Wait for CI, merge without overriding checks, tag the merged main revision as v1.0.4, then publish the GitHub release. The existing `Publish npm` release workflow publishes the package with provenance. Verify workflow and npm publication before declaring completion.