### PR TITLE
Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-09-09
+
 ### Changed
 
 - Make the workflow the only shell while preserving `#/v2/...` links, preferences
@@ -17,6 +19,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   or explicit Close aborts streams and clears transient state, not saved runs.
 - Open newly exported comparisons directly in Compare and preserve offline
   single-session and A/B exports.
+
+### Fixed
+
+- Price GPT-5.6 Sol, Terra, Luna and GPT-6 Astra using explicit fresh-input,
+  cache-read, cache-write and output rates, including supported service tiers.
+  Calculate context tiers per request rather than from session totals. (#135)
+- Preserve reported USD and AI Credits over estimates. Show unknown or ambiguous
+  costs as unavailable, disclose missing telemetry and Standard-tier assumptions,
+  and respect the documented OpenAI/Copilot Luna threshold difference. (#135)
+- Track verified cache-write usage and request checkpoints through Copilot and
+  Codex parsing, preserving live/batch parity and counting reasoning output once.
+  Share accounting across session summaries and cost displays. (#135)
+- Keep playback speed menus inside compact viewports, allow closing empty live
+  sessions, and avoid intercepting Alt-modified shortcuts. (#134)
+
+### Migration
+
+- Classic UI is no longer available. Use Find to import and select sessions for
+  comparison, Investigate for replay, Analyze for visualizations, and Improve
+  for Coach and Q&A.
+- Existing workflow URLs, preferences, stored sessions and v1 storage schemas
+  are preserved. No data migration is required.
 
 ## [1.0.4] - 2026-09-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentviz",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentviz",
-      "version": "1.0.4",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@github/copilot-sdk": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentviz",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Session replay visualizer for AI agent workflows (Claude Code, VS Code, Copilot CLI)",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Prepare the minor release following the workflow consolidation and corrected GPT-5.6/Astra pricing. Bump package and lockfile versions from 1.0.4 to 1.1.0 and promote the unreleased notes into a dated changelog, including pricing fixes and Classic migration guidance.

No runtime, dependency or publishing-workflow changes are included. Existing workflow URLs, preferences and saved session schemas remain supported; Classic UI is retired.

## Validation

- `npm test`: 1,080 tests passed across 66 files.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- `npm pack --dry-run --ignore-scripts`: valid agentviz@1.1.0 package, 834,810 packed bytes.
- `git diff --check`: passed.

## Release sequence

Merge this version bump, tag the merged commit as `v1.1.0`, and publish a GitHub release. The existing `Publish npm` workflow publishes through the `npm-publish` environment with provenance. Verify workflow completion and npm availability afterward. No npm release has been published by this PR itself.