### PR TITLE
Fix GPT-5.6 and Astra token cost estimation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,8 +66,8 @@ src/
     diffUtils.js       # Diff detection (isFileEditEvent) + Myers line diff algorithm
     waterfall.ts       # Waterfall view helpers: item building, stats, layout, windowing
     graphLayout.js     # Graph view helpers: ELKjs DAG builder, layout runner, position merger
-    costAnalysis.js    # Per-call cost, context, cache-miss, and token aggregation helpers
-    pricing.js         # Claude and OpenAI/Copilot model pricing table and cost estimation
+    costAnalysis.js    # Shared request-aware estimates, reported charges, and evidence limitations
+    pricing.js         # Model/tier/cache rates and nullable cost estimation
     exportHtml.js      # Self-contained HTML export for single sessions and comparisons
     dataInspector.js   # Payload summary and preview helpers for inspector panels
     formatTime.js      # Duration and date formatting utilities
@@ -169,6 +169,10 @@ Run `npx playwright install chromium` once before the first browser test run.
 - Product name is always AGENTVIZ (all caps, no spaces)
 - UI/UX design system: see docs/ui-ux-style-guide.md -- all UI changes must conform to it
 - Cache usage summaries omit the cache-write segment when `cacheWrite` is zero
+- Cost estimates use each request's model and input length, never session totals as request lengths. `estimateCost` returns null for unknown pricing; `buildCostAnalysis` is the shared session estimator. Keep actual USD and AI Credits authoritative and per-model nano-AIU charges intact.
+- Analyze memoizes one full-session cost analysis for its summary, Stats, and Cost; playback/filter changes do not reprice partial usage as whole-session costs. Peak context uses observed input counters, not the prompt-text composition heuristic.
+- GPT-5.6/Sol/Terra/Luna and GPT-6 Astra price cache writes at 1.25x input in total. Preserve `cacheWriteReported: false` for missing counters; never infer written tokens or Fast from reasoning effort. Disclose Standard assumptions. Luna needs explicit billing-provider context in the 200k-272k interval.
+- Codex `metadata.pricingRequests` contains only last-request usage verified against cumulative deltas; unchanged checkpoints are deduplicated. Batch and live paths share `observePricing`. `pricingContext` records sourced billing provider / actual response service tier, not model-provider guesses. See README pricing evidence for verified sources and dates.
 - Copilot CLI Session Info lists every explicit reasoning effort in first-seen order; selected events show the effective value, and effort is never inferred from reasoning text or token usage
 - The workflow is the only shell. Keep `#/v2/...` URLs, internal v2 filenames and preferences, and session-library/content v1 schema keys. Ignore obsolete UI preferences; never clear saved data to remove a shell.
 - Timeline transport in Investigate and Analyze shares PlaybackProvider state. Speeds live in playbackUtils.js. One shortcut dispatcher preserves 1-6 zones and the 7 Improve alias, without stealing native control keys.

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Interactive directed graph of session turns with expandable tool-call structure.
 
 ### Analyze: Stats
 
-Aggregate metrics, event distribution bars, tools used ranking, and a per-turn summary. Includes token counts, estimated USD cost per turn for Claude models, and per-turn cache hit rate summaries when prompt caching data is available. The cache write segment is omitted when it is zero.
+Aggregate metrics, event distribution bars, tools used ranking, and a per-turn summary. Includes token counts, estimated USD cost per turn using each request's model and context tier, and per-turn cache hit rate summaries when prompt caching data is available. The cache write segment is omitted when it is zero.
 
 A **Tools &amp; Skills** panel surfaces every skill, instruction file, custom agent, MCP server, built-in tool, and prompt that appeared in the session. Each entry shows its lifecycle stage (Discovered &rarr; Loaded &rarr; Invoked &rarr; Resources &rarr; Completed or Errored) as a mini progress bar, its invocation count, and its source (project / personal / extension / built-in / MCP). Click any row to expand its full event timeline. Filter by category (Skills, Instructions, Agents, Tools, MCP, Prompts) or click a source chip to isolate entries from that origin.
 
@@ -309,6 +309,23 @@ A **Tools &amp; Skills** panel surfaces every skill, instruction file, custom ag
 ### Analyze: Cost
 
 Per-call token spend, cache read/write usage, context composition, and cumulative cost for sessions with token usage. Copilot CLI sessions report usage-based AI Credits, shown with the USD equivalent (1 credit = $0.01); token-based USD estimates are used as a fallback for older logs when pricing is recognized. Copilot prompt exports include prompt context breakdowns so the view can highlight fresh input spikes, cache misses, tool schema growth, and which parts of the prompt are filling the context window.
+
+**Pricing evidence:** Reported USD and AI Credits remain authoritative and separate from token estimates. Per-model reported credits are never redistributed according to estimated prices. Unknown models, ambiguous context tiers, and aggregate-only totals that could span multiple pricing tiers display `--`, not a zero-dollar bill. Aggregate input is not a request length or a peak context window. Stats, Review, Compare, Replay, Q&A, and saved-session summaries share this request-aware accounting.
+
+GPT-5.6 and GPT-6 rates were verified on **2026-09-09** against [OpenAI pricing](https://developers.openai.com/api/docs/pricing) and [GitHub Copilot pricing](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing). Standard USD per million tokens:
+
+| Model | Fresh input | Cache read | Cache write | Output |
+| --- | ---: | ---: | ---: | ---: |
+| GPT-5.6 Sol | $4 | $0.40 | $5 | $20 |
+| GPT-5.6 Terra | $2 | $0.20 | $2.50 | $12 |
+| GPT-5.6 Luna | $0.20 | $0.02 | $0.25 | $1.20 |
+| GPT-6 Astra | $10 | $1 | $12.50 | $50 |
+
+- Long context doubles all input buckets and multiplies output by 1.5 above 272,000 request input tokens for Sol, Terra, and Astra. The official Luna thresholds differ: Copilot uses **>200,000**, while the [OpenAI Luna model page](https://developers.openai.com/api/docs/models/gpt-5.6-luna) uses **>272,000**. Unknown billing providers leave the disputed interval unpriced.
+- Explicit Fast / `priority` pricing is 2x Standard; Batch and Flex are 0.5x for these four models. A response's actual `service_tier` takes precedence; reasoning effort never selects a price tier. Without tier evidence, the UI discloses the Standard assumption. Sol's published promotional rates apply at least through **November 21, 2026**; this is a dated reference table, not historical invoice reconstruction.
+- Normalized input includes fresh, cached, and written tokens. A [cache write costs 1.25x input in total](https://developers.openai.com/api/docs/guides/prompt-caching), not an additional 1.25x surcharge. Reasoning tokens are already included in output.
+- Codex reads [`cache_write_input_tokens`](https://github.com/openai/codex/blob/main/codex-rs/protocol/src/protocol.rs) and uses `last_token_usage` only when it matches the cumulative checkpoint delta, deduplicating unchanged checkpoints in both batch and live parsing. Codex's `model_provider` is not proof of API billing versus a subscription, and its rollout turn context does not expose an actual response service tier.
+- Prompt exports read official Responses `input_tokens_details.cache_write_tokens` and Chat Completions `prompt_tokens_details.cache_write_tokens`; Copilot CLI reads `usage.cacheWriteTokens` or `tokenDetails.cache_write.tokenCount`. Missing write counters are disclosed rather than inferred from fresh input. Estimates exclude unreported write premiums, regional uplifts, negotiated discounts, and non-token charges; consult reported billing for actual spend.
 
 <div align="center">
 <img src="docs/screenshots/cost-view.png" alt="Cost View" width="800" />
@@ -504,8 +521,8 @@ src/
     diffUtils.js         # Diff detection and Myers line diff algorithm
     waterfall.ts         # Waterfall view helpers: item building, stats, layout
     graphLayout.js       # ELKjs graph builder, fork/join DAG for parallel agents, layout merger
-    costAnalysis.js      # Per-call cost, context, cache-miss, and token aggregation helpers
-    pricing.js           # Claude and OpenAI/Copilot model pricing table and cost estimation
+    costAnalysis.js      # Shared request-aware estimates, reported charges, and evidence limitations
+    pricing.js           # Model/tier/cache rates and nullable cost estimation
     pricing.d.ts         # TypeScript declarations for pricing.js
     exportHtml.js        # Self-contained HTML export for single sessions and comparisons
     headlessExport.js    # CLI/headless self-contained HTML export for static manifests

--- a/docs/color-palette.html
+++ b/docs/color-palette.html
@@ -29,6 +29,7 @@
 <p>Selected evidence keeps the accent focus treatment while virtual row measurements settle. Manual scrolling always takes precedence.</p>
 <p>The workflow-only shell shares this palette across Find, Review, Investigate, Analyze, Compare, and Improve. Timeline transport, Close session, and shortcut help use existing surface, border, text, and focus tokens; no new colors were introduced.</p>
 <p>Bottom transport menus open upward within the viewport using the same surface, border, shadow, and selected-option tokens as header menus. Empty live streams retain the standard Close action.</p>
+<p>Cost and Stats keep reported charges separate from token estimates. Pricing assumptions and missing evidence use the existing muted text token; unknown amounts display -- rather than a zero-dollar charge. No pricing-specific colors were added.</p>
 <div class="modes" id="palettes"></div>
 <script>
 // Static snapshots keep this reference usable offline without module loading.

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -1081,6 +1081,8 @@ Cache observability is shown when `cacheRead > 0` in token usage data.
 
 The cache write segment is omitted when `cacheWrite` is zero.
 
+**Cost evidence:** Label token-derived amounts `Est. cost` or `Token cost estimates`, never billed usage. Reported USD and AI Credits are authoritative and stay separate from estimates; do not prorate reported session charges into fabricated per-model bills. Unknown prices and ambiguous request tiers display `--`, not `$0.00`. Show pricing assumptions and missing evidence in readable `theme.text.muted` text, not only a hover tooltip. Metadata-only input totals are not peak context or individual request lengths. Stats turn estimates sum per-request model prices. No new colors are required.
+
 Percentages use `.toFixed(1)` (e.g. `85.3%`). Token counts use `.toLocaleString()` for thousands separators.
 
 ### Color Coding for Values

--- a/src/__tests__/autonomyMetrics.test.js
+++ b/src/__tests__/autonomyMetrics.test.js
@@ -37,13 +37,13 @@ describe("autonomy metrics", function () {
     expect(cost).toBeGreaterThan(0);
   });
 
-  it("uses fallback pricing for unrecognized Claude variant", function () {
+  it("leaves unrecognized Claude pricing unknown", function () {
     var cost = getSessionCost({
       format: "claude-code",
       primaryModel: "claude-99-mega-20260101",
       tokenUsage: { inputTokens: 1000000, outputTokens: 100000 },
     });
-    expect(cost).toBeGreaterThan(0);
+    expect(cost).toBeNull();
   });
 
   it("derives babysitting, idle time, interventions, and efficiency from session gaps", function () {

--- a/src/__tests__/codexParser.test.ts
+++ b/src/__tests__/codexParser.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from "fs";
 import { join } from "path";
 import { detectCodexJSONL, parseCodexJSONL } from "../lib/codexParser";
 import { detectFormat, parseSession } from "../lib/parseSession";
+import { appendLiveSessionText, createLiveSessionParser } from "../lib/liveSessionParser";
+import { buildCostAnalysis } from "../lib/costAnalysis.js";
 
 const FIXTURE = readFileSync(join(__dirname, "fixtures/test-codex.jsonl"), "utf8");
 
@@ -31,6 +33,47 @@ describe("detectCodexJSONL", function () {
 });
 
 describe("parseCodexJSONL", function () {
+  it("prices verified last-request usage, preserves writes, and deduplicates live checkpoints", function () {
+    const usage = { input_tokens: 200000, cached_input_tokens: 60000, cache_write_input_tokens: 20000, output_tokens: 10000, reasoning_output_tokens: 5000, total_tokens: 210000 };
+    const token = (total: typeof usage) => ({ type: "event_msg", payload: { type: "token_count", info: { total_token_usage: total, last_token_usage: usage } } });
+    const records = [
+      { type: "session_meta", payload: { originator: "codex-cli", model_provider: "openai" } },
+      { type: "turn_context", payload: { turn_id: "a", model: "gpt-5.6-sol", effort: "high" } },
+      { type: "response_item", payload: { type: "message", role: "user", content: "Synthetic pricing check" } },
+      token(usage),
+      token(usage),
+      { type: "turn_context", payload: { turn_id: "b", model: "gpt-6-astra", effort: "high" } },
+      token(Object.fromEntries(Object.entries(usage).map(([key, count]) => [key, count * 2])) as typeof usage),
+    ];
+    let live = createLiveSessionParser(records.slice(0, 3).map(line).join("\n"));
+    const snapshot = live.result;
+    for (let i = 3; i < records.length; i++) {
+      live = appendLiveSessionText(live, line(records[i])).state;
+      expect(live.result).toEqual(parseSession(records.slice(0, i + 1).map(line).join("\n")));
+    }
+    expect(snapshot?.metadata.tokenUsage).toBeNull();
+    const result = live.result!;
+    expect(result.metadata.tokenUsage).toMatchObject({ inputTokens: 400000, cacheWrite: 40000, cacheWriteReported: true, outputTokens: 20000 });
+    expect(result.metadata.pricingRequests).toHaveLength(2);
+    const analysis = buildCostAnalysis(result.events, result.metadata);
+    expect(analysis.calls.map(call => call.model)).toEqual(["gpt-5.6-sol", "gpt-6-astra"]);
+    expect(analysis.totals.cost).toBeCloseTo(0.804 + 2.01, 8);
+    expect(analysis.pricingNotes.join(" ")).toContain("Standard service tier assumed");
+  });
+
+  it("refuses to treat cumulative jumps as one request", function () {
+    const text = [
+      line({ type: "session_meta", payload: { originator: "codex-cli" } }),
+      line({ type: "turn_context", payload: { turn_id: "a", model: "gpt-5.6-sol" } }),
+      line({ type: "response_item", payload: { type: "message", role: "user", content: "Test" } }),
+      line({ type: "event_msg", payload: { type: "token_count", info: { total_token_usage: { input_tokens: 400000, output_tokens: 20000 }, last_token_usage: { input_tokens: 200000, output_tokens: 10000 } } } }),
+    ].join("\n");
+    const result = parseSession(text)!;
+    expect(result.metadata.pricingRequests).toBeUndefined();
+    expect(buildCostAnalysis(result.events, result.metadata).totals.cost).toBeNull();
+    expect(createLiveSessionParser(text).result).toEqual(result);
+  });
+
   it("normalizes Codex messages, reasoning, tools, outputs, turns, and metadata", function () {
     const result = parseCodexJSONL(FIXTURE);
     expect(result).not.toBeNull();

--- a/src/__tests__/copilotCliParser.test.js
+++ b/src/__tests__/copilotCliParser.test.js
@@ -520,6 +520,31 @@ describe("metadata", function () {
     expect(parsed.metadata.aiCredits).toBeCloseTo(3.5, 6);
   });
 
+  it("preserves exact model credits and cache-write evidence for new OpenAI models", function () {
+    var shutdown = JSON.parse(JSON.stringify(SESSION_SHUTDOWN));
+    shutdown.data.totalNanoAiu = 20e9;
+    shutdown.data.modelMetrics = {
+      "gpt-5.6-sol": { totalNanoAiu: 2e9, usage: { inputTokens: 100000, outputTokens: 10000, cacheReadTokens: 60000 }, tokenDetails: { cache_write: { tokenCount: 20000 } } },
+      "gpt-6-astra": { totalNanoAiu: 7e9, tokenDetails: { input: { tokenCount: 20000 }, cache_read: { tokenCount: 60000 }, cache_write: { tokenCount: 20000 }, output: { tokenCount: 10000 } } },
+    };
+    var parsed = parseCopilotCliJSONL(buildTrace([SESSION_START, USER_MSG, shutdown]));
+    expect(parsed.metadata.modelTokenUsage["gpt-5.6-sol"]).toMatchObject({ inputTokens: 100000, cacheWrite: 20000, cacheWriteReported: true, aiCredits: 2 });
+    expect(parsed.metadata.modelTokenUsage["gpt-6-astra"]).toMatchObject({ inputTokens: 100000, cacheWrite: 20000, aiCredits: 7 });
+    var analysis = buildCostAnalysis(parsed.events, parsed.metadata);
+    expect(analysis.calls.map(call => call.cost)).toEqual([2, 7]);
+    expect(analysis.totals.cost).toBe(20);
+    expect(analysis.totals.estimatedUsdCost).toBeCloseTo(1.414, 8);
+  });
+
+  it("does not turn a partial model-credit sum into a reported session total", function () {
+    var shutdown = JSON.parse(JSON.stringify(SESSION_SHUTDOWN));
+    delete shutdown.data.totalNanoAiu;
+    shutdown.data.modelMetrics["gpt-6-astra"] = { usage: { inputTokens: 10000, outputTokens: 1000 } };
+    var parsed = parseCopilotCliJSONL(buildTrace([SESSION_START, USER_MSG, shutdown]));
+    expect(parsed.metadata.totalCost).toBeNull();
+    expect(parsed.metadata.modelTokenUsage["claude-opus-4.6"].aiCredits).toBe(1);
+  });
+
   it("uses the session-level totalNanoAiu even when modelMetrics is absent", function () {
     var shutdown = JSON.parse(JSON.stringify(SESSION_SHUTDOWN));
     delete shutdown.data.modelMetrics;

--- a/src/__tests__/copilotCostParser.test.ts
+++ b/src/__tests__/copilotCostParser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { detectFormat, parseSession } from "../lib/parseSession";
 import { detectCopilotPrompts, parseCopilotPromptsJSON } from "../lib/copilotCostParser";
+import { buildCostAnalysis } from "../lib/costAnalysis.js";
 
 function fixture() {
   return JSON.stringify([
@@ -77,7 +78,8 @@ describe("parseCopilotPromptsJSON", function () {
       cacheRead: 1100,
       cacheWrite: 70,
     });
-    expect(parsed!.metadata.totalCost).toBeGreaterThan(0);
+    expect(parsed!.metadata.totalCost).toBeUndefined();
+    expect(buildCostAnalysis(parsed!.events, parsed!.metadata).totals.estimatedUsdCost).toBeGreaterThan(0);
     expect((parsed!.events[0].raw as any).costPrompt.toolNames).toEqual(["read_file"]);
     expect((parsed!.events[1].raw as any).costPrompt.contextBreakdown.history).toBeGreaterThan(0);
   });
@@ -86,6 +88,21 @@ describe("parseCopilotPromptsJSON", function () {
     const wrapped = JSON.stringify({ prompts: JSON.parse(fixture()) });
     const parsed = parseCopilotPromptsJSON(wrapped);
     expect(parsed!.metadata.promptCallCount).toBe(2);
+  });
+
+  it.each(["responses", "chat"])("reads official %s write counters and actual response tier", function (schema) {
+    const usage = schema === "responses"
+      ? { input_tokens: 100000, output_tokens: 10000, input_tokens_details: { cached_tokens: 60000, cache_write_tokens: 20000 }, output_tokens_details: { reasoning_tokens: 5000 } }
+      : { prompt_tokens: 100000, completion_tokens: 10000, prompt_tokens_details: { cached_tokens: 60000, cache_write_tokens: 20000 }, completion_tokens_details: { reasoning_tokens: 5000 } };
+    const parsed = parseCopilotPromptsJSON(JSON.stringify([{
+      request: { model: "gpt-5.6-unknown", service_tier: "auto", messages: [{ role: "user", content: "Test" }] },
+      response: { model: "gpt-5.6-sol", service_tier: "priority", usage },
+    }]))!;
+    expect(parsed.events[0].tokenUsage).toMatchObject({ inputTokens: 100000, cacheWrite: 20000, cacheWriteReported: true, outputTokens: 10000 });
+    expect(parsed.events[0].model).toBe("gpt-5.6-sol");
+    expect(parsed.events[0].pricingContext).toEqual({ provider: "copilot", serviceTier: "priority" });
+    expect(buildCostAnalysis(parsed.events, parsed.metadata).totals.cost).toBeCloseTo(0.808, 8);
+    expect(parsed.metadata.totalCost).toBeUndefined();
   });
 
   it("truncates prompt text exceeding MAX_DISPLAY_TEXT_LENGTH", function () {

--- a/src/__tests__/costAnalysis.test.js
+++ b/src/__tests__/costAnalysis.test.js
@@ -29,6 +29,98 @@ function event(index, usage, model, contextTotal, tools) {
 }
 
 describe("buildCostAnalysis", function () {
+  it("prices requests separately even when their sum crosses the context threshold", function () {
+    var calls = [0, 1].map(i => event(i, { inputTokens: 200000, outputTokens: 10000, cacheRead: 60000, cacheWrite: 20000 }, "gpt-5.6-sol", 200000));
+    var analysis = buildCostAnalysis(calls, { primaryModel: "gpt-5.6-sol", tokenUsage: { inputTokens: 400000, outputTokens: 20000, cacheRead: 120000, cacheWrite: 40000 } });
+    expect(analysis.totals.cost).toBeCloseTo(1.608, 8);
+    expect(analysis.totals.peakContext).toBe(200000);
+    expect(buildCostAnalysis([event(0, analysis.totals, "gpt-5.6-sol", 400000)], {}).totals.cost).toBeCloseTo(3.016, 8);
+  });
+
+  it("does not price metadata-only aggregates as a long request or show a fake peak context", function () {
+    var analysis = buildCostAnalysis([], { primaryModel: "gpt-5.6-sol", tokenUsage: { inputTokens: 400000, outputTokens: 20000, cacheWrite: 0 } });
+    expect(analysis.totals.cost).toBeNull();
+    expect(analysis.totals.estimatedUsdCost).toBeNull();
+    expect(analysis.totals.peakContext).toBeNull();
+    expect(analysis.pricingNotes.join(" ")).toContain("Per-request usage required");
+  });
+
+  it("does not publish partial estimates as mixed-model totals", function () {
+    var analysis = buildCostAnalysis([
+      event(0, { inputTokens: 100000 }, "gpt-5.6-sol", 100000),
+      event(1, { inputTokens: 100000 }, "gpt-6-unknown", 100000),
+    ], {});
+    expect(analysis.calls[0].cost).toBeCloseTo(0.4, 8);
+    expect(analysis.calls[1].cost).toBeNull();
+    expect(analysis.calls[1].cumulativeCost).toBeNull();
+    expect(analysis.totals.cost).toBeNull();
+  });
+
+  it("keeps reported session charges authoritative even with complete request usage", function () {
+    var calls = [event(0, { inputTokens: 100000, cacheRead: 60000, cacheWrite: 20000, outputTokens: 10000 }, "gpt-5.6-sol", 100000)];
+    for (var unit of ["usd", "ai_credits"]) {
+      var analysis = buildCostAnalysis(calls, { totalCost: 3, totalCostUnit: unit });
+      expect(analysis.totals.cost).toBe(3);
+      expect(analysis.totals.costUnit).toBe(unit);
+      expect(analysis.totals.estimatedUsdCost).toBeCloseTo(0.404, 8);
+      expect(analysis.calls[0].cost).toBeCloseTo(0.404, 8);
+      expect(analysis.calls[0].costUnit).toBe("usd");
+      expect(analysis.calls[0].isReportedCost).toBe(false);
+    }
+  });
+
+  it("preserves per-model reported credits instead of prorating a session bill by estimated prices", function () {
+    var analysis = buildCostAnalysis([], {
+      primaryModel: "gpt-5.6-sol", totalCost: 20, totalCostUnit: "ai_credits",
+      tokenUsage: { inputTokens: 200000, outputTokens: 20000 },
+      modelTokenUsage: {
+        "gpt-5.6-sol": { inputTokens: 100000, outputTokens: 10000, aiCredits: 2 },
+        "gpt-6-astra": { inputTokens: 100000, outputTokens: 10000, aiCredits: 7 },
+      },
+    });
+    expect(analysis.calls.map(call => call.cost)).toEqual([2, 7]);
+    expect(analysis.calls[1].cumulativeCost).toBe(9);
+    expect(analysis.totals.cost).toBe(20);
+    expect(analysis.pricingNotes.join(" ")).toContain("both are preserved");
+  });
+
+  it("does not allocate reported costs to unreported model charges", function () {
+    var analysis = buildCostAnalysis([], {
+      totalCost: 10, totalCostUnit: "usd",
+      modelTokenUsage: { "gpt-5.6-sol": { inputTokens: 10000 }, "gpt-6-astra": { inputTokens: 10000 } },
+    });
+
+    expect(analysis.calls.map(call => call.cost)).toEqual([null, null]);
+    expect(analysis.totals.cost).toBe(10);
+  });
+
+  it("does not report floating-point addition as a model-charge discrepancy", function () {
+    var analysis = buildCostAnalysis([], {
+      totalCost: 0.3, totalCostUnit: "ai_credits",
+      modelTokenUsage: {
+        "gpt-5.6-sol": { aiCredits: 0.1 },
+        "gpt-6-astra": { aiCredits: 0.2 },
+      },
+    });
+    expect(analysis.totals.cost).toBe(0.3);
+    expect(analysis.pricingNotes.join(" ")).not.toContain("do not sum");
+  });
+
+  it("uses Copilot's Luna threshold only for sourced Copilot sessions", function () {
+    var call = event(0, { inputTokens: 220000, outputTokens: 10000, cacheWrite: 0 }, "gpt-5.6-luna", 220000);
+    expect(buildCostAnalysis([call], { format: "copilot-cli" }).totals.cost).toBeCloseTo(0.106, 8);
+    expect(buildCostAnalysis([call], { format: "codex" }).totals.cost).toBeNull();
+    expect(buildCostAnalysis([{ ...call, pricingContext: { provider: "openai" } }], {}).totals.cost).toBeCloseTo(0.056, 8);
+  });
+
+  it("retains reported credits without token telemetry", function () {
+    var analysis = buildCostAnalysis([], { totalCost: 3, totalCostUnit: "ai_credits", modelTokenUsage: { "gpt-6-astra": { aiCredits: 3 } } });
+    expect(analysis.hasCostData).toBe(true);
+    expect(analysis.totals.cost).toBe(3);
+    expect(analysis.totals.estimatedUsdCost).toBeNull();
+    expect(analysis.calls[0].cost).toBe(3);
+  });
+
   it("builds cumulative costs and token totals", function () {
     var analysis = buildCostAnalysis([
       event(0, { inputTokens: 1000, outputTokens: 100, cacheRead: 200, cacheWrite: 50 }, "gpt-4.1", 1000),
@@ -41,7 +133,7 @@ describe("buildCostAnalysis", function () {
     expect(analysis.totals.cacheRead).toBe(800);
     expect(analysis.totals.freshInputTokens).toBe(1650);
     expect(analysis.calls[1].cumulativeCost).toBeGreaterThan(analysis.calls[0].cost);
-    expect(analysis.totals.peakContext).toBe(1300);
+    expect(analysis.totals.peakContext).toBe(1500);
   });
 
   it("flags same-model cache misses with tool diffs", function () {

--- a/src/__tests__/costView.test.jsx
+++ b/src/__tests__/costView.test.jsx
@@ -83,5 +83,21 @@ describe("CostView", function () {
     await act(async function () {
       root.unmount();
     });
+
+  });
+
+  it("labels token estimates and missing request evidence honestly", async function () {
+    var container = document.createElement("div");
+    document.body.appendChild(container);
+    var root = createRoot(container);
+    await act(async function () {
+      root.render(<CostView events={[]} metadata={{ primaryModel: "gpt-5.6-sol", tokenUsage: { inputTokens: 400000, outputTokens: 20000 } }} />);
+    });
+    expect(container.textContent).toContain("Per-request usage required");
+    expect(container.textContent).toContain("request sizes unavailable");
+    expect(container.textContent).toContain("$ ESTIMATE");
+    expect(container.textContent).not.toContain("$ BILLED");
+    expect(container.textContent).not.toContain("$0.00");
+    await act(async function () { root.unmount(); });
   });
 });

--- a/src/__tests__/fixtures/v2-golden-copilot.expected.json
+++ b/src/__tests__/fixtures/v2-golden-copilot.expected.json
@@ -85,7 +85,7 @@
     "freshInputTokens": 6200,
     "cost": 4.7,
     "cacheHitRate": 0.14634146341463414,
-    "peakContext": 8200,
+    "peakContext": null,
     "callCount": 1
   },
   "ui": {

--- a/src/__tests__/pricing.test.js
+++ b/src/__tests__/pricing.test.js
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { estimateCost, estimateMultiModelCost, formatCost, getSessionCostLabel, hasModelPricing } from "../lib/pricing.js";
+import { estimateCost, estimateCostDetails, estimateMultiModelCost, formatCost, getSessionCostLabel, hasModelPricing } from "../lib/pricing.js";
 
 describe("estimateCost", function () {
-  it("returns 0 for null tokenUsage", function () {
-    expect(estimateCost(null, "claude-sonnet-4")).toBe(0);
+  it("returns unknown for null tokenUsage", function () {
+    expect(estimateCost(null, "claude-sonnet-4")).toBeNull();
   });
 
-  it("returns 0 for unknown model", function () {
-    expect(estimateCost({ inputTokens: 1000 }, "gemini-pro")).toBe(0);
+  it("returns unknown for unknown model", function () {
+    expect(estimateCost({ inputTokens: 1000 }, "gemini-pro")).toBeNull();
   });
 
   it("prices cached input at the discounted rate", function () {
@@ -22,7 +22,7 @@ describe("estimateCost", function () {
     expect(cost).toBeCloseTo(3.325, 3);
   });
 
-  it("bills non-Anthropic cache write tokens at the standard input rate (no surcharge)", function () {
+  it("keeps older OpenAI cache write tokens at the standard input rate", function () {
     var cost = estimateCost({ inputTokens: 1000000, outputTokens: 0, cacheRead: 400000, cacheWrite: 100000 }, "gpt-4.1");
     // Fresh: 500K * $2/M = $1.00; cached: 400K * $0.20/M = $0.08; write: 100K * $2/M = $0.20 (input rate)
     expect(cost).toBeCloseTo(1.28, 2);
@@ -61,8 +61,8 @@ describe("estimateCost", function () {
 });
 
 describe("estimateMultiModelCost", function () {
-  it("returns 0 for null input", function () {
-    expect(estimateMultiModelCost(null)).toBe(0);
+  it("returns unknown for null input", function () {
+    expect(estimateMultiModelCost(null)).toBeNull();
   });
 
   it("returns 0 for empty map", function () {
@@ -95,13 +95,12 @@ describe("estimateMultiModelCost", function () {
     expect(multiModel).toBeGreaterThan(singleModel);
   });
 
-  it("skips unknown models without erroring", function () {
+  it("does not silently omit unknown models from totals", function () {
     var cost = estimateMultiModelCost({
       "claude-sonnet-4": { inputTokens: 1000000, outputTokens: 100000 },
       "gemini-pro":       { inputTokens: 500000, outputTokens: 50000 },
     });
-    // Only Sonnet is priced; Gemini contributes 0
-    expect(cost).toBeCloseTo(4.50, 2);
+    expect(cost).toBeNull();
   });
 });
 
@@ -173,8 +172,80 @@ describe("hasModelPricing", function () {
     expect(hasModelPricing("claude-opus-4")).toBe(true);
   });
 
-  it("returns true for unknown Claude variants (fallback pricing)", function () {
-    expect(hasModelPricing("claude-next-gen-99")).toBe(true);
+  it("does not invent pricing for unknown Claude variants", function () {
+    expect(hasModelPricing("claude-next-gen-99")).toBe(false);
+  });
+
+  describe("GPT-5.6 and GPT-6 Astra request pricing", function () {
+    var example = { inputTokens: 100000, cacheRead: 60000, cacheWrite: 20000, outputTokens: 10000 };
+    var models = [
+      ["gpt-5.6-sol", 4, 20, 0.404],
+      ["gpt-5.6-terra", 2, 12, 0.222],
+      ["gpt-5.6-luna", 0.2, 1.2, 0.0222],
+      ["gpt-6-astra", 10, 50, 1.01],
+    ];
+
+    it.each(models)("prices %s fresh, cached, written, and output tokens once", function (model, input, output, expected) {
+      expect(estimateCost(example, model)).toBeCloseTo(expected, 8);
+      expect(estimateCost(example, model.toUpperCase().replaceAll("-", " "))).toBeCloseTo(expected, 8);
+      expect(estimateCost(example, "openai/" + model + "-2026-09-01")).toBeCloseTo(expected, 8);
+    });
+
+    it.each(models)("applies %s tiers at threshold +1, not at threshold", function (model, input, output) {
+      for (var provider of ["openai", "copilot"]) {
+        var threshold = model === "gpt-5.6-luna" && provider === "copilot" ? 200000 : 272000;
+        for (var extra of [0, 1]) {
+          var long = extra === 1;
+          var usage = { inputTokens: threshold + extra, cacheRead: 60000, cacheWrite: 20000, outputTokens: 10000 };
+          var expected = ((usage.inputTokens - 80000) * input + 60000 * input * 0.1 + 20000 * input * 1.25) * (long ? 2 : 1) / 1e6
+            + 10000 * output * (long ? 1.5 : 1) / 1e6;
+          expect(estimateCost(usage, model, { provider })).toBeCloseTo(expected, 8);
+        }
+      }
+    });
+
+    it.each(models)("applies %s explicit service tiers to every bucket", function (model, input, output, standard) {
+      for (var [serviceTier, multiplier] of [["standard", 1], ["default", 1], ["fast", 2], ["priority", 2], ["batch", 0.5], ["flex", 0.5]]) {
+        expect(estimateCost(example, model, { serviceTier })).toBeCloseTo(standard * multiplier, 8);
+      }
+      expect(estimateCost(example, model + "-fast")).toBeCloseTo(standard * 2, 8);
+      expect(estimateCost(example, model, { serviceTier: "auto" })).toBeNull();
+    });
+
+    it("does not interpret reasoning effort as Fast or add reasoning output twice", function () {
+      expect(estimateCost({ ...example, reasoningTokens: 5000 }, "gpt-5.6-sol", { reasoningEffort: "high" })).toBeCloseTo(0.404, 8);
+      expect(estimateCostDetails(example, "gpt-5.6-sol").notes.join(" ")).toContain("Standard service tier assumed");
+    });
+
+    it("keeps provider-ambiguous Luna tiers unknown only where official thresholds disagree", function () {
+      expect(estimateCost({ inputTokens: 200000 }, "gpt-5.6-luna")).toBeCloseTo(0.04, 8);
+      expect(estimateCost({ inputTokens: 200001 }, "gpt-5.6-luna")).toBeNull();
+      expect(estimateCost({ inputTokens: 272000 }, "gpt-5.6-luna")).toBeNull();
+      expect(estimateCost({ inputTokens: 272001 }, "gpt-5.6-luna")).toBeCloseTo(0.1088004, 8);
+    });
+
+    it("does not apply request thresholds to accumulated model totals", function () {
+      expect(estimateMultiModelCost({ "gpt-5.6-sol": { inputTokens: 400000 } })).toBeNull();
+      expect(estimateMultiModelCost({ "gpt-5.6-sol": example, "gpt-6-astra": example })).toBeCloseTo(1.414, 8);
+    });
+
+    it("reports missing write evidence without inventing cache-write tokens", function () {
+      var details = estimateCostDetails({ inputTokens: 100000, outputTokens: 10000, cacheRead: 60000 }, "gpt-5.6-sol");
+      expect(details.cost).toBeCloseTo(0.384, 8);
+      expect(details.notes.join(" ")).toContain("Cache-write usage not reported");
+      expect(estimateCostDetails({ ...example, cacheWrite: 0 }, "gpt-5.6-sol").notes.join(" ")).not.toContain("Cache-write usage not reported");
+    });
+
+    it("does not assume short context for output-only telemetry", function () {
+      expect(estimateCost({ outputTokens: 10000 }, "gpt-5.6-sol")).toBeNull();
+      expect(estimateCostDetails({ outputTokens: 10000 }, "gpt-6-astra").notes.join(" ")).toContain("Request input usage required");
+    });
+
+    it.each(["gpt-5.6", "gpt-5.6-unknown", "gpt-5.6-sol-preview", "gpt-6", "gpt-6-astra-unknown", "gpt-5.7", "unknown-gpt-5"])("does not alias unknown %s to cheaper known pricing", function (model) {
+      expect(hasModelPricing(model)).toBe(false);
+      expect(estimateCost(example, model)).toBeNull();
+      expect(formatCost(estimateCost(example, model))).toBe("--");
+    });
   });
 
   it("returns true for known OpenAI/Copilot models", function () {

--- a/src/__tests__/replayView.test.jsx
+++ b/src/__tests__/replayView.test.jsx
@@ -43,6 +43,23 @@ function findExactText(container, text) {
 }
 
 describe("ReplayView", function () {
+  it("keeps session pricing based on unfiltered requests", async function () {
+    var container = document.createElement("div");
+    document.body.appendChild(container);
+    var root = createRoot(container);
+    var entries = [0, 1].map(index => makeEntry(index, {
+      agent: "assistant", track: "output", text: "Synthetic request", model: "gpt-5.6-sol",
+      tokenUsage: { inputTokens: 200000, outputTokens: 10000, cacheRead: 60000, cacheWrite: 20000 },
+    }));
+    await act(async function () {
+      root.render(<ReplayView currentTime={10} events={entries.map(entry => entry.event)} eventEntries={entries.slice(0, 1)} turnStartMap={{}}
+        metadata={{ primaryModel: "gpt-5.6-sol", models: { "gpt-5.6-sol": 2 }, tokenUsage: { inputTokens: 400000, outputTokens: 20000, cacheRead: 120000, cacheWrite: 40000 } }} />);
+    });
+    expect(findExactText(container, "$1.61")).not.toBeNull();
+    await act(async function () { root.unmount(); });
+    container.remove();
+  });
+
   beforeEach(function () {
     globalThis.IS_REACT_ACT_ENVIRONMENT = true;
     window.localStorage = createLocalStorage();

--- a/src/__tests__/tokenAccounting.test.js
+++ b/src/__tests__/tokenAccounting.test.js
@@ -128,6 +128,36 @@ function promptFixture() {
 }
 
 describe("token accounting across parsers and surfaces", function () {
+  it("uses per-request mixed-model prices in Cost, Stats, Compare, and Review", async function () {
+    var session = parseSession(JSON.stringify(["gpt-5.6-sol", "gpt-6-astra"].map(model => ({
+      request: { model, messages: [{ role: "user", content: "Synthetic cost request" }] },
+      response: { usage: { input_tokens: 200000, output_tokens: 10000, input_tokens_details: { cached_tokens: 60000, cache_write_tokens: 20000 } } },
+    }))));
+    expect(session.metadata.totalCost).toBeUndefined();
+    var expected = 0.804 + 2.01;
+    expect(buildCostAnalysis(session.events, session.metadata).totals.cost).toBeCloseTo(expected, 8);
+    expect(buildMetrics(session).cost).toBeCloseTo(expected, 8);
+    expect(buildReviewSummary(session, null).cost).toBeCloseTo(expected, 8);
+    var stats = await renderStatsText(session);
+    expect(stats).toContain("$2.81");
+    expect(stats).toContain("$0.804");
+    expect(stats).toContain("$2.01");
+    expect(stats).toContain("Standard service tier assumed");
+    expect(stats).not.toContain("reported by API");
+  });
+
+  it("shows missing pricing evidence instead of zero dollars in Stats", async function () {
+    var session = parseSession(JSON.stringify([{
+      request: { model: "gpt-5.6-unknown", messages: [{ role: "user", content: "Test unknown" }] },
+      response: { usage: { input_tokens: 100000, output_tokens: 10000 } },
+    }]));
+    expect(buildMetrics(session).cost).toBeNull();
+    var stats = await renderStatsText(session);
+    expect(stats).toContain("pricing evidence incomplete");
+    expect(stats).toContain("Pricing unavailable");
+    expect(stats).not.toContain("$0.00");
+  });
+
   it("keeps Copilot CLI shutdown totals consistent across metadata, Cost, Stats, Review, and Compare", async function () {
     var text = loadFixture("test-copilot.jsonl");
     var session = parseSession(text);

--- a/src/components/CompareView.jsx
+++ b/src/components/CompareView.jsx
@@ -51,8 +51,8 @@ export function buildMetrics(session) {
   var format = meta.format || "claude-code";
   var hasTokenUsage = tu.inputTokens != null || tu.outputTokens != null || tu.cacheRead != null || tu.cacheWrite != null;
 
-  // Cost: use API-reported cost when available, fall back to estimate for Claude Code.
-  var cost = getSessionCost(meta);
+  // Reported charges take precedence over request-aware token estimates.
+  var cost = getSessionCost(meta, session.events);
 
   return {
     model: meta.primaryModel || null,

--- a/src/components/CostView.jsx
+++ b/src/components/CostView.jsx
@@ -103,7 +103,7 @@ function CallRow({ call, miss }) {
         <div title={call.title} style={{ color: theme.text.primary, fontSize: theme.fontSize.sm, fontWeight: 800, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{call.title}</div>
         <div style={{ display: "flex", gap: theme.space.sm, flexWrap: "wrap", marginTop: theme.space.md }}>
           <Chip>{call.model}</Chip>
-          <Chip>{formatTokens(call.contextBreakdown.total || call.tokenUsage.inputTokens)} ctx</Chip>
+          <Chip>{formatTokens(call.tokenUsage.inputTokens)} {call.isMetadataSummary ? "input" : "ctx"}</Chip>
           {miss && <Chip warning>cache miss</Chip>}
           <Chip>{formatCostValue(call.cost, call.costUnit)}</Chip>
         </div>
@@ -125,8 +125,9 @@ function CostBars({ calls, cacheMisses }) {
   var missByIndex = new Map(cacheMisses.map(function (miss) { return [miss.callIndex, miss]; }));
   var costUnit = calls[0] && calls[0].costUnit;
   var usesCredits = isAiCreditsUnit(costUnit);
+  var reported = calls.length > 0 && calls.every(function (call) { return call.isReportedCost; });
   return (
-    <Panel label={usesCredits ? "Cumulative AI Credits" : "Cumulative cost"} title={usesCredits ? "Reported AI Credit usage" : "Billed input/output by call"} aside={<span style={{ color: theme.text.primary, fontSize: theme.fontSize.xs, fontFamily: theme.font.mono, border: "1px solid " + alpha(theme.accent.primary, 0.5), background: alpha(theme.accent.primary, 0.12), borderRadius: theme.radius.md, padding: theme.space.sm + "px " + theme.space.md + "px" }}>{usesCredits ? "CREDITS" : "$ BILLED"}</span>}>
+    <Panel label={usesCredits ? "Cumulative AI Credits" : "Cumulative cost"} title={reported ? (usesCredits ? "Reported AI Credit usage" : "Reported usage") : "Token cost estimates"} aside={<span style={{ color: theme.text.primary, fontSize: theme.fontSize.xs, fontFamily: theme.font.mono, border: "1px solid " + alpha(theme.accent.primary, 0.5), background: alpha(theme.accent.primary, 0.12), borderRadius: theme.radius.md, padding: theme.space.sm + "px " + theme.space.md + "px" }}>{reported ? (usesCredits ? "CREDITS" : "$ REPORTED") : "$ ESTIMATE"}</span>}>
       <Legend items={[{ label: "fresh", color: theme.accent.primary }, { label: "cached", color: theme.semantic.success }, { label: "cache write", color: theme.track.context }]} />
       <div style={{ padding: theme.space.lg, overflow: "auto" }}>
         {calls.map(function (call) {
@@ -167,8 +168,10 @@ function CacheMissAnnotation({ miss }) {
 
 function ContextBars({ calls }) {
   var max = maxCallValue(calls, function (call) { return call.contextBreakdown.total || call.tokenUsage.inputTokens || 0; });
+  var metadataOnly = calls.length > 0 && calls.every(function (call) { return call.isMetadataSummary; });
+  var estimated = calls.some(function (call) { return call.event && call.event.raw && call.event.raw.costPrompt; });
   return (
-    <Panel label="Context window" title="What is filling the prompt" aside="tokens">
+    <Panel label={metadataOnly ? "Session input" : "Context window"} title={metadataOnly ? "Aggregate input totals" : estimated ? "Estimated context composition" : "What is filling the prompt"} aside="tokens">
       <Legend items={[{ label: "system/tools", color: theme.track.context }, { label: "history", color: theme.accent.primary }, { label: "results", color: theme.semantic.success }, { label: "user", color: theme.agent.user }]} />
       <div style={{ padding: theme.space.lg, overflow: "auto" }}>
         {calls.map(function (call) {
@@ -190,10 +193,10 @@ function ContextBars({ calls }) {
   );
 }
 
-export default function CostView({ events, metadata }) {
+export default function CostView({ events, metadata, analysis: suppliedAnalysis }) {
   var analysis = useMemo(function () {
-    return buildCostAnalysis(events || [], metadata || {});
-  }, [events, metadata]);
+    return suppliedAnalysis || buildCostAnalysis(events || [], metadata || {});
+  }, [events, metadata, suppliedAnalysis]);
 
   if (!analysis.hasCostData) {
     return (
@@ -213,9 +216,9 @@ export default function CostView({ events, metadata }) {
   return (
     <div style={{ padding: theme.space.xl, display: "flex", flexDirection: "column", gap: theme.space.lg, minHeight: 0, height: "100%", overflow: "hidden", fontFamily: theme.font.mono, fontSize: theme.fontSize.base }}>
       <div style={{ display: "grid", gridTemplateColumns: SUMMARY_GRID_5_COLUMNS, gap: theme.space.lg }}>
-        <SummaryCard label="Cost view" value="Token spend & context buildup" valueSize={theme.fontSize.lg} sub="Full context, net-new tokens, and billed API usage." />
+        <SummaryCard label="Cost view" value="Token spend & context buildup" valueSize={theme.fontSize.lg} sub="Token estimates and reported charges, kept separate." />
         <SummaryCard
-          label={usesCredits ? "AI Credits" : "Total spend"}
+          label={usesCredits ? "AI Credits" : totals.isReportedCost ? "Reported cost" : "Est. cost"}
           value={formatCostValue(totals.cost, totals.costUnit)}
           sub={[
             cachePercent + "% cached input",
@@ -227,9 +230,10 @@ export default function CostView({ events, metadata }) {
           formatTokens(totals.cacheRead) + " cached",
           totals.cacheWrite > 0 ? formatTokens(totals.cacheWrite) + " write" : null,
         ].filter(Boolean).join(" · ")} />
-        <SummaryCard label="Peak context" value={formatTokens(totals.peakContext)} sub="tools + history dominate context" />
+        <SummaryCard label="Peak context" value={totals.peakContext == null ? "--" : formatTokens(totals.peakContext)} sub={totals.peakContext == null ? "request sizes unavailable" : "largest observed prompt"} />
         <SummaryCard label="Cache misses" value={analysis.cacheMisses.length} sub="unexpected fresh-token spikes" color={analysis.cacheMisses.length ? theme.semantic.warning : theme.text.primary} />
       </div>
+      {analysis.pricingNotes.length > 0 && <div style={{ color: theme.text.muted, fontSize: theme.fontSize.sm, lineHeight: 1.5, flexShrink: 0 }}>{analysis.pricingNotes.join(" ")}</div>}
 
       <div style={{ display: "grid", gridTemplateColumns: MAIN_GRID_3_COLUMNS, gap: theme.space.lg, minHeight: 0, flex: 1 }}>
         <Panel label="Prompt & steps" title="Calls in session order" aside="session order">

--- a/src/components/ReplayView.jsx
+++ b/src/components/ReplayView.jsx
@@ -47,10 +47,11 @@ function highlightText(text, query) {
   return parts.length > 0 ? parts : text;
 }
 
-function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, toolEntries, renderSelectedActions }) {
+function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, events, toolEntries, renderSelectedActions }) {
   var selected = selectedEntry ? selectedEntry.event : null;
   var [showRaw, setShowRaw] = useState(false);
   var hasDiff = selected && isDiffViewable(selected);
+  var sessionCost = useMemo(function () { return getSessionCost(metadata, events); }, [metadata, events]);
 
   return (
     <div style={{
@@ -98,7 +99,7 @@ function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, toolEn
               metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0
                 ? ["Tokens", (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens).toLocaleString(), theme.accent.primary] : null,
               (function () {
-                var cost = getSessionCost(metadata);
+                var cost = sessionCost;
                 if (cost == null) return null;
                 var label = metadata.totalCost != null ? getSessionCostLabel(metadata) : "Est. cost";
                 return [label, metadata.totalCost != null ? formatSessionCost(metadata) : formatCost(cost), theme.semantic.success];
@@ -285,7 +286,7 @@ function ReplayInspector({ selectedEntry, hasExplicitSelection, metadata, toolEn
   );
 }
 
-export default function ReplayView({ currentTime, eventEntries, turnStartMap, searchQuery, matchSet, metadata, targetEventIndex, targetRequest, renderSelectedActions }) {
+export default function ReplayView({ currentTime, events, eventEntries, turnStartMap, searchQuery, matchSet, metadata, targetEventIndex, targetRequest, renderSelectedActions }) {
   var breakpoint = useBreakpoint();
   var containerRef = useRef(null);
   var itemRefs = useRef({});
@@ -665,6 +666,7 @@ export default function ReplayView({ currentTime, eventEntries, turnStartMap, se
 
       <ErrorBoundary resetKey={selectedEntry ? selectedEntry.index : "none"}>
         <ReplayInspector
+          events={events}
           selectedEntry={selectedEntry}
           hasExplicitSelection={hasExplicitSelection}
           metadata={metadata}

--- a/src/components/StatsView.jsx
+++ b/src/components/StatsView.jsx
@@ -1,6 +1,7 @@
 import { theme, TRACK_TYPES, alpha } from "../lib/theme.js";
 import Icon from "./Icon.jsx";
-import { estimateCost, estimateMultiModelCost, formatCost, formatSessionCost, getSessionCostLabel, isAiCreditsUnit, hasModelPricing } from "../lib/pricing.js";
+import { formatCost, formatSessionCost, getSessionCostLabel, isAiCreditsUnit } from "../lib/pricing.js";
+import { buildCostAnalysis } from "../lib/costAnalysis.js";
 import { formatDurationLong } from "../lib/formatTime.js";
 import { formatCacheUsageSummary, summarizeTokenUsage } from "../lib/cacheMetrics";
 import ToolbarButton from "./ui/ToolbarButton.jsx";
@@ -333,7 +334,7 @@ function CapabilitiesPanel({ events, turns, metadata }) {
   );
 }
 
-export default function StatsView({ events, totalTime, metadata, turns, autonomyMetrics, onOpenCoach }) {
+export default function StatsView({ events, totalTime, metadata, turns, autonomyMetrics, onOpenCoach, analysis }) {
   var [showAllTurns, setShowAllTurns] = useState(false);
   var TURNS_PREVIEW = 15;
   var cardStyle = getCardStyle();
@@ -377,32 +378,39 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
   var userMsgs = eventCounts.userMsgs;
   var errorCount = eventCounts.errorCount;
 
+  var costAnalysis = useMemo(function () { return analysis || buildCostAnalysis(events, metadata); }, [events, metadata, analysis]);
   var tokenMaps = useMemo(function () {
     var turnMap = {};
-    var modelMap = {};
-    events.forEach(function (e) {
+    var costs = {};
+    var turnIndices = new Map((turns || []).map(function (turn) { return [turn.turnId, turn.index]; }));
+    var usageEvents = costAnalysis.calls.some(function (call) { return call.event; })
+      ? costAnalysis.calls.map(function (call) { return call.event; }).filter(Boolean)
+      : events;
+    usageEvents.forEach(function (e) {
       if (e.tokenUsage) {
         if (e.turnIndex !== undefined) {
           var t = summarizeTokenUsage([turnMap[e.turnIndex], e.tokenUsage]);
           turnMap[e.turnIndex] = t;
         }
-        var modelKey = e.model || (metadata && metadata.primaryModel) || "__unknown__";
-        var m = modelMap[modelKey] || { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0 };
-        m.inputTokens += e.tokenUsage.inputTokens || 0;
-        m.outputTokens += e.tokenUsage.outputTokens || 0;
-        m.cacheRead += e.tokenUsage.cacheRead || 0;
-        m.cacheWrite += e.tokenUsage.cacheWrite || 0;
-        modelMap[modelKey] = m;
       }
+    });
+    costAnalysis.calls.forEach(function (call) {
+      var request = call.event;
+      if (!request) return;
+      var turnIndex = request.turnIndex != null ? request.turnIndex : request.turnId != null ? turnIndices.get(request.turnId) : undefined;
+      if (turnIndex == null) return;
+      if (call.eventIndex == null && request.turnIndex == null) turnMap[turnIndex] = summarizeTokenUsage([turnMap[turnIndex], call.tokenUsage]);
+      if (!(turnIndex in costs)) costs[turnIndex] = 0;
+      costs[turnIndex] = costs[turnIndex] == null || call.estimatedUsdCost == null ? null : costs[turnIndex] + call.estimatedUsdCost;
     });
     var cacheSummary = metadata && metadata.tokenUsage
       ? formatCacheUsageSummary(metadata.tokenUsage, { variant: "compact" })
       : null;
-    return { turnTokenMap: turnMap, modelTokenMap: modelMap, sessionCacheSummary: cacheSummary };
-  }, [events, metadata]);
+    return { turnTokenMap: turnMap, turnCosts: costs, sessionCacheSummary: cacheSummary };
+  }, [events, metadata, turns, costAnalysis]);
   var turnTokenMap = tokenMaps.turnTokenMap;
-  var modelTokenMap = tokenMaps.modelTokenMap;
   var sessionCacheSummary = tokenMaps.sessionCacheSummary;
+  var turnCosts = tokenMaps.turnCosts;
 
   var cards = useMemo(function () {
     return [
@@ -450,23 +458,7 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
     if (!metadata || !metadata.primaryModel) return null;
     var hasTokens = metadata.tokenUsage && (metadata.tokenUsage.inputTokens + metadata.tokenUsage.outputTokens) > 0;
     var hasApiCost = metadata.totalCost != null;
-    var perModelData = metadata.modelTokenUsage || (Object.keys(modelTokenMap).length > 0 ? modelTokenMap : null);
-    var modelKeys = perModelData ? Object.keys(perModelData) : [];
-    var modelCount = modelKeys.length;
-    var pricedCount = modelKeys.filter(function (k) { return hasModelPricing(k); }).length;
-    var estimated = perModelData
-      ? estimateMultiModelCost(perModelData)
-      : estimateCost(metadata.tokenUsage, metadata.primaryModel);
-    var modelLabel;
-    if (modelCount > 1) {
-      modelLabel = pricedCount < modelCount
-        ? pricedCount + " of " + modelCount + " models"
-        : modelCount + " models";
-    } else if (modelCount === 1) {
-      modelLabel = modelKeys[0].split("-").slice(0, 3).join("-") + " pricing";
-    } else {
-      modelLabel = (metadata.primaryModel ? metadata.primaryModel.split("-").slice(0, 3).join("-") : "default") + " pricing";
-    }
+    var estimated = costAnalysis.totals.estimatedUsdCost;
 
     var usageCards = [];
     var mKeys = Object.keys(metadata.models || {});
@@ -485,18 +477,19 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
         sub: isAiCreditsUnit(metadata.totalCostUnit) ? "reported by Copilot" : "reported by API",
       });
     }
-    if (estimated > 0) {
-      usageCards.push({ label: "Est. cost", value: formatCost(estimated), color: hasApiCost ? theme.text.muted : theme.semantic.success, sub: "based on " + modelLabel });
+    if (hasTokens || costAnalysis.hasCostData) {
+      usageCards.push({ label: "Est. cost", value: formatCost(estimated), color: hasApiCost ? theme.text.muted : theme.semantic.success, sub: estimated == null ? "pricing evidence incomplete" : "based on token usage" });
     }
     var allModelsEntries = Object.keys(metadata.models).length > 1
       ? Object.entries(metadata.models).sort(function (a, b) { return b[1] - a[1]; })
       : null;
     return { usageCards: usageCards, allModelsEntries: allModelsEntries };
-  }, [metadata, modelTokenMap, themeMode]);
+  }, [metadata, costAnalysis, themeMode]);
 
   return (
     <ResizablePanel initialSplit={0.72} minPx={200} direction="horizontal">
       <div style={{ height: "100%", display: "flex", flexDirection: "column", gap: theme.space.xl, overflowY: "auto", overflowX: "hidden", padding: theme.space.md + "px " + theme.space.lg + "px " + theme.space.md + "px 0" }}>
+        {costAnalysis.pricingNotes.length > 0 && <div style={{ color: theme.text.muted, fontSize: theme.fontSize.sm, lineHeight: 1.5 }}>{costAnalysis.pricingNotes.join(" ")}</div>}
         <div style={{ fontSize: theme.fontSize.xs, color: theme.text.dim, textTransform: "uppercase", letterSpacing: 1 }}>
           Session Overview
         </div>
@@ -717,8 +710,8 @@ export default function StatsView({ events, totalTime, metadata, turns, autonomy
                     <span style={{ fontSize: theme.fontSize.xs, color: theme.track.tool_call, flexShrink: 0 }}>{turn.toolCount} tools</span>
                   )}
                   {turnTokenMap[turn.index] && (
-                    <span style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, flexShrink: 0 }}>
-                      {formatCost(estimateCost(turnTokenMap[turn.index], metadata && metadata.primaryModel))}
+                    <span title="Token cost estimate" style={{ fontSize: theme.fontSize.xs, color: theme.text.muted, fontFamily: theme.font.mono, flexShrink: 0 }}>
+                      {formatCost(turnCosts[turn.index])}
                     </span>
                   )}
                   {formatCacheUsageSummary(turnTokenMap[turn.index], { variant: "verbose" }) && (

--- a/src/components/v2/AnalyzeShell.jsx
+++ b/src/components/v2/AnalyzeShell.jsx
@@ -47,7 +47,7 @@ function LoadingPanel({ label }) {
   );
 }
 
-function renderPanel(panelId, session, pb, autonomyMetrics, onNavigate, targetEventIndex, targetRequest) {
+function renderPanel(panelId, session, pb, autonomyMetrics, onNavigate, targetEventIndex, targetRequest, costAnalysis) {
   if (panelId === "tracks") {
     return (
       <TracksView
@@ -94,6 +94,7 @@ function renderPanel(panelId, session, pb, autonomyMetrics, onNavigate, targetEv
         <CostView
           events={pb.filteredEvents}
           metadata={session.metadata}
+          analysis={costAnalysis}
         />
       </React.Suspense>
     );
@@ -102,6 +103,7 @@ function renderPanel(panelId, session, pb, autonomyMetrics, onNavigate, targetEv
   return (
     <StatsView
       events={pb.filteredEvents}
+      analysis={costAnalysis}
       totalTime={session.total}
       metadata={session.metadata}
       turns={session.turns}
@@ -111,13 +113,12 @@ function renderPanel(panelId, session, pb, autonomyMetrics, onNavigate, targetEv
   );
 }
 
-function getAnalyzeSummary(events, metadata) {
-  var cost = buildCostAnalysis(events, metadata);
+function getAnalyzeSummary(events, metadata, cost) {
   return [
     { label: "Events", value: events.length },
     { label: "Tools", value: metadata.totalToolCalls || events.filter(function (event) { return event.track === "tool_call"; }).length },
     { label: "Tokens", value: metadata.tokenUsage ? formatTokens(metadata.tokenUsage.inputTokens || 0) + " in" : "--" },
-    { label: cost.totals && cost.totals.costUnit === "ai_credits" ? "Credits" : "Cost", value: cost.totals && cost.totals.cost > 0 ? formatCostValue(cost.totals.cost, cost.totals.costUnit) : "--" },
+    { label: cost.totals.costUnit === "ai_credits" ? "Credits" : cost.totals.isReportedCost ? "Cost" : "Est. cost", value: formatCostValue(cost.totals.cost, cost.totals.costUnit) },
   ];
 }
 
@@ -197,9 +198,12 @@ export default function AnalyzeShell({ session, autonomyMetrics, targetPanelId, 
     if (isValidPanel(targetPanelId)) setPanelId(targetPanelId);
   }, [targetPanelId, setPanelId]);
 
+  var costAnalysis = useMemo(function () {
+    return buildCostAnalysis(session.events, session.metadata);
+  }, [session.events, session.metadata]);
   var summary = useMemo(function () {
-    return getAnalyzeSummary(pb.filteredEvents || [], session.metadata || {});
-  }, [pb.filteredEvents, session.metadata]);
+    return getAnalyzeSummary(pb.filteredEvents || [], session.metadata || {}, costAnalysis);
+  }, [pb.filteredEvents, session.metadata, costAnalysis]);
 
   function selectPanel(nextPanelId) {
     if (!isValidPanel(nextPanelId)) return;
@@ -291,7 +295,7 @@ export default function AnalyzeShell({ session, autonomyMetrics, targetPanelId, 
           overflow: "hidden",
           padding: activePanelId === "stats" || activePanelId === "cost" ? theme.space.md : 0,
         }}>
-          {renderPanel(activePanelId, session, pb, autonomyMetrics, onNavigate, targetEventIndex, targetRequest)}
+          {renderPanel(activePanelId, session, pb, autonomyMetrics, onNavigate, targetEventIndex, targetRequest, costAnalysis)}
         </div>
       </section>
     </main>

--- a/src/components/v2/InvestigateView.jsx
+++ b/src/components/v2/InvestigateView.jsx
@@ -316,6 +316,7 @@ export default function InvestigateView({ session, targetEventIndex, targetReque
           overflow: "hidden",
         }}>
           <ReplayView
+            events={session.events}
             currentTime={pb.playback.time}
             eventEntries={visibleEntries}
             turns={session.turns}

--- a/src/components/v2/ReviewHub.jsx
+++ b/src/components/v2/ReviewHub.jsx
@@ -132,7 +132,7 @@ export function buildReviewSummary(session, autonomyMetrics) {
     autonomyMetrics: autonomyMetrics,
     errorCount: metadata.errorCount || 0,
   }))));
-  var totalCost = getSessionCost(metadata);
+  var totalCost = getSessionCost(metadata, events);
   var topTools = getTopTools(events, 3);
 
   return {

--- a/src/lib/autonomyMetrics.js
+++ b/src/lib/autonomyMetrics.js
@@ -1,5 +1,5 @@
 import { formatDurationLong } from "./formatTime.js";
-import { estimateCost } from "./pricing.js";
+import { buildCostAnalysis } from "./costAnalysis.js";
 import { getSessionTotal } from "./session";
 
 var LONG_IDLE_GAP_SECONDS = 30;
@@ -45,12 +45,10 @@ function isContinuationMessage(text) {
   return String(text).trim().toLowerCase() === "(continuation)";
 }
 
-export function getSessionCost(metadata) {
+export function getSessionCost(metadata, events) {
   if (!metadata) return null;
   if (metadata.totalCost != null) return metadata.totalCost;
-  // Claude Code: estimate when model is recognized (avoid fabricating $0.00)
-  if (!metadata.primaryModel) return null;
-  return estimateCost(metadata.tokenUsage, metadata.primaryModel) || null;
+  return buildCostAnalysis(events, metadata).totals.estimatedUsdCost;
 }
 
 export function buildAutonomyMetrics(events, turns, metadata) {
@@ -121,7 +119,7 @@ export function buildAutonomyMetrics(events, turns, metadata) {
     errorCount: metadata ? metadata.errorCount || 0 : 0,
     totalToolCalls: metadata ? metadata.totalToolCalls || 0 : 0,
     totalTurns: metadata ? metadata.totalTurns || 0 : (turns || []).length,
-    cost: getSessionCost(metadata),
+    cost: getSessionCost(metadata, events),
     topTools: topTools,
     userFollowUps: userFollowUps,
     idleGaps: idleGaps,

--- a/src/lib/codexParser.ts
+++ b/src/lib/codexParser.ts
@@ -10,7 +10,7 @@
 import { computeCacheHitRate } from "./cacheMetrics";
 import { truncateText as truncate } from "./formatTime.js";
 import { getSessionTotal } from "./session";
-import type { NormalizedEvent, ParsedSession, SessionMetadata, SessionTurn, TokenUsage } from "./sessionTypes";
+import type { NormalizedEvent, ParsedSession, PricingRequest, SessionMetadata, SessionTurn, TokenUsage } from "./sessionTypes";
 import type { TrackType } from "./theme";
 
 const MAX_TEXT_LENGTH = 4000;
@@ -44,6 +44,7 @@ type ParseState = {
   turnContexts: Record<string, CodexTurnContext>;
   turns: Record<string, CodexTurnLifecycle>;
   turnCount?: number;
+  pricing?: { requests: PricingRequest[]; total: TokenUsage; incomplete: boolean };
 };
 
 type ParsedRecords = {
@@ -412,6 +413,7 @@ function buildEvents(records: RawRecord[], state: ParseState): NormalizedEvent[]
 
   for (let index = 0; index < records.length; index += 1) {
     const record = records[index];
+    observePricing(record, state);
     const t = getEventTime(record, syntheticTime);
     syntheticTime += 1;
 
@@ -562,6 +564,47 @@ function getSubagentName(meta: Record<string, any>): string | null {
   return keys.length === 1 && keys[0] !== "thread_spawn" ? keys[0] : null;
 }
 
+function normalizeTokenUsage(raw: Record<string, any>): TokenUsage {
+  const inputTokens = numberValue(raw.input_tokens);
+  const cacheRead = numberValue(raw.cached_input_tokens);
+  const cacheWrite = numberValue(raw.cache_write_input_tokens);
+  return {
+    inputTokens,
+    // reasoning_output_tokens is already included in output_tokens.
+    outputTokens: numberValue(raw.output_tokens),
+    cacheRead,
+    cacheWrite,
+    cacheWriteReported: raw.cache_write_input_tokens != null,
+    cacheHitRate: computeCacheHitRate(inputTokens, cacheWrite, cacheRead),
+  };
+}
+
+// Both batch and live parsing observe each record once. Cumulative checkpoints
+// deduplicate token_count notifications; only verified last-request usage is
+// priced, never a delta that could hide multiple requests.
+function observePricing(record: RawRecord, state: ParseState): void {
+  const pricing = state.pricing ||= { requests: [], total: {}, incomplete: false };
+  const payload = record.payload || {};
+  if (record.type !== "event_msg" || payload.type !== "token_count" || !isRecord(payload.info?.total_token_usage)) return;
+  const total = normalizeTokenUsage(payload.info.total_token_usage);
+  const fields = ["inputTokens", "outputTokens", "cacheRead", "cacheWrite"] as const;
+  if (fields.every(key => (total[key] || 0) === (pricing.total[key] || 0))) return;
+  const last = isRecord(payload.info.last_token_usage) ? normalizeTokenUsage(payload.info.last_token_usage) : null;
+  if (last && fields.every(key => (total[key] || 0) - (pricing.total[key] || 0) === (last[key] || 0))) {
+    pricing.requests.push({
+      model: state.currentModel,
+      turnId: state.currentTurnId,
+      tokenUsage: last,
+      // Codex can use an API key or a subscription. model_provider=openai
+      // identifies the model backend, not the billing provider.
+      pricingContext: {},
+    });
+  } else {
+    pricing.incomplete = true;
+  }
+  pricing.total = total;
+}
+
 function getLastTokenUsage(records: RawRecord[], warnings: string[]): TokenUsage | null {
   let lastUsage: Record<string, any> | null = null;
   for (let index = 0; index < records.length; index += 1) {
@@ -572,20 +615,8 @@ function getLastTokenUsage(records: RawRecord[], warnings: string[]): TokenUsage
   }
 
   if (!lastUsage) return null;
-  const inputTokens = numberValue(lastUsage.input_tokens);
-  const cacheRead = numberValue(lastUsage.cached_input_tokens);
-  // Codex reports reasoning_output_tokens as a subset of output_tokens, not an
-  // addition to it: its TokenUsage.blended_total sums only output_tokens, and the
-  // CLI prints "output=N (reasoning M)". Adding the two double-counts reasoning.
-  const outputTokens = numberValue(lastUsage.output_tokens);
-  const usage = {
-    inputTokens,
-    outputTokens,
-    cacheRead,
-    cacheWrite: 0,
-    cacheHitRate: computeCacheHitRate(inputTokens, 0, cacheRead),
-  };
-  if (usage.inputTokens + usage.outputTokens + usage.cacheRead === 0) return null;
+  const usage = normalizeTokenUsage(lastUsage);
+  if ((usage.inputTokens || 0) + (usage.outputTokens || 0) + (usage.cacheRead || 0) + (usage.cacheWrite || 0) === 0) return null;
   warnings.push("Codex token usage is based on cumulative token_count totals");
   return usage;
 }
@@ -616,6 +647,8 @@ function buildMetadata(records: RawRecord[], events: NormalizedEvent[], turns: S
     models,
     primaryModel: modelEntries.length > 0 ? modelEntries[0][0] : null,
     tokenUsage,
+    ...(state.pricing && !state.pricing.incomplete && state.pricing.requests.length
+      ? { pricingRequests: state.pricing.requests } : {}),
     warnings,
     parseIssues: { malformedLines, invalidEvents: 0 },
     format: "codex",
@@ -654,5 +687,5 @@ export function parseCodexJSONL(text: string): ParsedSession | null {
 export const codexLive = {
   getEventTime, updateTurnContext, handleEventMessage, pushMessageEvent,
   pushReasoningEvent, pushToolCallEvent, pushToolOutputEvent, getWebSearchQuery,
-  buildMetadata, isRecord,
+  buildMetadata, isRecord, observePricing,
 };

--- a/src/lib/copilotCliParser.ts
+++ b/src/lib/copilotCliParser.ts
@@ -615,14 +615,15 @@ function getTokenDetailCount(details: Record<string, any> | null | undefined, ke
   return bucket && typeof bucket.tokenCount === "number" ? bucket.tokenCount : 0;
 }
 
-function getMetricTokenUsage(metric: Record<string, any> | null | undefined): { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number } | null {
+function getMetricTokenUsage(metric: Record<string, any> | null | undefined): { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; cacheWriteReported: boolean } | null {
   if (!metric) return null;
   if (metric.usage) {
     const usage = {
       inputTokens: metric.usage.inputTokens || 0,
       outputTokens: metric.usage.outputTokens || 0,
       cacheRead: metric.usage.cacheReadTokens || 0,
-      cacheWrite: metric.usage.cacheWriteTokens || 0,
+      cacheWrite: metric.usage.cacheWriteTokens ?? getTokenDetailCount(metric.tokenDetails, "cache_write"),
+      cacheWriteReported: metric.usage.cacheWriteTokens != null || metric.tokenDetails?.cache_write?.tokenCount != null,
     };
     if (usage.inputTokens + usage.outputTokens + usage.cacheRead + usage.cacheWrite > 0) return usage;
   }
@@ -633,7 +634,7 @@ function getMetricTokenUsage(metric: Record<string, any> | null | undefined): { 
     const cacheWrite = getTokenDetailCount(metric.tokenDetails, "cache_write");
     const outputTokens = getTokenDetailCount(metric.tokenDetails, "output");
     const inputTokens = freshInput + cacheRead + cacheWrite;
-    const usage = { inputTokens, outputTokens, cacheRead, cacheWrite };
+    const usage = { inputTokens, outputTokens, cacheRead, cacheWrite, cacheWriteReported: metric.tokenDetails.cache_write != null };
     if (usage.inputTokens + usage.outputTokens + usage.cacheRead + usage.cacheWrite > 0) return usage;
   }
 
@@ -675,7 +676,7 @@ function buildMetadata(
   let totalCost: number | null = null;
   let totalCostUnit: "ai_credits" | null = null;
   let aiCredits: number | null = null;
-  let modelTokenUsage: Record<string, { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; cacheHitRate?: number; aiCredits?: number | null }> | null = null;
+  let modelTokenUsage: Record<string, { inputTokens: number; outputTokens: number; cacheRead: number; cacheWrite: number; cacheWriteReported?: boolean; cacheHitRate?: number; aiCredits?: number | null }> | null = null;
 
   if (sessionShutdown && sessionShutdown.modelMetrics) {
     const modelMetrics = sessionShutdown.modelMetrics;
@@ -698,15 +699,19 @@ function buildMetadata(
           outputTokens,
           cacheRead: cacheReadTokens,
           cacheWrite: cacheWriteTokens,
+          cacheWriteReported: usage.cacheWriteReported,
           cacheHitRate: computeCacheHitRate(inputTokens, cacheWriteTokens, cacheReadTokens),
           aiCredits: modelCredits,
         };
+      } else if (modelCredits != null) {
+        modelTokenUsage[model] = { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0, aiCredits: modelCredits };
       }
       if (modelCredits != null) {
         aiCredits = (aiCredits || 0) + modelCredits;
       }
       if (!models[model]) models[model] = metric.requests ? metric.requests.count : 0;
     }
+    if (Object.values(modelMetrics).some((metric: any) => nanoAiuToCredits(metric?.totalNanoAiu) == null)) aiCredits = null;
   }
 
   if (sessionShutdown) {

--- a/src/lib/copilotCostParser.ts
+++ b/src/lib/copilotCostParser.ts
@@ -1,5 +1,4 @@
 import { computeCacheHitRate } from "./cacheMetrics";
-import { estimateMultiModelCost } from "./pricing.js";
 import type { NormalizedEvent, ParsedSession, SessionMetadata, SessionTurn, TokenUsage } from "./sessionTypes";
 
 const MAX_DISPLAY_TEXT_LENGTH = 4000;
@@ -122,7 +121,7 @@ function getTools(request: AnyRecord): unknown[] {
 function getModel(call: PromptCall): string | null {
   const request = call.request || {};
   const response = call.response || {};
-  const model = request.model || request.modelId || response.model || call.model || call.modelId;
+  const model = response.model || request.model || request.modelId || call.model || call.modelId;
   return typeof model === "string" && model.trim() ? model : null;
 }
 
@@ -173,6 +172,8 @@ function getUsage(usage: AnyRecord): TokenUsage | null {
     inputDetails.cached_tokens,
   );
   const cacheWrite = firstNumber(
+    inputDetails.cache_write_tokens,
+    promptDetails.cache_write_tokens,
     usage.cache_creation_input_tokens,
     usage.cache_write_input_tokens,
     usage.cache_write_tokens,
@@ -186,6 +187,12 @@ function getUsage(usage: AnyRecord): TokenUsage | null {
     outputTokens,
     cacheRead,
     cacheWrite,
+    cacheWriteReported: [
+      inputDetails.cache_write_tokens, promptDetails.cache_write_tokens,
+      usage.cache_creation_input_tokens, usage.cache_write_input_tokens,
+      usage.cache_write_tokens, usage.cacheWrite, inputDetails.cache_creation_tokens,
+      outputDetails.cache_creation_tokens,
+    ].some(value => value != null),
     cacheHitRate: computeCacheHitRate(rawInput, cacheWrite, cacheRead),
   };
 }
@@ -246,6 +253,10 @@ function makeEvent(index: number, call: PromptCall): NormalizedEvent | null {
     isError: false,
     model,
     tokenUsage: usage,
+    pricingContext: {
+      provider: "copilot",
+      ...(typeof call.response.service_tier === "string" ? { serviceTier: call.response.service_tier } : {}),
+    },
   };
 }
 
@@ -300,7 +311,6 @@ function buildMetadata(events: NormalizedEvent[], calls: PromptCall[]): SessionM
     primaryModel: modelEntries.length > 0 ? modelEntries[0][0] : null,
     tokenUsage,
     modelTokenUsage,
-    totalCost: estimateMultiModelCost(modelTokenUsage),
     format: "copilot-prompts",
     customTitle: "Copilot prompt cost analysis",
     promptCallCount: calls.length,

--- a/src/lib/costAnalysis.js
+++ b/src/lib/costAnalysis.js
@@ -1,5 +1,5 @@
 import { computeCacheHitRate, computeEffectiveInputTokens } from "./cacheMetrics";
-import { estimateCost } from "./pricing.js";
+import { estimateCostDetails } from "./pricing.js";
 
 var CACHE_MISS_MAX_CACHE_READ_RATIO = 0.35;
 var CACHE_MISS_FRESH_SPIKE_MULTIPLIER = 1.5;
@@ -79,30 +79,42 @@ function usageMapCoversMetadata(usageByModel, metadataUsage) {
   return totalsCoverMetadata(totals, metadataUsage);
 }
 
+function pricingContext(metadata, event, aggregate) {
+  var provider = metadata && ["copilot-cli", "copilot-prompts", "vscode-chat"].includes(metadata.format) ? "copilot" : undefined;
+  return { provider, ...(event && event.pricingContext), aggregate };
+}
+
+function addCost(total, cost) {
+  return total == null || cost == null ? null : total + cost;
+}
+
 function buildMetadataUsageCalls(metadata) {
   var usageByModel = metadata && metadata.modelTokenUsage;
   var useModelBreakdown = usageMapCoversMetadata(usageByModel, metadata && metadata.tokenUsage);
   var modelNames = useModelBreakdown && usageByModel && Object.keys(usageByModel).length > 0
     ? Object.keys(usageByModel)
-    : (hasUsage(metadata && metadata.tokenUsage) ? [metadata.primaryModel || "unknown"] : []);
+    : (hasUsage(metadata && metadata.tokenUsage)
+      ? [Object.keys(metadata.models || {}).length > 1 ? "unknown" : metadata.primaryModel || "unknown"] : []);
   var calls = [];
   var cumulativeCost = 0;
+  var cumulativeUnit = null;
   var reportedCost = metadata && metadata.totalCost != null ? metadata.totalCost : null;
   var reportedCostUnit = reportedCost != null ? metadata.totalCostUnit || "usd" : "usd";
-  var estimatedCosts = modelNames.map(function (model) {
-    var usage = useModelBreakdown && usageByModel && usageByModel[model] ? usageByModel[model] : metadata.tokenUsage;
-    return estimateCost(usage, model);
-  });
-  var estimatedTotal = estimatedCosts.reduce(function (sum, cost) { return sum + cost; }, 0);
-
   for (var i = 0; i < modelNames.length; i += 1) {
     var model = modelNames[i];
     var usage = useModelBreakdown && usageByModel && usageByModel[model] ? usageByModel[model] : metadata.tokenUsage;
-    if (!hasUsage(usage)) continue;
-    var callCost = reportedCost != null
-      ? (estimatedTotal > 0 ? reportedCost * (estimatedCosts[i] / estimatedTotal) : reportedCost / modelNames.length)
-      : estimatedCosts[i];
-    cumulativeCost += callCost;
+    if (!hasUsage(usage) && usage.aiCredits == null) continue;
+    var estimate = estimateCostDetails(hasUsage(usage) ? usage : null, model, pricingContext(metadata, null, true));
+    var modelCredits = useModelBreakdown ? usage.aiCredits : null;
+    var callCost = modelCredits != null
+      ? modelCredits
+      : reportedCost != null
+        ? (modelNames.length === 1 ? reportedCost : null)
+        : estimate.cost;
+    var callUnit = modelCredits != null ? "ai_credits" : reportedCost != null ? reportedCostUnit : "usd";
+    if (cumulativeUnit && cumulativeUnit !== callUnit) cumulativeCost = null;
+    cumulativeUnit = callUnit;
+    cumulativeCost = addCost(cumulativeCost, callCost);
 
     calls.push({
       index: calls.length,
@@ -116,8 +128,10 @@ function buildMetadataUsageCalls(metadata) {
       cacheWriteTokens: usage.cacheWrite || 0,
       outputTokens: usage.outputTokens || 0,
       cost: callCost,
-      costUnit: reportedCost != null ? reportedCostUnit : "usd",
-      estimatedUsdCost: estimatedCosts[i],
+      costUnit: callUnit,
+      estimatedUsdCost: estimate.cost,
+      pricingNotes: estimate.notes,
+      isReportedCost: modelCredits != null || (reportedCost != null && modelNames.length === 1),
       cumulativeCost: cumulativeCost,
       contextBreakdown: getBreakdown(null, usage),
       netNewTokens: usage.inputTokens || 0,
@@ -150,6 +164,12 @@ export function formatTokens(value) {
 
 export function buildCostAnalysis(events, metadata) {
   var sourceEvents = events || [];
+  var usesPricingRequests = false;
+  if (metadata && metadata.pricingRequests && metadata.pricingRequests.length
+      && !usageMapCoversMetadata(Object.fromEntries(sourceEvents.filter(e => e.tokenUsage).map((e, i) => [i, e.tokenUsage])), metadata.tokenUsage)) {
+    sourceEvents = metadata.pricingRequests;
+    usesPricingRequests = true;
+  }
   var calls = [];
   var totalCost = 0;
   var totalCostUnit = "usd";
@@ -164,15 +184,16 @@ export function buildCostAnalysis(events, metadata) {
     var usage = getTokenUsage(event);
     if (!usage) continue;
 
-    var model = event.model || (metadata && metadata.primaryModel) || "unknown";
+    var model = event.model || (metadata && Object.keys(metadata.models || {}).length <= 1 && metadata.primaryModel) || "unknown";
     var freshInputTokens = effectiveFreshInput(usage);
     var cachedInputTokens = usage.cacheRead || 0;
     var cacheWriteTokens = usage.cacheWrite || 0;
     var outputTokens = usage.outputTokens || 0;
-    var callCost = estimateCost(usage, model);
+    var estimate = estimateCostDetails(usage, model, pricingContext(metadata, event, false));
+    var callCost = estimate.cost;
     var estimatedCost = callCost;
-    totalCost += callCost;
-    estimatedUsdCost += estimatedCost;
+    totalCost = addCost(totalCost, callCost);
+    estimatedUsdCost = addCost(estimatedUsdCost, estimatedCost);
     totals.inputTokens += usage.inputTokens || 0;
     totals.outputTokens += outputTokens;
     totals.cacheRead += cachedInputTokens;
@@ -186,11 +207,11 @@ export function buildCostAnalysis(events, metadata) {
     var cacheHitRate = usage.cacheHitRate != null
       ? usage.cacheHitRate
       : computeCacheHitRate(usage.inputTokens || 0, cacheWriteTokens, cachedInputTokens) || 0;
-    peakContext = Math.max(peakContext, contextBreakdown.total || usage.inputTokens || 0);
+    peakContext = Math.max(peakContext, usage.inputTokens || 0);
 
     var call = {
       index: calls.length,
-      eventIndex: i,
+      eventIndex: usesPricingRequests ? null : i,
       event: event,
       title: event.text || "LLM call",
       model: model,
@@ -202,6 +223,8 @@ export function buildCostAnalysis(events, metadata) {
       cost: callCost,
       costUnit: "usd",
       estimatedUsdCost: estimatedCost,
+      pricingNotes: estimate.notes,
+      isReportedCost: false,
       cumulativeCost: totalCost,
       contextBreakdown: contextBreakdown,
       netNewTokens: netNewTokens,
@@ -242,13 +265,13 @@ export function buildCostAnalysis(events, metadata) {
   }
 
   var metadataUsage = metadata && metadata.tokenUsage;
-  if (!totalsCoverMetadata(totals, metadataUsage)) {
+  if (!totalsCoverMetadata(totals, metadataUsage) || (!calls.length && metadata && metadata.modelTokenUsage)) {
     calls = buildMetadataUsageCalls(metadata || {});
     totalCostUnit = metadata && metadata.totalCost != null ? metadata.totalCostUnit || "usd" : "usd";
     totalCost = metadata && metadata.totalCost != null
       ? metadata.totalCost
-      : calls.reduce(function (sum, call) { return sum + call.cost; }, 0);
-    estimatedUsdCost = calls.reduce(function (sum, call) { return sum + (call.estimatedUsdCost || (call.costUnit === "usd" ? call.cost : 0)); }, 0);
+      : calls.reduce(function (sum, call) { return addCost(sum, call.estimatedUsdCost); }, 0);
+    estimatedUsdCost = calls.reduce(function (sum, call) { return addCost(sum, call.estimatedUsdCost); }, 0);
     totals = { inputTokens: 0, outputTokens: 0, cacheRead: 0, cacheWrite: 0 };
     peakContext = 0;
     cacheMisses = [];
@@ -259,10 +282,27 @@ export function buildCostAnalysis(events, metadata) {
       totals.outputTokens += summaryUsage.outputTokens || 0;
       totals.cacheRead += summaryUsage.cacheRead || 0;
       totals.cacheWrite += summaryUsage.cacheWrite || 0;
-      peakContext = Math.max(peakContext, calls[callIndex].contextBreakdown.total || summaryUsage.inputTokens || 0);
     }
+    // A session aggregate is not an observed context window.
+    peakContext = null;
   }
 
+  var notes = [...new Set(calls.flatMap(call => call.pricingNotes || []))];
+  var isReportedCost = metadata && metadata.totalCost != null;
+  if (isReportedCost) {
+    totalCost = metadata.totalCost;
+    totalCostUnit = metadata.totalCostUnit || "usd";
+    if (calls.some(call => !call.isReportedCost)) notes.push("Reported session charges are authoritative; request costs are separate token estimates, not allocated bills.");
+    if (calls.length && calls.every(call => call.isReportedCost && call.costUnit === totalCostUnit)) {
+      var reportedModelTotal = calls.reduce((sum, call) => sum + call.cost, 0);
+      var roundingTolerance = Number.EPSILON * Math.max(1, Math.abs(totalCost), Math.abs(reportedModelTotal)) * calls.length;
+      if (Math.abs(reportedModelTotal - totalCost) > roundingTolerance) notes.push("Reported model charges do not sum to the reported session charge; both are preserved.");
+    }
+  }
+  if (!calls.length) {
+    estimatedUsdCost = null;
+    if (!isReportedCost) totalCost = null;
+  }
   var cacheHitRate = computeCacheHitRate(totals.inputTokens, totals.cacheWrite, totals.cacheRead) || 0;
   return {
     calls: calls,
@@ -278,8 +318,10 @@ export function buildCostAnalysis(events, metadata) {
       aiCredits: metadata && metadata.aiCredits != null ? metadata.aiCredits : null,
       cacheHitRate: cacheHitRate,
       peakContext: peakContext,
+      isReportedCost: Boolean(isReportedCost),
     },
+    pricingNotes: notes,
     cacheMisses: cacheMisses,
-    hasCostData: calls.length > 0,
+    hasCostData: calls.length > 0 || Boolean(isReportedCost),
   };
 }

--- a/src/lib/liveCodexNormalizer.ts
+++ b/src/lib/liveCodexNormalizer.ts
@@ -108,6 +108,7 @@ export class LiveCodexNormalizer implements LiveNormalizer {
     const changedCalls = new Set<Slot>();
     const hadLifecycle = this.buckets.size > 0;
     for (const record of records) {
+      helpers.observePricing(record, this.state);
       const payload = record.payload || {};
       if (!this.meta && record.type === "session_meta" && helpers.isRecord(record.payload)) this.meta = record;
       if (record.type === "event_msg" && payload.type === "token_count" && helpers.isRecord(payload.info?.total_token_usage)) this.token = record;

--- a/src/lib/pricing.d.ts
+++ b/src/lib/pricing.d.ts
@@ -1,17 +1,18 @@
-import type { TokenUsage } from "./sessionTypes";
+import type { TokenUsage, PricingContext } from "./sessionTypes";
 
 export const NANO_AIU_PER_CREDIT: number;
 export const USD_PER_CREDIT: number;
 
 export function hasModelPricing(modelName: string | null | undefined): boolean;
-export function estimateCost(tokenUsage: TokenUsage | null | undefined, modelName?: string | null): number;
-export function estimateMultiModelCost(modelTokenMap: Record<string, TokenUsage> | null | undefined): number;
-export function formatCost(usd: number): string;
+export function estimateCostDetails(tokenUsage: TokenUsage | null | undefined, modelName?: string | null, context?: PricingContext): { cost: number | null; notes: string[] };
+export function estimateCost(tokenUsage: TokenUsage | null | undefined, modelName?: string | null, context?: PricingContext): number | null;
+export function estimateMultiModelCost(modelTokenMap: Record<string, TokenUsage> | null | undefined, context?: PricingContext): number | null;
+export function formatCost(usd: number | null | undefined): string;
 export function nanoAiuToCredits(nanoAiu: number | null | undefined): number | null;
 export function creditsToUsd(credits: number | null | undefined): number;
 export function isAiCreditsUnit(unit: string | null | undefined): boolean;
 export function formatCredits(value: number | null | undefined): string;
 export function formatCreditsWithUsd(value: number | null | undefined): string;
-export function formatCostValue(value: number, unit?: string | null): string;
+export function formatCostValue(value: number | null | undefined, unit?: string | null): string;
 export function formatSessionCost(metadata: { totalCost?: number | null; totalCostUnit?: string | null } | null | undefined): string | null;
 export function getSessionCostLabel(metadata: { totalCost?: number | null; totalCostUnit?: string | null } | null | undefined, estimated?: boolean): string;

--- a/src/lib/pricing.js
+++ b/src/lib/pricing.js
@@ -6,9 +6,9 @@
  * https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing
  * (rates can change there; update this table when they do).
  *
- * Each row may carry explicit `cachedInput` and (Anthropic) `cacheWrite` rates.
- * When a row omits `cachedInput` we fall back to ~10% of input. Only Anthropic
- * rows have a separate cache-write bucket; for other providers cache-write
+ * Each row may carry explicit `cachedInput` and `cacheWrite` rates.
+ * When a row omits `cachedInput` we fall back to ~10% of input. Anthropic and
+ * newer OpenAI rows price writes explicitly. For remaining providers cache-write
  * tokens are billed at the standard input rate (no surcharge). Rows with a
  * `longContext` tier switch to the higher rates once input tokens exceed
  * `threshold`.
@@ -22,6 +22,21 @@ export var USD_PER_CREDIT = 0.01;
 
 var PRICE_TABLE = [
   // OpenAI -- order specific variants before generic prefixes.
+  // Verified 2026-09-09 against OpenAI pricing and GitHub Copilot pricing.
+  // Sol promotional rates apply at least through 2026-11-21.
+  // https://developers.openai.com/api/docs/pricing
+  ...[
+    ["gpt-5.6-sol", 4, 20],
+    ["gpt-5.6-terra", 2, 12],
+    ["gpt-5.6-luna", 0.2, 1.2],
+    ["gpt-6-astra", 10, 50],
+  ].map(function ([match, input, output]) {
+    return {
+      match, input, output, cachedInput: input * 0.1, cacheWrite: input * 1.25,
+      serviceTiers: true,
+      longContext: { threshold: 272000, input: input * 2, cachedInput: input * 0.2, cacheWrite: input * 2.5, output: output * 1.5 },
+    };
+  }),
   { match: "gpt-5.4-nano",  input:  0.20, cachedInput: 0.020, output:  1.25 },
   { match: "gpt-5.4-mini",  input:  0.75, cachedInput: 0.075, output:  4.50 },
   { match: "gpt-5-mini",    input:  0.25, cachedInput: 0.025, output:  2.00 },
@@ -34,7 +49,7 @@ var PRICE_TABLE = [
     match: "gpt-5.4", input: 2.50, cachedInput: 0.25, output: 15.00,
     longContext: { threshold: 272000, input: 5.00, cachedInput: 0.50, output: 22.50 },
   },
-  // Generic GPT-5.x / GPT-5 fallback for unlisted variants (keep last in group).
+  // GPT-5 itself, not a fallback for unknown GPT-5.x variants.
   { match: "gpt-5",         input:  1.25, cachedInput: 0.125, output: 10.00 },
   { match: "gpt-4.1",       input:  2.00, cachedInput: 0.200, output:  8.00 },
   { match: "gpt-4o-mini",   input:  0.15, cachedInput: 0.015, output:  0.60 },
@@ -70,32 +85,23 @@ var PRICE_TABLE = [
   { match: "mai-code-1-flash", input: 0.75, cachedInput: 0.075, output: 4.50 },
 ];
 
-// Fallback for unrecognized Claude model variants (new releases, etc.)
-var DEFAULT_CLAUDE_PRICE = { input: 3.00, cachedInput: 0.30, cacheWrite: 3.75, output: 15.00 };
-
 function normalizeModelName(modelName) {
-  return String(modelName).toLowerCase().replace(/[^a-z0-9.]+/g, "-");
+  return String(modelName).trim().toLowerCase().replace(/[^a-z0-9.]+/g, "-");
 }
 
 function lookupPrice(modelName) {
   if (!modelName) return null;
   var lower = normalizeModelName(modelName);
   for (var i = 0; i < PRICE_TABLE.length; i++) {
-    if (lower.includes(PRICE_TABLE[i].match)) return PRICE_TABLE[i];
+    var row = PRICE_TABLE[i];
+    // OpenAI variants must be known identifiers, optionally provider-prefixed,
+    // dated, or explicitly suffixed Fast. Never price a new model as GPT-5.
+    if (/^(gpt-|o[34])/.test(row.match)) {
+      var pattern = new RegExp("^(?:openai-|azure-openai-)?" + row.match.replace(/\./g, "\\.") + "(?:-\\d{4}-\\d{2}-\\d{2})?" + (row.serviceTiers ? "(?:-fast)?" : "") + "$");
+      if (pattern.test(lower)) return row;
+    } else if (lower.includes(row.match)) return row;
   }
-  // Apply Claude default only to Claude variants we haven't explicitly listed.
-  // For Gemini or other unknown models we return null -- cost unknown.
-  if (lower.includes("claude")) return DEFAULT_CLAUDE_PRICE;
   return null;
-}
-
-// Resolve the effective rates for a price row, applying the long-context tier
-// when the request's input token count exceeds the row threshold.
-function resolveRates(price, inputTokens) {
-  if (price.longContext && (inputTokens || 0) > price.longContext.threshold) {
-    return price.longContext;
-  }
-  return price;
 }
 
 function cachedInputRate(rates) {
@@ -103,9 +109,7 @@ function cachedInputRate(rates) {
 }
 
 function cacheWriteRate(rates) {
-  // Only Anthropic rows define a dedicated cache-write bucket. For other
-  // providers there is no cache-write surcharge, so bill those tokens at the
-  // standard input rate rather than inventing a multiplier.
+  // A write rate is the whole bucket price, not an additional surcharge.
   return rates.cacheWrite != null ? rates.cacheWrite : rates.input;
 }
 
@@ -120,30 +124,64 @@ export function hasModelPricing(modelName) {
  * and cache writes. Cache write tokens are billed in their own bucket.
  * modelName: string (optional, used to look up pricing)
  */
-export function estimateCost(tokenUsage, modelName) {
-  if (!tokenUsage) return 0;
+export function estimateCostDetails(tokenUsage, modelName, context = {}) {
+  var notes = [];
+  if (!tokenUsage) return { cost: null, notes: ["Token usage unavailable."] };
   var price = lookupPrice(modelName);
-  if (!price) return 0; // unknown model -- don't fabricate a number
-  var rates = resolveRates(price, tokenUsage.inputTokens || 0);
+  if (!price) return { cost: null, notes: ["Pricing unavailable for " + (modelName || "unknown model") + "."] };
+  var threshold = price.longContext && price.longContext.threshold;
+  if (threshold && tokenUsage.inputTokens == null) {
+    return { cost: null, notes: ["Request input usage required to determine the context pricing tier."] };
+  }
+  var inputTokens = tokenUsage.inputTokens || 0;
+  if (price.match === "gpt-5.6-luna") {
+    if (context.provider === "copilot") threshold = 200000;
+    else if (context.provider !== "openai" && inputTokens > 200000 && inputTokens <= 272000) {
+      return { cost: null, notes: ["Luna long-context pricing needs a billing provider: Copilot uses >200k; OpenAI uses >272k."] };
+    }
+  }
+  if (context.aggregate && threshold && inputTokens > threshold) {
+    return { cost: null, notes: ["Per-request usage required for long-context pricing; session totals are not request lengths."] };
+  }
+  var rates = threshold && inputTokens > threshold ? price.longContext : price;
+  var multiplier = 1;
+  if (price.serviceTiers) {
+    var tier = context.serviceTier || (/-fast$/.test(normalizeModelName(modelName)) ? "fast" : null);
+    if (tier === "fast" || tier === "priority") multiplier = 2;
+    else if (tier === "batch" || tier === "flex") multiplier = 0.5;
+    else if (tier && tier !== "standard" && tier !== "default") {
+      return { cost: null, notes: ["Pricing unavailable for service tier " + tier + "."] };
+    }
+    if (!tier) notes.push("Standard service tier assumed; actual billed charges may differ.");
+    if (tokenUsage.cacheWrite == null || tokenUsage.cacheWriteReported === false) notes.push("Cache-write usage not reported; estimate excludes any unreported write premium.");
+  }
   var freshInputTokens = Math.max((tokenUsage.inputTokens || 0) - (tokenUsage.cacheRead || 0) - (tokenUsage.cacheWrite || 0), 0);
   var inputCost  = freshInputTokens / 1e6 * rates.input;
   var outputCost = (tokenUsage.outputTokens || 0) / 1e6 * rates.output;
   var cacheReadCost  = (tokenUsage.cacheRead  || 0) / 1e6 * cachedInputRate(rates);
   var cacheWriteCost = (tokenUsage.cacheWrite || 0) / 1e6 * cacheWriteRate(rates);
-  return inputCost + outputCost + cacheReadCost + cacheWriteCost;
+  return { cost: (inputCost + outputCost + cacheReadCost + cacheWriteCost) * multiplier, notes };
+}
+
+/** Unknown prices return null, never a fabricated zero-dollar charge. */
+export function estimateCost(tokenUsage, modelName, context) {
+  return estimateCostDetails(tokenUsage, modelName, context).cost;
 }
 
 /**
  * Estimate cost across multiple models by pricing each model's tokens at its own rate.
  * modelTokenMap: { [modelName]: { inputTokens, outputTokens, cacheRead, cacheWrite } }
- * Returns 0 if no models have recognized pricing.
+ * This map contains aggregates, not individual requests. Ambiguous tiers and
+ * unrecognized models make the total unknown rather than silently undercounted.
  */
-export function estimateMultiModelCost(modelTokenMap) {
-  if (!modelTokenMap) return 0;
+export function estimateMultiModelCost(modelTokenMap, context) {
+  if (!modelTokenMap) return null;
   var total = 0;
   var keys = Object.keys(modelTokenMap);
   for (var i = 0; i < keys.length; i++) {
-    total += estimateCost(modelTokenMap[keys[i]], keys[i]);
+    var cost = estimateCost(modelTokenMap[keys[i]], keys[i], { ...context, aggregate: true });
+    if (cost == null) return null;
+    total += cost;
   }
   return total;
 }
@@ -155,6 +193,7 @@ export function estimateMultiModelCost(modelTokenMap) {
  * >= $1    -> "$X.XX"
  */
 export function formatCost(usd) {
+  if (usd == null || !Number.isFinite(usd)) return "--";
   if (usd <= 0) return "$0.00";
   if (usd < 0.01) return "<$0.01";
   if (usd < 1) return "$" + usd.toFixed(3);

--- a/src/lib/qaClassifier.js
+++ b/src/lib/qaClassifier.js
@@ -174,7 +174,7 @@ function answerCost(data) {
     return instant("No token usage data available for this session.");
   }
 
-  var cost = getSessionCost(data.metadata);
+  var cost = getSessionCost(data.metadata, data.events);
   var lines = [];
   if (cost != null) {
     var label = data.metadata.totalCost != null ? getSessionCostLabel(data.metadata) : "Estimated cost";
@@ -230,7 +230,7 @@ function answerSummary(data) {
     lines.push("- Autonomy: " + (m.autonomyEfficiency * 100).toFixed(0) + "%");
   }
 
-  var sessionCost = getSessionCost(meta);
+  var sessionCost = getSessionCost(meta, data.events);
   if (sessionCost != null) {
     var costLabel = meta.totalCost != null ? getSessionCostLabel(meta) : "Estimated cost";
     lines.push("- " + costLabel + ": " + (meta.totalCost != null ? formatSessionCost(meta) : formatCost(sessionCost)));

--- a/src/lib/sessionLibrary.js
+++ b/src/lib/sessionLibrary.js
@@ -223,7 +223,7 @@ export function buildSessionLibraryEntry(fileName, result, rawText, previousEntr
     totalToolCalls: metadata.totalToolCalls || 0,
     errorCount: metadata.errorCount || 0,
     duration: metadata.duration || 0,
-    totalCost: getSessionCost(metadata),
+    totalCost: getSessionCost(metadata, result.events),
     totalCostUnit: metadata.totalCostUnit || null,
     aiCredits: metadata.aiCredits != null ? metadata.aiCredits : null,
     warnings: metadata.warnings || [],

--- a/src/lib/sessionTypes.ts
+++ b/src/lib/sessionTypes.ts
@@ -5,7 +5,22 @@ export interface TokenUsage {
   outputTokens?: number;
   cacheRead?: number;
   cacheWrite?: number;
+  cacheWriteReported?: boolean;
   cacheHitRate?: number;
+}
+
+export interface PricingContext {
+  provider?: "openai" | "copilot";
+  serviceTier?: string;
+  aggregate?: boolean;
+}
+
+export interface PricingRequest {
+  model?: string | null;
+  tokenUsage: TokenUsage;
+  pricingContext?: PricingContext;
+  turnIndex?: number;
+  turnId?: string | null;
 }
 
 export type SessionFormat = "claude-code" | "copilot-cli" | "vscode-chat" | "atif" | "copilot-prompts" | "codex";
@@ -30,6 +45,7 @@ export interface NormalizedEvent {
   model?: string | null;
   reasoningEffort?: string | null;
   tokenUsage?: TokenUsage | null;
+  pricingContext?: PricingContext;
   toolCallId?: string | null;
   parentToolCallId?: string | null;
   agentName?: string | null;
@@ -72,6 +88,7 @@ export interface SessionMetadata {
   totalCost?: number | null;
   totalCostUnit?: "usd" | "ai_credits" | null;
   aiCredits?: number | null;
+  pricingRequests?: PricingRequest[];
   [key: string]: unknown;
 }
 

--- a/tests/e2e/v2-smoke.spec.js
+++ b/tests/e2e/v2-smoke.spec.js
@@ -52,6 +52,36 @@ async function importGoldenFixture(page) {
   await expect(page.getByText("Ready", { exact: true })).toBeVisible();
 }
 
+test("new OpenAI token prices stay request-scoped and unknown models stay unpriced", async function ({ page }) {
+  var failures = captureFailures(page);
+  await openV2(page);
+  var prompts = [0, 1].map(function (index) {
+    return {
+      request: { model: "gpt-5.6-sol", messages: [{ role: "user", content: "Synthetic pricing request " + index }] },
+      response: { usage: { input_tokens: 200000, output_tokens: 10000, input_tokens_details: { cached_tokens: 60000, cache_write_tokens: 20000 } } },
+    };
+  });
+  await page.locator('input[type="file"]').setInputFiles({ name: "pricing.json", mimeType: "application/json", buffer: Buffer.from(JSON.stringify(prompts)) });
+  await expect(page).toHaveURL(/review$/);
+  await page.getByRole("button", { name: /Analyze,/ }).click();
+  await expect(page.getByText("$1.61", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText(/Standard service tier assumed/)).toBeVisible();
+  await page.getByRole("tab", { name: "Cost", exact: true }).click();
+  await expect(page.getByText("Token cost estimates", { exact: true })).toBeVisible();
+  await expect(page.getByText("$1.61", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("200k", { exact: true })).toBeVisible();
+  await expect(page.getByText("Estimated context composition", { exact: true })).toBeVisible();
+  expect(await page.getByText("$ BILLED", { exact: true }).count()).toBe(0);
+  await page.getByRole("button", { name: /Find,/ }).click();
+  prompts[0].request.model = "gpt-5.6-unknown";
+  await page.locator('input[type="file"]').setInputFiles({ name: "unknown-pricing.json", mimeType: "application/json", buffer: Buffer.from(JSON.stringify(prompts)) });
+  await expect(page).toHaveURL(/review$/);
+  await page.getByRole("button", { name: /Analyze,/ }).click();
+  await expect(page.getByText(/Pricing unavailable for gpt-5.6-unknown/)).toBeVisible();
+  expect(await page.getByText("$0.00", { exact: true }).count()).toBe(0);
+  expect(failures).toEqual([]);
+});
+
 for (let width of [1400, 600]) {
   test("playback speed options stay inside the viewport at " + width + "px", async function ({ page }) {
     var failures = captureFailures(page);


### PR DESCRIPTION
## Why

AGENTVIZ priced GPT-5.6 variants using the generic GPT-5 fallback and did not recognize GPT-6 Astra. These models introduce separately priced cache writes; applying long-context rates to session aggregates also produces incorrect totals even with an updated price table.

## Changes

- Add explicit Sol, Terra, Luna and Astra rates for fresh input, cached input, cache writes and output, plus supported explicit Fast/priority, Batch and Flex tiers.
- Price individual requests before aggregation. Do not treat session totals as request context lengths, silently substitute old GPT-5 rates, or display unknown costs as zero.
- Preserve reported USD and AI Credits, including per-model billed credits, independently of token estimates.
- Carry verified cache-write telemetry and request-level evidence through Copilot prompt exports, Copilot CLI and Codex, with batch/live normalization parity and reasoning output counted once.
- Share request-aware accounting across Cost, Stats, Review, Compare, Replay, Q&A and saved-session summaries; disclose Standard assumptions and missing evidence.

## Pricing sources and limitations

Rates checked on 2026-09-09: [OpenAI API pricing](https://developers.openai.com/api/docs/pricing), [OpenAI prompt caching](https://developers.openai.com/api/docs/guides/prompt-caching), and [GitHub Copilot pricing](https://docs.github.com/en/copilot/reference/copilot-billing/models-and-pricing).

Standard USD per million tokens:

| Model | Fresh input | Cache read | Cache write | Output |
|---|---:|---:|---:|---:|
| GPT-5.6 Sol | 4.00 | 0.40 | 5.00 | 20.00 |
| GPT-5.6 Terra | 2.00 | 0.20 | 2.50 | 12.00 |
| GPT-5.6 Luna | 0.20 | 0.02 | 0.25 | 1.20 |
| GPT-6 Astra | 10.00 | 1.00 | 12.50 | 50.00 |

Luna's documented threshold differs by provider: Copilot uses >200K input, while the [OpenAI model page](https://developers.openai.com/api/docs/models/gpt-5.6-luna) specifies >272K. Unknown providers remain unpriced in that disputed interval. Aggregate-only usage that cannot establish request tiers is unavailable rather than a fabricated precise total. Missing write telemetry and service-tier assumptions are disclosed. Regional uplifts, negotiated discounts and non-token charges are not modeled. Sol's rates are promotional, available at least through November 21, 2026; this table is not historical invoice reconstruction.

## Validation

- Final `npm test`: 1,080 tests passed in 66 files.
- `npm run typecheck` and `npm run build`: passed.
- Implementation browser run: 15 tests passed, including new pricing display coverage.
- Regression coverage includes explicit bucket costs, threshold boundaries, separate short requests versus one long request, provider differences, service tiers, unknown prices, reported credits, cache-write extraction and live parity.

README, contributor guidance, style guide and palette notes are updated. Documentation screenshot regeneration is deferred: repository policy requires explicit confirmation, and the user was unavailable to approve it. Existing screenshots are retained. No workflow or dependency changes are included.