### PR TITLE
Add event bookmarks and annotations with portable findings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ points.
 - Single-session and comparison HTML exports use ExportStatusButton and the current workflow-only production build.
 - Investigate search preserves timeline context; Enter and Shift+Enter, plus adjacent arrow controls, navigate next and previous matches.
 - User-only filtering uses the normalized `event.agent === "user"` field across every parser, and search operates on the filtered event set.
+- Event findings and note drafts belong to the loader, not playback or a zone. Findings storage is separate from raw transcripts and retains failed edits with retry/backup recovery. Match original index plus source/action, occurrence and prefix guards; unmatched findings remain unavailable, never timestamp-rebound. Exports validate session/snapshot ownership and isolate embedded findings from ordinary local notes.
 
 ## Discovery and live parsing invariants
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ AI coding agents (Claude Code, Codex, VS Code Copilot Chat, Copilot CLI, ATIF / 
 - **Switch themes** between dark, light, and system-matched modes with one click
 - **Use one workflow**: Find, Review, Investigate, Analyze, Compare, Improve
 - **Follow exact evidence** from command-palette events/turns and Review insights into Investigate or Waterfall, including equal-time events and offscreen rows. Playback and search survive workflow switches.
+- **Keep findings** with event bookmarks and plain-text notes in Investigate, exact-event navigation, local persistence, and portable HTML/JSON backups.
 - **Recover failed imports** with visible loading, read/parse errors, retry, and reimport actions. Find opens Review only after parsing succeeds; failed or superseded loads do not replace the last successful session.
 
 ## Quick Start
@@ -173,7 +174,7 @@ AGENTVIZ has one task-oriented workflow shell, backed by shared parsers and sess
 |------|---------|
 | Find | Unified session portfolio with search, filters, layout toggle, tags, import, demo, refresh, and multi-select compare |
 | Review | Health score, summary cards, top tools, and evidence-linked insights |
-| Investigate | Replay evidence stream with contextual Analyze, Compare, Ask, and Coach actions |
+| Investigate | Replay evidence stream with bookmarks, event notes, and contextual Analyze, Compare, Ask, and Coach actions |
 | Analyze | Existing Stats, Tracks, Waterfall, Graph, and Cost views as sub-panels |
 | Compare | Inline comparison using the existing scorecard and tools chart |
 | Improve | Coach recommendations, next-run checklist, and Session Q&A |
@@ -199,6 +200,35 @@ Classic UI and its toggle, recent-session dropdown, direct A/B upload screen, an
 Close also works before a live stream produces its first event. The bottom transport's speed menu opens upward so every speed remains reachable on desktop and compact screens.
 
 **Local save status** is separate from loading a session. Each active A/B transcript shows whether its latest snapshot is saved locally. Storage access, quota, and session-index failures do not prevent replay or comparison: use **Retry saving** or **Download transcript** to recover the active raw file before closing. A failed live content write keeps any earlier cached snapshot and its metadata, but does not label the latest events as saved. Index-write failures attempt to restore the earlier content and report restoration failures too. When quota eviction removes older cached transcripts, a notice identifies the number removed; reopen discovered sources or reimport those files. Refresh rechecks cached availability. A damaged index is reported, never silently replaced.
+
+### Bookmarks and event notes
+
+In **Investigate**, select an event and choose **Bookmark event** or **Add note**.
+Each event has one bookmark with an optional plain-text note (up to 20,000 characters).
+Use **Save note** to persist, or **Cancel note** to discard the draft. **Remove bookmark
+and note** deletes both; saving an empty note keeps the bookmark.
+
+The **Bookmarks** toggle opens a compact list. Jump targets use original event indices,
+including index zero and events with identical timestamps. Saved findings survive Close,
+browser reload, and reopening the same session. Drafts survive zone changes and failed
+loads, but are not automatically saved: save or download them before replacement, Close,
+or reload. Findings are separate from the raw transcript and cannot prevent transcript saving.
+
+Live appends preserve matching anchors. Truncated, reordered, or changed evidence is
+retained in the list as **Unavailable in this snapshot**, never reassigned by timestamp.
+Sessions with explicit IDs share findings across snapshots; renamed imports and foreign
+discovery paths do not change that identity. Without an explicit ID, JSONL identity uses
+its first complete source record; standalone JSON documents use their content. Identical
+copied source identities cannot be distinguished, and changed inferred identities may
+require the original snapshot to recover findings.
+
+Storage failures keep edits in memory and show recovery controls above the workspace.
+**Retry findings save** retries without touching the transcript. **Download findings**
+backs up bookmarks, unavailable findings, and note drafts as JSON without needing the
+production bundle or working storage. **Restore findings** validates the session and exact
+transcript snapshot, then asks before replacing its findings. Corrupt stores are never
+silently overwritten. Conflicting edits to the same finding require downloading edits and
+explicitly reloading the saved copy; independent findings from A/B views can merge.
 
 ## Session Comparison
 
@@ -232,6 +262,13 @@ Horizontal bar chart showing tool call counts for both sessions on the same axis
 ### Export
 
 Click **Export** in the workflow header or comparison header to download a single self-contained `.html` file. Share it with anyone, no server required. Opening it restores the session or comparison for offline investigation.
+
+Exports include the active session's bookmarks, notes, and unsaved note drafts, separately
+for A and B. Review notes before sharing. Embedded findings take precedence over unrelated
+local notes; edits to that exact export use an isolated local namespace, including saved
+deletions. Legacy exports without findings still open. Invalid or foreign findings are
+reported without replacing transcript data. In offline viewers, use **Download findings**
+to back up new edits; generating another HTML export requires the production server.
 
 Export is available in two places:
 
@@ -477,6 +514,7 @@ src/
     useSearch.js         # Debounced full-text search with match highlighting
     useKeyboardShortcuts.js  # Centralized keyboard handler
     useSessionLoader.js  # Transactional parsing, completion signaling, live snapshot bootstrap, session reset
+    useFindings.js       # Session findings and drafts, persistence, conflict recovery and export payloads
     useQA.js             # Session Q&A state: messages, classifier, SSE streaming, abort
     useLiveStream.js     # Cursor-resumable SSE hook with 500ms debounce and reset handling
     usePersistentState.js    # localStorage-backed useState with debounced writes
@@ -505,6 +543,7 @@ src/
     dataInspector.js     # Payload summary and preview helpers for inspector panels
     session.ts           # Pure helpers: getSessionTotal, buildFilteredEventEntries
     sessionLibrary.js    # localStorage snapshots, save failures and quota eviction reporting
+    findings.ts          # Session identities, guarded event anchors, validation and independent storage
     downloadText.ts      # Shared raw transcript and HTML download primitive
     sessionParsing.ts    # Session parsing utilities and types
     sessionTypes.ts      # TypeScript type definitions for session data
@@ -554,7 +593,7 @@ src/
     ErrorBoundary.jsx    # React error boundary with resetKey for recovery
     Icon.jsx             # Lucide icon wrapper; all icons must be imported AND added to ICON_MAP
     ui/                  # Shared primitives: BrandWordmark, ToolbarButton, ToolbarSelect, ExportStatusButton, KeyboardHint
-    v2/                  # Default workflow UI: FlowRail, V2Header, FindPortfolio, ReviewHub, InvestigateView, AnalyzeShell, InlineCompare, ImproveView, LiveSessionBanner, SessionStorageNotice
+    v2/                  # Default workflow UI: FlowRail, V2Header, FindPortfolio, ReviewHub, InvestigateView, FindingsPanel, AnalyzeShell, InlineCompare, ImproveView, LiveSessionBanner, SessionStorageNotice
     waterfall/           # Waterfall sub-components: WaterfallChart, WaterfallRow, WaterfallInspector, TimeAxis
 routes/
   discovery.js         # Async traversal and bounded cached preview enrichment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,7 @@ src/
     useKeyboardShortcuts.js # Centralized keyboard handler with stable listener
     useQA.js           # Q&A messages, classifier, SSE streaming, abort
     useSessionLoader.js # Transactional parsing, active raw snapshot/save status, live bootstrap and reset
+    useFindings.js      # Loader-scoped findings, drafts, persistence, conflict recovery and export payloads
     useLiveStream.js   # Cursor-resumable SSE, debounce and reset handling
     usePersistentState.js # localStorage-backed state with debounced writes
     useDiscoveredSessions.js # Discovery via /api/sessions or manifest URL
@@ -60,6 +61,7 @@ src/
     parseSession.ts    # Format detection and parsing router
     session.ts         # Totals, filtered entries, turn start maps
     sessionLibrary.js  # localStorage snapshots, structured failures and quota eviction reporting
+    findings.ts        # Findings identity, guarded anchors, schema validation and three-way storage merge
     downloadText.ts    # Shared raw transcript and HTML download primitive
     sessionParsing.ts  # Parsing utilities and types
     sessionTypes.ts    # Session data types
@@ -105,6 +107,7 @@ src/
     ui/                # Shared brand, toolbar, export-status and keyboard primitives
     v2/                # FlowRail, V2Header, FindPortfolio, ReviewHub, InvestigateView,
                        # AnalyzeShell, InlineCompare, ImproveView, LiveSessionBanner, SessionStorageNotice
+                       # FindingsPanel (bookmark list, editor, restore and shared recovery controls)
     waterfall/         # Chart, row, inspector and time-axis components
 routes/
   discovery.js        # Async traversal, enrichment, bounded preview cache
@@ -138,6 +141,41 @@ cross-tab storage events, so eviction or replacement cannot leave a saved label.
 `SessionStorageNotice` exposes non-blocking recovery across zones; raw downloads
 reuse `ExportStatusButton` and `useAsyncStatus`, without needing a production
 bundle or browser storage. Demo and Close clear active save status.
+
+### Findings persistence and identity
+
+Each loader owns `useFindings` independently of playback and conditional zone rendering.
+Successful parsing initializes findings; failed loads leave them and drafts untouched.
+Close/replacement clears in-memory state only. Loading B alongside current A does not
+replace A or its draft. Live reset keeps findings unavailable until guarded evidence
+matches again; a newly sourced explicit session ID initializes that session's own store.
+
+`agentviz:findings:v1:<identity>` is independent of the unchanged transcript/index keys.
+Identity uses format plus explicit session ID, or a deterministic canonical-source
+fingerprint when no ID exists. Inferred JSONL identity uses the first source record;
+single JSON documents remain content-specific. Import names and discovery paths are
+not findings identity. Identical source copies are intentionally the same identity.
+
+An anchor stores original index, immutable-action/source fingerprint, occurrence, and a
+chained prefix fingerprint. Matching requires all four, not nearest time or a text search.
+Changed predecessors conservatively make later findings unavailable. Mutable completion
+output, usage and duration are excluded. Anchor construction is linear and memoized on
+event snapshots, never on playback ticks. Lists paginate 50 findings at a time.
+
+Reads validate version, ownership, anchors, unique IDs and bounded plain-text notes.
+Writes merge changes against the caller's baseline, preserving independent A/B edits and
+rejecting same-finding conflicts. Access, quota and corruption errors retain working
+items/drafts. An unknown baseline cannot overwrite newly available saved findings.
+Same-page and storage events refresh clean copies; drafts/unsaved copies retain their
+baseline for conflict detection. localStorage does not provide cross-tab transactions.
+
+HTML exports embed `{version, sessionId, snapshot, items, drafts}` separately for each
+active loader. The snapshot fingerprints raw text without modifying it. Offline bootstrap
+passes single findings through `/api/meta` and A/B findings through the existing compare
+payload. Validation rejects foreign snapshot payloads. Normal local notes are never read
+into an export: its initial payload is authoritative and subsequent local edits use a
+namespace fingerprinted from that exact payload. JSON backup/restore uses the same
+validated payload, supports draft recovery, and requires explicit replacement.
 
 ## Core data shapes
 

--- a/docs/ui-ux-style-guide.md
+++ b/docs/ui-ux-style-guide.md
@@ -732,6 +732,9 @@ Rules:
 - Close session is distinct from Find navigation: Close cancels active loads and viewer subscriptions, clears A/B and overlays, and retains the library and preferences.
 - Close remains available while a live stream is waiting for its first event or has reset to empty.
 - Q&A history and its unfinished draft belong above conditional zone rendering and beneath successful-session identity. Failed loads and zone switches retain them; replacement or Close aborts streams and resets them.
+- Investigate bookmarks extend the selected-event actions and a bounded inline list, not a new workflow zone or modal. Use original event indices, readable unavailable states, and 50-item pagination.
+- Event notes use a labeled plain textarea, `theme.reading.fontSize`, explicit Save/Cancel, and action text that names bookmark-plus-note deletion. An empty saved note retains its bookmark.
+- Findings save status is independent of transcript status. Retain failed edits and drafts; show textual failure/retry/backup controls across zones, and require confirmation before restoring a backup or discarding edits to reload saved findings. Downloads reuse `ExportStatusButton`.
 
 **Cards must be `<button>` elements**, not clickable `<div>`. Set `textAlign: "left"` to
 override the button default. This ensures keyboard accessibility.
@@ -1305,6 +1308,7 @@ When reviewing a PR that touches UI, verify each of these:
 - [ ] **Semantic HTML**: Buttons are `<button>`, not clickable `<div>`.
 - [ ] **Error states**: Use `theme.semantic.error*` tokens. Always pair color with icon or text.
 - [ ] **Local saves**: Distinguish active/latest/earlier cached snapshots; test quota, blocked storage, index failure, eviction, retry and raw download for A/B and live/reset paths.
+- [ ] **Findings**: Exact index/equal-time navigation, plain notes, draft retention, unavailable anchors after reset, independent save failures, and isolated offline A/B payloads. Check list/editor bounds at 1400px and 600px.
 - [ ] **Empty states**: Centered message with `theme.text.dim` and `theme.fontSize.md`.
 - [ ] **Brand**: Product name is "AGENTVIZ" (all caps). Uses `BrandWordmark` component.
 - [ ] **Data formatting**: Durations, numbers, and costs follow the formatting rules in Section 15.

--- a/src/AppV2.jsx
+++ b/src/AppV2.jsx
@@ -346,7 +346,8 @@ function AnalyzeZone({ sessionState, targetPanelId, targetEventIndex, targetRequ
 }
 
 function InvestigateZone({ sessionState, targetEventIndex, targetRequest, onNavigate }) {
-  if (!sessionState.session.events) {
+  if (!sessionState.session.events && !sessionState.session.findings?.items.length
+    && !Object.keys(sessionState.session.findings?.drafts || {}).length) {
     return <ZonePlaceholder zone="investigate" sessionState={sessionState} />;
   }
 

--- a/src/__tests__/appRegression.test.jsx
+++ b/src/__tests__/appRegression.test.jsx
@@ -602,7 +602,7 @@ describe("App browser regressions", function () {
       return exportMocks.exportSingleSession.mock.calls.length > 0;
     }, "expected export handler to run");
 
-    expect(exportMocks.exportSingleSession).toHaveBeenCalledWith(FIXTURE_TEXT, "fixture.jsonl");
+    expect(exportMocks.exportSingleSession).toHaveBeenCalledWith(FIXTURE_TEXT, "fixture.jsonl", expect.objectContaining({ version: 1, items: [] }));
 
     expect(app.container.querySelector('button[aria-label^="Compare,"]').getAttribute("aria-disabled")).toBe("true");
     expect(app.container.querySelector('button[aria-label^="Improve,"]').getAttribute("aria-disabled")).toBe("true");

--- a/src/__tests__/exportHtml.test.js
+++ b/src/__tests__/exportHtml.test.js
@@ -68,6 +68,26 @@ function readPayload(html) {
 }
 
 describe("exportHtml module", function () {
+  it("embeds isolated single and A/B findings and drafts without changing raw text", async function () {
+    var captured = stubBrowser(buildResponses());
+    var mod = await import("../lib/exportHtml.js");
+    var a = { version: 1, sessionId: "a", items: [{ note: "</script><script>alert('note')</script> & \u2028" }], drafts: [{ note: "draft" }] };
+    var b = { version: 1, sessionId: "b", items: [{ note: "B only" }] };
+    await mod.exportSingleSession("raw-a", "a.jsonl", a);
+    var html = await captured.blob.text();
+    expect(readPayload(html).session).toEqual({ filename: "a.jsonl", text: "raw-a", findings: a });
+    expect(html).not.toContain("</script><script>alert");
+    await mod.exportComparison("raw-a", "a.jsonl", "raw-b", "b.jsonl", a, b);
+    expect(readPayload(await captured.blob.text()).compare).toEqual({
+      a: { name: "a.jsonl", text: "raw-a", findings: a }, b: { name: "b.jsonl", text: "raw-b", findings: b },
+    });
+    vi.stubGlobal("CompressionStream", undefined);
+    await mod.exportSingleSession("raw-a", "a.jsonl", a);
+    html = await captured.blob.text();
+    expect(html).not.toContain("</script><script>alert");
+    expect(html).toContain("\\u003c");
+  });
+
   afterEach(function () {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();

--- a/src/__tests__/findings.test.ts
+++ b/src/__tests__/findings.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { parseSessionText } from "../lib/sessionParsing";
+import { appendLiveSessionText, createLiveSessionParser } from "../lib/liveSessionParser";
+import {
+  FINDINGS_PREFIX, anchorId, buildEventAnchors, createFinding, findingsSessionId,
+  fingerprint, matchesAnchor, readFindings, saveFindings, validateFindingsPayload,
+} from "../lib/findings";
+
+function storage() {
+  const values = new Map<string, string>();
+  return { getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => { values.set(key, value); },
+    removeItem: (key: string) => { values.delete(key); } } as Storage;
+}
+const events = [
+  { t: 0, agent: "user", track: "output", text: "First", raw: { id: "a", timestamp: "2026-01-01" } },
+  { t: 0, agent: "assistant", track: "output", text: "Second", raw: { id: "b", timestamp: "2026-01-01" } },
+];
+const anchors = buildEventAnchors(events);
+const first = createFinding(anchors[0], events[0], "A note");
+const second = createFinding(anchors[1], events[1], "Another note");
+
+describe("findings identities and anchors", () => {
+  it("distinguishes index zero, equal times and duplicate occurrences", () => {
+    expect(anchorId(anchors[0])).not.toBe(anchorId(anchors[1]));
+    expect(matchesAnchor(first.anchor, anchors)).toBe(true);
+    const repeated = buildEventAnchors([events[0], events[0]]);
+    expect(repeated[0].occurrence).toBe(0);
+    expect(repeated[1].occurrence).toBe(1);
+    expect(anchorId(repeated[0])).not.toBe(anchorId(repeated[1]));
+  });
+  it("keeps anchors on append and completion but rejects truncation, replacement and reorder", () => {
+    expect(matchesAnchor(second.anchor, buildEventAnchors([...events, { text: "Third" }]))).toBe(true);
+    expect(matchesAnchor(second.anchor, buildEventAnchors(events.map(e => ({ ...e, duration: 99, toolOutput: "Late", tokenUsage: { input: 100 } }))))).toBe(true);
+    expect(matchesAnchor(second.anchor, buildEventAnchors(events.slice(0, 1)))).toBe(false);
+    expect(matchesAnchor(second.anchor, buildEventAnchors([...events].reverse()))).toBe(false);
+    expect(matchesAnchor(second.anchor, buildEventAnchors([{ ...events[0], text: "Replaced" }, events[1]]))).toBe(false);
+    expect(matchesAnchor(first.anchor, [])).toBe(false);
+  });
+  it("guards untruncated source text and timestamps when normalized previews are identical", () => {
+    const shared = "a".repeat(300);
+    const original = { t: 0, agent: "assistant", track: "output", text: shared, raw: { type: "text", text: shared + "original" } };
+    const anchor = buildEventAnchors([original])[0];
+    expect(matchesAnchor(anchor, buildEventAnchors([{ ...original, raw: { type: "text", text: shared + "replacement" } }]))).toBe(false);
+    expect(matchesAnchor(anchor, buildEventAnchors([{ ...original, t: 10 }]))).toBe(false);
+  });
+  it("keeps pending Copilot tool anchors through actual late completion normalization", () => {
+    const raw = readFileSync(resolve(process.cwd(), "src", "__tests__", "fixtures", "test-copilot.jsonl"), "utf8");
+    const lines = raw.trim().split("\n");
+    const initialText = lines.slice(0, 5).join("\n") + "\n";
+    const initial = parseSessionText(initialText).result!;
+    const pending = buildEventAnchors(initial.events);
+    const live = appendLiveSessionText(createLiveSessionParser(initialText), lines.slice(5).join("\n") + "\n");
+    const completed = buildEventAnchors(live.result!.events);
+    expect(initial.events.some(event => event.track === "tool_call")).toBe(true);
+    pending.forEach(anchor => expect(matchesAnchor(anchor, completed)).toBe(true));
+  });
+  it("uses explicit session identity across snapshots, independent of path and name", () => {
+    expect(findingsSessionId({ format: "test", sessionId: "one", sourcePath: "foreign" }, "first"))
+      .toBe(findingsSessionId({ format: "test", sessionId: "one" }, "second"));
+    expect(findingsSessionId({ format: "test", sessionId: "two" }, "first"))
+      .not.toBe(findingsSessionId({ format: "test", sessionId: "one" }, "first"));
+  });
+  it("recognizes renamed inferred JSONL reimports and append but not different first records", () => {
+    const text = '{"timestamp":"first","content":"hello"}\n{"content":"second"}';
+    const id = findingsSessionId({ format: "test", sourcePath: "old" }, text);
+    expect(findingsSessionId({ format: "test", sourcePath: "new" }, text + '\n{"content":"third"}')).toBe(id);
+    expect(findingsSessionId({ format: "test" }, "\n \n" + text)).toBe(id);
+    expect(findingsSessionId({ format: "test", sourcePath: "old" }, text.replace("first", "other"))).not.toBe(id);
+    expect(findingsSessionId(null, '{"a":1,"b":2}')).toBe(findingsSessionId(null, '{"b":2,"a":1}'));
+    expect(findingsSessionId(null, '{"a":1}')).not.toBe(findingsSessionId(null, '{"a":2}'));
+  });
+  it("validates export snapshot ownership, unique anchors, bounded plain-text notes and drafts", () => {
+    const payload = { version: 1, sessionId: "one", snapshot: fingerprint("raw"), items: [first], drafts: [second] };
+    expect(validateFindingsPayload(payload, "one", "raw").items).toEqual([first]);
+    expect(() => validateFindingsPayload(payload, "two", "raw")).toThrow();
+    expect(() => validateFindingsPayload(payload, "one", "other")).toThrow();
+    for (const items of [[first, first], [{ ...first, note: "x".repeat(20001) }], [{ ...first, id: "wrong" }],
+      [{ ...first, anchor: { ...first.anchor, index: -1 } }]]) {
+      expect(() => validateFindingsPayload({ ...payload, items }, "one", "raw")).toThrow();
+    }
+  });
+});
+
+describe("findings persistence", () => {
+  it("saves, reads and removes independently of transcript storage", () => {
+    const store = storage();
+    store.setItem("agentviz:session-content:v1:one", "unchanged raw");
+    expect(saveFindings("one", [first], [], store).error).toBeNull();
+    expect(readFindings("one", store).items).toEqual([first]);
+    expect(readFindings("two", store).items).toEqual([]);
+    expect(saveFindings("one", [], [first], store).items).toEqual([]);
+    expect(store.getItem("agentviz:session-content:v1:one")).toBe("unchanged raw");
+  });
+  it("preserves corrupt JSON and structurally corrupt stores without overwriting", () => {
+    const store = storage();
+    for (const raw of ["{broken", '{"version":2,"sessionId":"one","items":[]}', '{"version":1,"sessionId":"other","items":[]}']) {
+      store.setItem(FINDINGS_PREFIX + "one", raw);
+      expect(readFindings("one", store).error?.kind).toBe("corrupt");
+      expect(saveFindings("one", [first], [], store).error?.kind).toBe("corrupt");
+      expect(store.getItem(FINDINGS_PREFIX + "one")).toBe(raw);
+    }
+  });
+  it("surfaces read and write access failures, quota failures, and successful retry", () => {
+    const store = storage();
+    const write = store.setItem;
+    store.setItem = () => { throw new DOMException("Full", "QuotaExceededError"); };
+    expect(saveFindings("one", [first], [], store).error?.kind).toBe("quota");
+    store.setItem = write;
+    expect(saveFindings("one", [first], [], store).items).toEqual([first]);
+    store.getItem = () => { throw new Error("Blocked"); };
+    expect(readFindings("one", store).error?.kind).toBe("access");
+    expect(saveFindings("one", [second], [first], store).error?.kind).toBe("access");
+  });
+  it("merges independent A/B edits but refuses concurrent changes to the same finding", () => {
+    const store = storage();
+    saveFindings("one", [first], [], store);
+    expect(saveFindings("one", [second], [], store).items).toEqual([first, second]);
+    const changed = { ...first, note: "From A" };
+    saveFindings("one", [changed, second], [first, second], store);
+    expect(saveFindings("one", [{ ...first, note: "From B" }, second], [first, second], store).error?.kind).toBe("conflict");
+    expect(readFindings("one", store).items).toEqual([changed, second]);
+  });
+  it("does not overwrite findings discovered after a previously blocked read", () => {
+    const store = storage();
+    saveFindings("one", [first], [], store);
+    expect(saveFindings("one", [second], null, store).error?.kind).toBe("conflict");
+    expect(readFindings("one", store).items).toEqual([first]);
+  });
+});

--- a/src/__tests__/sessionProvider.test.jsx
+++ b/src/__tests__/sessionProvider.test.jsx
@@ -28,6 +28,7 @@ import {
 } from "../contexts/SessionProvider.jsx";
 import { parseSessionText } from "../lib/sessionParsing";
 import { persistSessionSnapshot } from "../lib/sessionLibrary.js";
+import { FINDINGS_PREFIX, findingsSessionId, fingerprint } from "../lib/findings";
 
 var FIXTURE_TEXT = readFileSync(resolve(process.cwd(), "src/__tests__/fixtures/test-copilot.jsonl"), "utf8");
 
@@ -126,6 +127,8 @@ beforeEach(function () {
 });
 
 afterEach(function () {
+  delete window.__AGENTVIZ_STANDALONE__;
+  delete window.__AGENTVIZ_COMPARE__;
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
   document.body.innerHTML = "";
@@ -133,6 +136,173 @@ afterEach(function () {
 });
 
 describe("SessionProvider", function () {
+  it("persists event findings independently, keeps drafts on failed loads, and restores renamed reimports", async function () {
+    var ctx;
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "first.jsonl"); });
+    var entry = { index: 0, event: ctx.session.events[0] };
+    await act(async function () { ctx.session.findings.save(entry, "Remember index zero"); });
+    expect(ctx.session.findings.entries[0]).toMatchObject({ note: "Remember index zero", available: true, anchor: { index: 0 } });
+    await act(async function () { ctx.session.findings.setDraft(entry, "Unfinished"); });
+    await act(async function () { expect(await ctx.handleFile("bad", "invalid")).toBe(false); });
+    expect(Object.values(ctx.session.findings.drafts)[0].note).toBe("Unfinished");
+    expect(ctx.session.getRawText()).toBe(FIXTURE_TEXT);
+    await act(async function () { ctx.reset(); });
+    expect(ctx.session.findings.items).toEqual([]);
+    expect(ctx.session.findings.drafts).toEqual({});
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "renamed.jsonl", "foreign-path"); });
+    expect(ctx.session.findings.entries[0]).toMatchObject({ note: "Remember index zero", available: true });
+    expect(ctx.session.findings.drafts).toEqual({});
+    await app.unmount();
+    app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.openStoredSession(ctx.allSessions[0]); });
+    expect(ctx.session.findings.items[0].note).toBe("Remember index zero");
+    await app.unmount();
+  });
+
+  it("keeps quota-failed findings and note drafts, exports them, and retries without affecting transcript save", async function () {
+    var ctx;
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "first.jsonl"); });
+    var entry = { index: 0, event: ctx.session.events[0] };
+    var original = global.localStorage.setItem;
+    var write = vi.spyOn(global.localStorage, "setItem").mockImplementation(function (key, value) {
+      if (key.startsWith(FINDINGS_PREFIX)) throw new DOMException("Full", "QuotaExceededError");
+      original(key, value);
+    });
+    await act(async function () {
+      ctx.session.findings.setDraft(entry, "</script> unsaved");
+      ctx.session.findings.save(entry, "</script> unsaved");
+    });
+    expect(ctx.session.findings.error.kind).toBe("quota");
+    expect(ctx.session.findings.dirty).toBe(true);
+    expect(Object.values(ctx.session.findings.drafts)[0].note).toBe("</script> unsaved");
+    expect(ctx.session.storageStatus.saved).toBe(true);
+    await act(async function () { ctx.handleExportSession(); });
+    expect(exportMocks.exportSingleSession.mock.calls[0][2].items[0].note).toBe("</script> unsaved");
+    expect(exportMocks.exportSingleSession.mock.calls[0][0]).toBe(FIXTURE_TEXT);
+    write.mockRestore();
+    await act(async function () { ctx.session.findings.retry(); });
+    expect(ctx.session.findings.dirty).toBe(false);
+    expect(ctx.session.findings.error).toBeNull();
+    await app.unmount();
+  });
+
+  it("synchronizes identical A/B identities without crossing other sessions or binding different snapshots", async function () {
+    var ctx;
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "a.jsonl"); });
+    await act(async function () { await ctx.sessionB.handleFile(FIXTURE_TEXT, "b.jsonl"); });
+    await act(async function () { ctx.session.findings.save({ index: 0, event: ctx.session.events[0] }, "A"); });
+    expect(ctx.sessionB.findings.items[0].note).toBe("A");
+    await act(async function () { ctx.sessionB.findings.save({ index: 1, event: ctx.sessionB.events[1] }, "B"); });
+    expect(ctx.session.findings.items).toHaveLength(2);
+    await act(async function () { await ctx.sessionB.handleFile(FIXTURE_TEXT.replace("Can you add", "Would you add"), "changed.jsonl"); });
+    expect(ctx.sessionB.findings.entries.every(function (item) { return !item.available; })).toBe(true);
+    expect(ctx.session.findings.entries.every(function (item) { return item.available; })).toBe(true);
+    await act(async function () { await ctx.sessionB.handleFile(FIXTURE_TEXT.replaceAll("aaaabbbb-1234-5678-abcd-000000000001", "another"), "other.jsonl"); });
+    expect(ctx.sessionB.findings.items).toEqual([]);
+    expect(ctx.session.findings.items).toHaveLength(2);
+    await app.unmount();
+  });
+
+  it("preserves current A findings and drafts when loading a comparison", async function () {
+    var ctx;
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "a.jsonl"); });
+    await act(async function () { ctx.session.findings.setDraft({ index: 0, event: ctx.session.events[0] }, "Still drafting"); });
+    global.localStorage.setItem("agentviz:session-content:v1:b", FIXTURE_TEXT);
+    await act(async function () { expect(await ctx.openCompareCurrentWithEntry({ id: "b", file: "b.jsonl" })).toBe(true); });
+    expect(Object.values(ctx.session.findings.drafts)[0].note).toBe("Still drafting");
+    expect(ctx.compareReady).toBe(true);
+    await app.unmount();
+  });
+
+  it("retains stale A/B drafts as conflicts rather than silently overwriting a newer note", async function () {
+    var ctx;
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "a.jsonl"); });
+    await act(async function () { await ctx.sessionB.handleFile(FIXTURE_TEXT, "b.jsonl"); });
+    var entry = { index: 0, event: ctx.session.events[0] };
+    await act(async function () { ctx.session.findings.save(entry, "Original"); });
+    await act(async function () { ctx.session.findings.setDraft(entry, "A draft"); });
+    await act(async function () { ctx.sessionB.findings.save(entry, "B saved"); });
+    await act(async function () { ctx.session.findings.save(entry, "A draft"); });
+    expect(ctx.session.findings.error.kind).toBe("conflict");
+    expect(Object.values(ctx.session.findings.drafts)[0].note).toBe("A draft");
+    expect(ctx.sessionB.findings.items[0].note).toBe("B saved");
+    await act(async function () { ctx.session.findings.reload(); });
+    expect(ctx.session.findings.items[0].note).toBe("B saved");
+    expect(ctx.session.findings.drafts).toEqual({});
+    await app.unmount();
+  });
+
+  it("restores explicit export findings and drafts, isolates local notes, and validates ownership", async function () {
+    var ctx;
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "local.jsonl"); });
+    await act(async function () { ctx.session.findings.save({ index: 0, event: ctx.session.events[0] }, "Local private note"); });
+    var payload = ctx.session.findings.payload(FIXTURE_TEXT);
+    payload = { ...payload, items: payload.items.map(function (item) { return { ...item, note: "Shared note" }; }) };
+    window.__AGENTVIZ_STANDALONE__ = true;
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "offline.jsonl", null, payload); });
+    expect(ctx.session.findings.items[0].note).toBe("Shared note");
+    expect(ctx.session.findings.embedded).toBe(true);
+    await act(async function () { ctx.session.findings.remove(payload.items[0].id); });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "offline.jsonl", null, payload); });
+    expect(ctx.session.findings.items).toEqual([]);
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "legacy.jsonl"); });
+    expect(ctx.session.findings.items).toEqual([]);
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "bad-export.jsonl", null, { ...payload, snapshot: fingerprint("other") }); });
+    expect(ctx.session.findings.items).toEqual([]);
+    expect(ctx.session.findings.error.kind).toBe("corrupt");
+    expect(ctx.session.getRawText()).toBe(FIXTURE_TEXT);
+    delete window.__AGENTVIZ_STANDALONE__;
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "local.jsonl"); });
+    expect(ctx.session.findings.items[0].note).toBe("Local private note");
+    await app.unmount();
+  });
+
+  it("retains unavailable live findings through empty reset and never binds them after source reorder", async function () {
+    var ctx;
+    vi.stubGlobal("EventSource", class { close() {} });
+    global.fetch = vi.fn(async function (url) {
+      if (String(url).includes("/api/meta")) return { ok: true, json: async function () { return { filename: "live.jsonl", live: true }; } };
+      if (String(url).includes("/api/file")) return { ok: true, text: async function () { return FIXTURE_TEXT; } };
+      return { ok: false };
+    });
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await waitFor(function () { return ctx?.session.events?.length; });
+    await act(async function () { ctx.session.findings.save({ index: 0, event: ctx.session.events[0] }, "Live note"); });
+    var newLine = JSON.stringify({ type: "user.message", id: "later", timestamp: "2026-01-15T10:03:00.000Z", data: { content: "Later" } });
+    await act(async function () { ctx.session.appendLines(newLine, false); });
+    expect(ctx.session.findings.entries[0].available).toBe(true);
+    await act(async function () { ctx.session.appendLines("", true); });
+    expect(ctx.session.findings.entries[0]).toMatchObject({ note: "Live note", available: false });
+    await act(async function () { ctx.session.appendLines(FIXTURE_TEXT.replace("Can you add", "Changed prompt"), false); });
+    expect(ctx.session.findings.entries[0].available).toBe(false);
+    await act(async function () { ctx.session.appendLines(FIXTURE_TEXT, true); });
+    expect(ctx.session.findings.entries[0].available).toBe(true);
+    await app.unmount();
+  });
+
+  it("does not overwrite corrupt findings and recovers when storage is repaired", async function () {
+    var ctx;
+    var id = findingsSessionId(parseSessionText(FIXTURE_TEXT).result.metadata, FIXTURE_TEXT);
+    global.localStorage.setItem(FINDINGS_PREFIX + id, "{corrupt");
+    var app = await renderProvider({ onContext: function (value) { ctx = value; } });
+    await act(async function () { await ctx.handleFile(FIXTURE_TEXT, "a.jsonl"); });
+    expect(ctx.session.findings.error.kind).toBe("corrupt");
+    await act(async function () { ctx.session.findings.save({ index: 0, event: ctx.session.events[0] }, "Memory"); });
+    expect(global.localStorage.getItem(FINDINGS_PREFIX + id)).toBe("{corrupt");
+    expect(ctx.session.storageStatus.saved).toBe(true);
+    global.localStorage.removeItem(FINDINGS_PREFIX + id);
+    await act(async function () { ctx.session.findings.retry(); });
+    expect(ctx.session.findings.error).toBeNull();
+    expect(ctx.session.findings.items[0].note).toBe("Memory");
+    await app.unmount();
+  });
+
   it("keeps a parsed import usable on storage failure, retries saving, and retains state on failed loads", async function () {
     var ctx;
     var app = await renderProvider({ onContext: function (value) { ctx = value; } });
@@ -178,6 +348,7 @@ describe("SessionProvider", function () {
       expect(ctx.storageError.kind).toBe("access");
       await act(async function () { expect(await ctx.handleFile(FIXTURE_TEXT, "blocked.jsonl")).toBe(true); });
       expect(ctx.session.storageStatus.saved).toBe(false);
+      expect(ctx.session.findings.error.kind).toBe("access");
       expect(ctx.session.getRawText()).toBe(FIXTURE_TEXT);
       await act(async function () { await ctx.refreshSessions(); });
       expect(ctx.storageError.kind).toBe("access");
@@ -533,12 +704,14 @@ describe("SessionProvider", function () {
         && exportMocks.exportComparison.mock.calls.length === 1;
     }, "expected export helpers to run");
 
-    expect(exportMocks.exportSingleSession).toHaveBeenCalledWith(FIXTURE_TEXT, "fixture-a.jsonl");
+    expect(exportMocks.exportSingleSession).toHaveBeenCalledWith(FIXTURE_TEXT, "fixture-a.jsonl", expect.objectContaining({ version: 1, items: [] }));
     expect(exportMocks.exportComparison).toHaveBeenCalledWith(
       FIXTURE_TEXT,
       "fixture-a.jsonl",
       FIXTURE_TEXT,
       "fixture-b.jsonl",
+      expect.objectContaining({ version: 1, items: [] }),
+      expect.objectContaining({ version: 1, items: [] }),
     );
 
     await app.unmount();

--- a/src/components/Icon.jsx
+++ b/src/components/Icon.jsx
@@ -44,6 +44,7 @@ import {
   RefreshCw,
   Tag,
   Copy,
+  Bookmark,
 } from "lucide-react";
 
 var ICON_MAP = {
@@ -92,6 +93,7 @@ var ICON_MAP = {
   "refresh-cw": RefreshCw,
   tag: Tag,
   copy: Copy,
+  bookmark: Bookmark,
 };
 
 export default function Icon({ name, size, strokeWidth, style, className }) {

--- a/src/components/v2/FindingsPanel.jsx
+++ b/src/components/v2/FindingsPanel.jsx
@@ -1,0 +1,146 @@
+import { useMemo, useRef, useState } from "react";
+import { theme } from "../../lib/theme.js";
+import { MAX_NOTE_LENGTH, validateFindingsPayload } from "../../lib/findings";
+import { downloadText } from "../../lib/downloadText";
+import useAsyncStatus from "../../hooks/useAsyncStatus.js";
+import ToolbarButton from "../ui/ToolbarButton.jsx";
+import ExportStatusButton from "../ui/ExportStatusButton.jsx";
+
+function controlsStyle() {
+  return { display: "flex", flexWrap: "wrap", alignItems: "center", gap: theme.space.md };
+}
+
+export function FindingsRecovery({ session }) {
+  var download = useAsyncStatus();
+  var findings = session.findings;
+  var [confirmReload, setConfirmReload] = useState(false);
+  return (
+    <div style={controlsStyle()}>
+      {findings.error && <span role="status" style={{ color: theme.semantic.errorText, overflowWrap: "anywhere", flex: "1 1 240px" }}>
+        Findings not saved locally. {findings.error.message} Download findings before closing.
+      </span>}
+      {(findings.error || findings.dirty) && <ToolbarButton onClick={findings.retry}>Retry findings save</ToolbarButton>}
+      {findings.error && <ToolbarButton onClick={function () { setConfirmReload(true); }}>Reload saved findings</ToolbarButton>}
+      <ExportStatusButton state={download.state} error={download.error} label="Download findings"
+        title="Download bookmarks and note drafts as JSON, including unsaved and unavailable findings"
+        onClick={function () { download.run(function () {
+          downloadText(JSON.stringify(findings.payload(session.getRawText()), null, 2), "agentviz-findings.json", "application/json");
+        }); }} />
+      {download.error && <span role="alert" style={{ color: theme.semantic.errorText }}>{download.error}</span>}
+      {confirmReload && <div style={controlsStyle()}>
+        <span>Discard in-memory findings and drafts and reload the saved copy?</span>
+        <ToolbarButton onClick={function () { findings.reload(); setConfirmReload(false); }}>Discard edits and reload</ToolbarButton>
+        <ToolbarButton onClick={function () { setConfirmReload(false); }}>Cancel reload</ToolbarButton>
+      </div>}
+    </div>
+  );
+}
+
+export function FindingActions({ entry, findings }) {
+  var selected = findings.forEntry(entry);
+  var item = selected.item;
+  var draft = selected.draft;
+  return (
+    <div style={{ width: "100%", minWidth: 0, color: theme.text.secondary, fontSize: theme.reading.fontSize, lineHeight: 1.6 }}>
+      <div style={controlsStyle()}>
+        {!item && !draft && <ToolbarButton icon="bookmark" onClick={function () { findings.save(entry, ""); }}>Bookmark event</ToolbarButton>}
+        {item && <span role="status">{findings.dirty || findings.error ? "Bookmark not saved locally" : findings.embedded ? "Bookmark included in export" : "Bookmark saved locally"}</span>}
+        {!draft && <ToolbarButton icon="pencil" onClick={function () { findings.setDraft(entry, item ? item.note : ""); }}>
+          {item && item.note ? "Edit note" : "Add note"}
+        </ToolbarButton>}
+        {item && <ToolbarButton onClick={function () { findings.remove(item.id); }}>
+          {item.note || draft ? "Remove bookmark and note" : "Remove bookmark"}
+        </ToolbarButton>}
+      </div>
+      {item && item.note && !draft && <p style={{ margin: theme.space.md + "px 0", whiteSpace: "pre-wrap", overflowWrap: "anywhere" }}>{item.note}</p>}
+      {draft && <div style={{ marginTop: theme.space.md }}>
+        <label htmlFor={"finding-note-" + entry.index}>Event note</label>
+        <textarea id={"finding-note-" + entry.index} value={draft.note} maxLength={MAX_NOTE_LENGTH}
+          onChange={function (event) { findings.setDraft(entry, event.target.value); }}
+          rows={4} autoFocus
+          style={{ display: "block", boxSizing: "border-box", width: "100%", minWidth: 0, resize: "vertical",
+            margin: theme.space.sm + "px 0", padding: theme.space.md, border: "1px solid " + theme.border.default,
+            borderRadius: theme.radius.md, background: theme.bg.base, color: theme.text.primary,
+            fontFamily: theme.font.mono, fontSize: theme.reading.fontSize, lineHeight: 1.6 }} />
+        <div style={controlsStyle()}>
+          <ToolbarButton onClick={function () { findings.save(entry, draft.note); }}>Save note</ToolbarButton>
+          <ToolbarButton onClick={function () { findings.cancelDraft(selected.id); }}>Cancel note</ToolbarButton>
+          <span style={{ color: theme.text.muted }}>Unsaved draft · {draft.note.length}/{MAX_NOTE_LENGTH}</span>
+        </div>
+      </div>}
+    </div>
+  );
+}
+
+export default function FindingsPanel({ session, onJump }) {
+  var findings = session.findings;
+  var inputRef = useRef(null);
+  var [backup, setBackup] = useState(null);
+  var [importError, setImportError] = useState(null);
+  var [limit, setLimit] = useState(50);
+  var items = findings.entries;
+  var itemIds = useMemo(function () { return new Set(items.map(function (item) { return item.id; })); }, [items]);
+  var drafts = findings.draftEntries.filter(function (draft) { return !itemIds.has(draft.id); });
+  var rows = items.concat(drafts);
+  return (
+    <section id="investigate-bookmarks" aria-label="Bookmarks" style={{
+      flexShrink: 0, maxHeight: 240, overflow: "auto", padding: theme.space.lg + "px " + theme.space.xl + "px",
+      borderBottom: "1px solid " + theme.border.default, background: theme.bg.surface,
+      fontFamily: theme.font.mono, color: theme.text.secondary, fontSize: theme.reading.fontSize, lineHeight: 1.6,
+    }}>
+      <div style={controlsStyle()}>
+        <strong style={{ color: theme.text.primary }}>Bookmarks ({items.length})</strong>
+        <span role="status">{findings.dirty ? "Changes not saved locally" : findings.embedded ? "Included in export" : items.length && !findings.error ? "Saved locally" : ""}</span>
+        <ToolbarButton onClick={function () { inputRef.current.click(); }}>Restore findings</ToolbarButton>
+        <input ref={inputRef} type="file" accept=".json" aria-label="Restore findings backup" style={{ display: "none" }}
+          onChange={async function (event) {
+            var file = event.target.files[0];
+            event.target.value = "";
+            if (!file) return;
+            try {
+              var value = JSON.parse(await file.text());
+              setBackup(validateFindingsPayload(value, findings.sessionId, session.getRawText()));
+              setImportError(null);
+            } catch (error) { setImportError("This backup is invalid or belongs to a different transcript snapshot. Nothing was changed."); }
+          }} />
+      </div>
+      {!findings.error && !findings.dirty && !findings.draftEntries.length && <FindingsRecovery session={session} />}
+      {backup && <div style={controlsStyle()}>
+        <span>Replace this session's findings and drafts with this backup?</span>
+        <ToolbarButton onClick={function () {
+          try { findings.restore(backup, session.getRawText()); setBackup(null); }
+          catch (error) { setImportError("The transcript changed. Select a backup for the current snapshot."); }
+        }}>Replace with backup</ToolbarButton>
+        <ToolbarButton onClick={function () { setBackup(null); }}>Cancel restore</ToolbarButton>
+      </div>}
+      {importError && <p role="alert" style={{ color: theme.semantic.errorText }}>{importError}</p>}
+      {rows.length === 0 && <p style={{ margin: theme.space.md + "px 0 0" }}>No bookmarks yet. Select an event, then bookmark it or add a note.</p>}
+      <ul style={{ margin: theme.space.md + "px 0 0", padding: 0, listStyle: "none" }}>
+        {rows.slice(0, limit).map(function (item) {
+          var draft = findings.drafts[item.id];
+          return (
+            <li key={item.id} style={{ borderTop: "1px solid " + theme.border.default, padding: theme.space.md + "px 0" }}>
+              <div style={controlsStyle()}>
+                <ToolbarButton disabled={!item.available} onClick={function () { onJump(item.anchor.index); }}
+                  aria-label={"Jump to bookmarked event " + (item.anchor.index + 1)}
+                  style={{ minHeight: theme.reading.controlMin, maxWidth: "100%", color: theme.text.primary }}>
+                  Event {item.anchor.index + 1}
+                </ToolbarButton>
+                <span style={{ flex: "1 1 200px", minWidth: 0, overflowWrap: "anywhere" }}>{item.label}</span>
+                {draft && <span>Unsaved note draft</span>}
+                {!item.available && <span>Unavailable in this snapshot</span>}
+                <ToolbarButton onClick={function () { findings.remove(item.id); }}>
+                  {item.note || draft ? "Remove bookmark and note" : "Remove bookmark"}
+                </ToolbarButton>
+              </div>
+              {(draft ? draft.note : item.note) && <p style={{ whiteSpace: "pre-wrap", overflowWrap: "anywhere", margin: theme.space.sm + "px 0 0" }}>
+                {draft ? draft.note : item.note}
+              </p>}
+            </li>
+          );
+        })}
+      </ul>
+      {rows.length > limit && <ToolbarButton onClick={function () { setLimit(function (value) { return value + 50; }); }}>Show next 50 findings</ToolbarButton>}
+    </section>
+  );
+}

--- a/src/components/v2/InvestigateView.jsx
+++ b/src/components/v2/InvestigateView.jsx
@@ -5,6 +5,7 @@ import ReplayView from "../ReplayView.jsx";
 import ToolbarButton from "../ui/ToolbarButton.jsx";
 import Icon from "../Icon.jsx";
 import { V2ZoneHeader } from "./V2ShellPrimitives.jsx";
+import FindingsPanel, { FindingActions } from "./FindingsPanel.jsx";
 
 function ActionButton({ children, icon, onClick, tone }) {
   return (
@@ -87,6 +88,7 @@ function buildEntryActions(entry, onNavigate) {
 export default function InvestigateView({ session, targetEventIndex, targetRequest, onNavigate }) {
   var pb = usePlaybackContext();
   var [errorsOnly, setErrorsOnly] = useState(false);
+  var [showBookmarks, setShowBookmarks] = useState(false);
   var handledTargetRef = useRef({ session: null, eventIndex: null });
   var visibleEntries = useMemo(function () {
     return errorsOnly
@@ -142,9 +144,13 @@ export default function InvestigateView({ session, targetEventIndex, targetReque
       <V2ZoneHeader
         eyebrow="Investigate"
         title="Evidence stream"
-        description="Select an event to reveal Compare, Analyze, and Coach actions."
+        description="Select an event to bookmark, annotate, compare, analyze, or ask."
         actions={(
           <>
+          {session.findings && <ToolbarButton icon="bookmark" aria-expanded={showBookmarks} aria-controls="investigate-bookmarks"
+            onClick={function () { setShowBookmarks(function (value) { return !value; }); }}>
+            Bookmarks{session.findings.items.length ? " (" + session.findings.items.length + ")" : ""}
+          </ToolbarButton>}
           <ToolbarButton onClick={function () { if (onNavigate) onNavigate("review"); }}>
             Back to Review
           </ToolbarButton>
@@ -154,6 +160,9 @@ export default function InvestigateView({ session, targetEventIndex, targetReque
           </>
         )}
       />
+      {showBookmarks && session.findings && <FindingsPanel session={session} onJump={function (index) {
+        if (onNavigate) onNavigate("investigate", { eventIndex: index });
+      }} />}
 
       <div style={{
         flexShrink: 0,
@@ -316,7 +325,7 @@ export default function InvestigateView({ session, targetEventIndex, targetReque
           overflow: "hidden",
         }}>
           <ReplayView
-            events={session.events}
+            events={session.events || []}
             currentTime={pb.playback.time}
             eventEntries={visibleEntries}
             turns={session.turns}
@@ -330,6 +339,7 @@ export default function InvestigateView({ session, targetEventIndex, targetReque
               return (
                 <div style={{ display: "flex", gap: theme.space.sm, flexWrap: "wrap" }}>
                   {buildEntryActions(props.entry, onNavigate)}
+                  {session.findings && <FindingActions entry={props.entry} findings={session.findings} />}
                 </div>
               );
             }}

--- a/src/components/v2/SessionStorageNotice.jsx
+++ b/src/components/v2/SessionStorageNotice.jsx
@@ -3,6 +3,7 @@ import { downloadText } from "../../lib/downloadText";
 import useAsyncStatus from "../../hooks/useAsyncStatus.js";
 import ExportStatusButton from "../ui/ExportStatusButton.jsx";
 import ToolbarButton from "../ui/ToolbarButton.jsx";
+import { FindingsRecovery } from "./FindingsPanel.jsx";
 
 function rowStyle() { return {
   display: "flex",
@@ -67,6 +68,15 @@ export default function SessionStorageNotice({ sessionState }) {
       )}
       <ActiveCopy key={"a-" + state.session.sessionKey} loader={state.session} label="A" />
       <ActiveCopy key={"b-" + state.sessionB.sessionKey} loader={state.sessionB} label="B" />
+      {[state.session, state.sessionB].map(function (loader, index) {
+        var findings = loader.findings;
+        if (!findings || (!findings.error && !findings.dirty && !Object.keys(findings.drafts).length)) return null;
+        return <div key={index + "-" + loader.sessionKey} style={rowStyle()}>
+          <span>{index === 0 ? "A" : "B"} findings: {Object.keys(findings.drafts).length > 0 ? "Unsaved note drafts. " : ""}
+            {findings.dirty && !findings.error ? "Changes not saved locally." : ""}</span>
+          <FindingsRecovery session={loader} />
+        </div>;
+      })}
       {state.evictedIds.length > 0 && (
         <div style={rowStyle()}>
           <span role="status" style={{ flex: "1 1 280px" }}>

--- a/src/contexts/SessionProvider.jsx
+++ b/src/contexts/SessionProvider.jsx
@@ -134,8 +134,8 @@ export function SessionProvider({ children }) {
     if (!compareData || !compareData.a || !compareData.b) return;
     delete window.__AGENTVIZ_COMPARE__;
     setComparisonActive(true);
-    session.handleFile(compareData.a.text, compareData.a.name);
-    sessionB.handleFile(compareData.b.text, compareData.b.name);
+    session.handleFile(compareData.a.text, compareData.a.name, null, compareData.a.findings);
+    sessionB.handleFile(compareData.b.text, compareData.b.name, null, compareData.b.findings);
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   useLiveStream({
@@ -152,12 +152,12 @@ export function SessionProvider({ children }) {
     return { summary: buildAutonomySummary(autonomyMetrics) };
   }, [autonomyMetrics]);
 
-  var handleFile = useCallback(function (text, name, sourcePath) {
+  var handleFile = useCallback(function (text, name, sourcePath, embeddedFindings) {
     sessionLoadCount.current += 1;
     sessionB.cancelPendingLoad();
     setLoadError(null);
-    setRetryLoad(function () { return function () { return handleFile(text, name, sourcePath); }; });
-    return session.handleFile(text, name, sourcePath).then(function (success) {
+    setRetryLoad(function () { return function () { return handleFile(text, name, sourcePath, embeddedFindings); }; });
+    return session.handleFile(text, name, sourcePath, embeddedFindings).then(function (success) {
       if (success) {
         setComparisonActive(false);
         sessionB.resetSession();
@@ -310,8 +310,6 @@ export function SessionProvider({ children }) {
     if (!entry) return Promise.resolve(false);
     var currentRaw = session.getRawText();
     if (!currentRaw) return Promise.resolve(false);
-    var currentName = session.file || "current-session.jsonl";
-    var currentSourcePath = session.sourcePath || null;
     var requestId = ++sessionLoadCount.current;
     session.beginLoad();
     sessionB.beginLoad();
@@ -322,10 +320,10 @@ export function SessionProvider({ children }) {
       .then(async function (text) {
         if (requestId !== sessionLoadCount.current) return false;
         if (!text || !parseSessionText(text).result) throw new Error("Invalid comparison session");
-        var results = await Promise.all([
-          session.handleFile(currentRaw, currentName, currentSourcePath),
-          sessionB.handleFile(text, entry.file || entry.summary || entry.filename || "session-b.jsonl", entry.discoveredPath || null),
-        ]);
+        // A is already active. Do not replace its findings or unsaved drafts
+        // merely to load B.
+        session.failLoad(null);
+        var results = [await sessionB.handleFile(text, entry.file || entry.summary || entry.filename || "session-b.jsonl", entry.discoveredPath || null)];
         if (requestId !== sessionLoadCount.current || !results.every(Boolean)) return false;
         setComparisonActive(true);
         return true;
@@ -361,14 +359,14 @@ export function SessionProvider({ children }) {
   var openCompareSessionInCoach = useCallback(function (loader) {
     var rawText = loader.getRawText();
     if (!rawText) return Promise.resolve(false);
-    return handleFile(rawText, loader.file, loader.sourcePath);
+    return handleFile(rawText, loader.file, loader.sourcePath, loader.findings.payload(rawText));
   }, [handleFile]);
 
   var handleExportSession = useCallback(function () {
     var rawText = session.getRawText();
     if (!rawText) return;
     sessionExport.run(function () {
-      return exportSingleSession(rawText, session.file);
+      return exportSingleSession(rawText, session.file, session.findings.payload(rawText));
     });
   }, [session.getRawText, session.file, sessionExport]);
 
@@ -377,7 +375,7 @@ export function SessionProvider({ children }) {
     var rawB = sessionB.getRawText();
     if (!rawA || !rawB) return;
     compareExport.run(function () {
-      return exportComparison(rawA, session.file, rawB, sessionB.file);
+      return exportComparison(rawA, session.file, rawB, sessionB.file, session.findings.payload(rawA), sessionB.findings.payload(rawB));
     });
   }, [compareExport, session.getRawText, session.file, sessionB.getRawText, sessionB.file]);
 

--- a/src/hooks/useFindings.js
+++ b/src/hooks/useFindings.js
@@ -1,0 +1,156 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  FINDINGS_CHANGED, FINDINGS_PREFIX, anchorId, buildEventAnchors, createFinding,
+  findingsError, findingsSessionId, fingerprint, matchesAnchor, readFindings,
+  saveFindings, validateFindingsPayload,
+} from "../lib/findings";
+
+function emptyState() {
+  return { sessionId: null, storageId: null, items: [], baseline: [], drafts: {}, error: null, dirty: false, embedded: false };
+}
+
+export default function useFindings(events) {
+  var [state, setState] = useState(emptyState);
+  var current = useRef(state);
+  var anchors = useMemo(function () { return buildEventAnchors(events || []); }, [events]);
+  function update(next) { current.current = next; setState(next); }
+
+  var open = useCallback(function (metadata, text, embedded, standalone) {
+    var sessionId = findingsSessionId(metadata, text);
+    var next = Object.assign(emptyState(), { sessionId: sessionId, storageId: sessionId });
+    if (standalone) {
+      // Each export owns its local edits. Never read the normal session's notes
+      // into a received export, even when it has the same explicit session ID.
+      try {
+        var payload = embedded === undefined
+          ? { version: 1, sessionId: sessionId, snapshot: fingerprint(text), items: [], drafts: [] }
+          : validateFindingsPayload(embedded, sessionId, text);
+        next.storageId = "export:" + fingerprint(JSON.stringify(payload));
+        next.items = payload.items;
+        next.drafts = Object.fromEntries((payload.drafts || []).map(function (item) { return [item.id, item]; }));
+        next.embedded = true;
+        var local = readFindings(next.storageId);
+        // The payload is authoritative unless there are edits for this exact
+        // export, stored in its own namespace.
+        next.baseline = local.items;
+        if (local.exists) { next.items = local.items; next.embedded = false; }
+        next.error = local.error;
+      } catch (error) {
+        next.storageId = null;
+        next.error = findingsError(error);
+      }
+    } else {
+      var saved = readFindings(sessionId);
+      next.items = saved.items || [];
+      next.baseline = saved.items;
+      next.error = saved.error;
+      if (embedded !== undefined) {
+        try {
+          var transferred = validateFindingsPayload(embedded, sessionId, text);
+          next.items = transferred.items;
+          next.drafts = Object.fromEntries(transferred.drafts.map(function (item) { return [item.id, item]; }));
+          next.dirty = JSON.stringify(next.items) !== JSON.stringify(next.baseline);
+        } catch (error) { next.error = findingsError(error); }
+      }
+    }
+    update(next);
+  }, []);
+
+  var close = useCallback(function () { update(emptyState()); }, []);
+  var persist = useCallback(function (items, drafts) {
+    var previous = current.current;
+    var saved = previous.storageId
+      ? saveFindings(previous.storageId, items, previous.baseline)
+      : { items: null, error: previous.error || { kind: "access", message: "Findings cannot be saved for this session. Download findings to keep them." } };
+    update(Object.assign({}, previous, {
+      items: saved.items || items, baseline: saved.items || previous.baseline,
+      drafts: drafts || previous.drafts, dirty: Boolean(saved.error), error: saved.error, embedded: false,
+    }));
+    if (!saved.error) window.dispatchEvent(new CustomEvent(FINDINGS_CHANGED, { detail: previous.storageId }));
+    return !saved.error;
+  }, []);
+  var retry = useCallback(function () {
+    var previous = current.current;
+    var saved = persist(previous.items);
+    if (saved) {
+      var notes = new Map(current.current.items.map(function (item) { return [item.id, item.note]; }));
+      var drafts = Object.fromEntries(Object.entries(current.current.drafts).filter(function (entry) {
+        return notes.get(entry[0]) !== entry[1].note;
+      }));
+      update(Object.assign({}, current.current, { drafts: drafts }));
+    }
+    return saved;
+  }, [persist]);
+  var reload = useCallback(function () {
+    var previous = current.current;
+    if (!previous.storageId) return;
+    var saved = readFindings(previous.storageId);
+    if (saved.error) update(Object.assign({}, previous, { error: saved.error }));
+    else update(Object.assign({}, previous, { items: saved.items, baseline: saved.items, drafts: {}, error: null, dirty: false, embedded: false }));
+  }, []);
+
+  useEffect(function () {
+    function changed(event) {
+      var previous = current.current;
+      if (!previous.storageId || (event.type === FINDINGS_CHANGED ? event.detail !== previous.storageId
+        : event.key && event.key !== FINDINGS_PREFIX + previous.storageId)) return;
+      if (previous.dirty || previous.embedded || Object.keys(previous.drafts).length) return;
+      var saved = readFindings(previous.storageId);
+      update(Object.assign({}, previous, { items: saved.items || previous.items, baseline: saved.items || previous.baseline, error: saved.error }));
+    }
+    window.addEventListener("storage", changed);
+    window.addEventListener(FINDINGS_CHANGED, changed);
+    return function () {
+      window.removeEventListener("storage", changed);
+      window.removeEventListener(FINDINGS_CHANGED, changed);
+    };
+  }, []);
+
+  function setDraft(entry, note) {
+    var anchor = anchors[entry.index];
+    if (!anchor) return;
+    var item = createFinding(anchor, entry.event, note);
+    update(Object.assign({}, current.current, { drafts: Object.assign({}, current.current.drafts, { [item.id]: item }) }));
+  }
+  function cancelDraft(id) {
+    var drafts = Object.assign({}, current.current.drafts);
+    delete drafts[id];
+    update(Object.assign({}, current.current, { drafts: drafts }));
+  }
+  function save(entry, note) {
+    var anchor = anchors[entry.index];
+    if (!anchor) return;
+    var item = createFinding(anchor, entry.event, note);
+    if (persist(current.current.items.filter(function (existing) { return existing.id !== item.id; }).concat(item))) cancelDraft(item.id);
+  }
+  function remove(id) {
+    var drafts = Object.assign({}, current.current.drafts);
+    delete drafts[id];
+    persist(current.current.items.filter(function (item) { return item.id !== id; }), drafts);
+  }
+  function payload(text) {
+    var previous = current.current;
+    return { version: 1, sessionId: previous.sessionId, snapshot: fingerprint(text),
+      items: previous.items, drafts: Object.values(previous.drafts) };
+  }
+  function restore(value, text) {
+    var restored = validateFindingsPayload(value, current.current.sessionId, text);
+    return persist(restored.items, Object.fromEntries(restored.drafts.map(function (item) { return [item.id, item]; })));
+  }
+  var byId = useMemo(function () { return new Map(state.items.map(function (item) { return [item.id, item]; })); }, [state.items]);
+  var entries = useMemo(function () {
+    return state.items.map(function (item) { return Object.assign({}, item, { available: matchesAnchor(item.anchor, anchors) }); });
+  }, [state.items, anchors]);
+  return Object.assign({}, state, {
+    open: open, close: close, retry: retry, reload: reload, save: save, remove: remove,
+    setDraft: setDraft, cancelDraft: cancelDraft, payload: payload, restore: restore, entries: entries,
+    forEntry: function (entry) {
+      var anchor = anchors[entry.index];
+      var id = anchor && anchorId(anchor);
+      return { id: id, item: byId.get(id), draft: state.drafts[id] };
+    },
+    draftEntries: Object.values(state.drafts).map(function (item) {
+      return Object.assign({}, item, { available: matchesAnchor(item.anchor, anchors) });
+    }),
+  });
+}

--- a/src/hooks/useSessionLoader.js
+++ b/src/hooks/useSessionLoader.js
@@ -5,6 +5,7 @@ import { SAMPLE_EVENTS, SAMPLE_TOTAL, SAMPLE_TURNS, SAMPLE_METADATA, MULTIAGENT_
 import { getSessionTotal } from "../lib/session";
 import { buildAppliedSession, parseSessionText } from "../lib/sessionParsing";
 import { createLiveParserClient } from "../lib/liveParserClient";
+import useFindings from "./useFindings.js";
 
 export var LIVE_NOTIFY_DEBOUNCE_MS = 250;
 
@@ -16,6 +17,7 @@ export default function useSessionLoader(options) {
   var autoBootstrap = !options || options.autoBootstrap !== false;
   var onSessionParsed = options ? options.onSessionParsed : null;
   var [events, setEvents] = useState(null);
+  var findings = useFindings(events);
   var [turns, setTurns] = useState([]);
   var [metadata, setMetadata] = useState(null);
   var [total, setTotal] = useState(0);
@@ -28,6 +30,7 @@ export default function useSessionLoader(options) {
   var [streamOffset, setStreamOffset] = useState(null);
   var [storageStatus, setStorageStatus] = useState(null);
   var snapshotRef = useRef(null);
+  var findingsIdentityRef = useRef(null);
   var pendingCompletionRef = useRef(null);
   var parseTimeoutRef = useRef(null);
   var liveNotifyTimeoutRef = useRef(null);
@@ -138,7 +141,7 @@ export default function useSessionLoader(options) {
     setError(message);
   }, []);
 
-  var handleFile = useCallback(function (text, name, nextSourcePath) {
+  var handleFile = useCallback(function (text, name, nextSourcePath, embeddedFindings) {
     beginLoad();
     var requestId = requestIdRef.current;
     return new Promise(function (resolve) {
@@ -162,11 +165,13 @@ export default function useSessionLoader(options) {
         if (nextSourcePath) parsed.result.metadata.sourcePath = nextSourcePath;
         resetLiveParser(text);
         applySession(parsed.result, name, nextSourcePath);
+        findings.open(parsed.result.metadata, text, embeddedFindings, Boolean(window.__AGENTVIZ_STANDALONE__));
+        findingsIdentityRef.current = parsed.result.metadata.sessionId || true;
         notifySessionParsed(parsed.result, name, text);
         resolve(true);
       }, 16);
     });
-  }, [beginLoad, applySession, notifySessionParsed, resetLiveParser]);
+  }, [beginLoad, applySession, notifySessionParsed, resetLiveParser, findings.open]);
 
   // Called by useLiveStream with each batch of new JSONL lines.
   // Parses only appended lines and rebuilds normalized session output from the
@@ -189,6 +194,11 @@ export default function useSessionLoader(options) {
           function (updated) {
             if (requestId !== requestIdRef.current) return;
             if (updated.result && sourcePath) updated.result.metadata.sourcePath = sourcePath;
+            if (updated.result && (!findingsIdentityRef.current
+              || (updated.result.metadata.sessionId && updated.result.metadata.sessionId !== findingsIdentityRef.current))) {
+              findings.open(updated.result.metadata, updated.rawText);
+              findingsIdentityRef.current = updated.result.metadata.sessionId || true;
+            }
             rawTextRef.current = updated.rawText;
             setEvents(updated.result ? updated.result.events : null);
             setTurns(updated.result ? updated.result.turns : []);
@@ -216,13 +226,18 @@ export default function useSessionLoader(options) {
       notifyLiveSessionParsed(null, file, rawTextRef.current);
       return;
     }
+    if (!findingsIdentityRef.current
+      || (updated.result.metadata.sessionId && updated.result.metadata.sessionId !== findingsIdentityRef.current)) {
+      findings.open(updated.result.metadata, updated.state.rawText);
+      findingsIdentityRef.current = updated.result.metadata.sessionId || true;
+    }
 
     setEvents(updated.result.events);
     setTurns(updated.result.turns);
     setMetadata(updated.result.metadata);
     setTotal(getSessionTotal(updated.result.events));
     notifyLiveSessionParsed(updated.result, file || "live-session.jsonl", updated.state.rawText);
-  }, [file, sourcePath, notifyLiveSessionParsed, resetLiveParser, clearLiveNotify]);
+  }, [file, sourcePath, notifyLiveSessionParsed, resetLiveParser, clearLiveNotify, findings.open]);
 
   var loadSample = useCallback(function (mode) {
     cancelPendingLoad();
@@ -235,6 +250,7 @@ export default function useSessionLoader(options) {
     setEvents(isMultiAgent ? MULTIAGENT_SAMPLE_EVENTS : SAMPLE_EVENTS);
     setTurns(isMultiAgent ? MULTIAGENT_SAMPLE_TURNS : SAMPLE_TURNS);
     setMetadata(isMultiAgent ? MULTIAGENT_SAMPLE_METADATA : SAMPLE_METADATA);
+    findings.open({ format: "demo", sessionId: isMultiAgent ? "multiagent" : "default" }, "");
     setTotal(isMultiAgent ? MULTIAGENT_SAMPLE_TOTAL : SAMPLE_TOTAL);
     setFile(isMultiAgent ? "multiagent-demo.jsonl" : "demo-session.jsonl");
     setSourcePath(null);
@@ -242,13 +258,15 @@ export default function useSessionLoader(options) {
     setLoading(false);
     setIsLive(false);
     setSessionKey(function (key) { return key + 1; });
-  }, [resetLiveParser, cancelPendingLoad]);
+  }, [resetLiveParser, cancelPendingLoad, findings.open]);
 
   var resetSession = useCallback(function () {
     cancelPendingLoad();
 
     rawTextRef.current = "";
     snapshotRef.current = null;
+    findings.close();
+    findingsIdentityRef.current = null;
     setStorageStatus(null);
     resetLiveParser("");
     setEvents(null);
@@ -261,7 +279,7 @@ export default function useSessionLoader(options) {
     setLoading(false);
     setIsLive(false);
     setSessionKey(function (key) { return key + 1; });
-  }, [resetLiveParser, cancelPendingLoad]);
+  }, [resetLiveParser, cancelPendingLoad, findings.close]);
 
   // When served by the CLI (server.js), /api/meta tells us the filename
   // and /api/file provides the initial content. Bootstrap from there.
@@ -299,6 +317,9 @@ export default function useSessionLoader(options) {
             setFile(meta.filename);
             setSourcePath(meta.path || null);
             setError(null);
+            findings.open(parsed.result ? parsed.result.metadata : { format: "live", sessionId: meta.path || meta.filename },
+              text, meta.findings, Boolean(window.__AGENTVIZ_STANDALONE__));
+            findingsIdentityRef.current = parsed.result ? parsed.result.metadata.sessionId || true : null;
             if (!parsed.result) return;
             applySession(parsed.result, meta.filename, meta.path);
             notifySessionParsed(parsed.result, meta.filename, text);
@@ -308,7 +329,7 @@ export default function useSessionLoader(options) {
         if (isCurrent()) failLoad(err.message || "Unable to load the session. Reimport it from Find.");
       });
     return function () { cancelled = true; };
-  }, [autoBootstrap, notifySessionParsed, resetLiveParser, applySession, failLoad]);
+  }, [autoBootstrap, notifySessionParsed, resetLiveParser, applySession, failLoad, findings.open]);
 
   useEffect(function () {
     return function () {
@@ -318,6 +339,7 @@ export default function useSessionLoader(options) {
 
   return {
     events: events,
+    findings: findings,
     turns: turns,
     metadata: metadata,
     total: total,

--- a/src/lib/exportHtml.js
+++ b/src/lib/exportHtml.js
@@ -220,7 +220,7 @@ var BOOT_SCRIPT = `
       }
       var route = target.slice(apiIndex);
       if (session && route.indexOf("/api/meta") === 0) {
-        return jsonResponse({ filename: session.filename, live: false });
+        return jsonResponse({ filename: session.filename, live: false, findings: session.findings });
       }
       if (session && route.indexOf("/api/file") === 0) {
         return Promise.resolve(new Response(session.text, {
@@ -578,18 +578,18 @@ function downloadHtml(html, filename) {
 
 // Export a single session as a self-contained HTML file.
 // rawText: the full JSONL content; filename: original file name.
-export async function exportSingleSession(rawText, filename) {
+export async function exportSingleSession(rawText, filename, findings) {
   var html = await buildExportHtml("AGENTVIZ - " + filename, {
-    session: { filename: filename, text: rawText },
+    session: { filename: filename, text: rawText, findings: findings },
   });
   var exportName = filename.replace(/\.jsonl$/, "") + "-agentviz.html";
   downloadHtml(html, exportName);
 }
 
 // Export a side-by-side comparison as a self-contained HTML file.
-export async function exportComparison(rawTextA, filenameA, rawTextB, filenameB) {
+export async function exportComparison(rawTextA, filenameA, rawTextB, filenameB, findingsA, findingsB) {
   var html = await buildExportHtml("AGENTVIZ - Comparison", {
-    compare: { a: { name: filenameA, text: rawTextA }, b: { name: filenameB, text: rawTextB } },
+    compare: { a: { name: filenameA, text: rawTextA, findings: findingsA }, b: { name: filenameB, text: rawTextB, findings: findingsB } },
   });
   downloadHtml(html, "comparison-agentviz.html");
 }

--- a/src/lib/findings.ts
+++ b/src/lib/findings.ts
@@ -1,0 +1,176 @@
+export const FINDINGS_PREFIX = "agentviz:findings:v1:";
+export const FINDINGS_CHANGED = "agentviz:findings-changed";
+export const MAX_NOTE_LENGTH = 20000;
+
+export interface EventAnchor {
+  index: number;
+  fingerprint: string;
+  occurrence: number;
+  prefix: string;
+}
+export interface Finding {
+  id: string;
+  anchor: EventAnchor;
+  label: string;
+  note: string;
+}
+export interface FindingsPayload {
+  version: 1;
+  sessionId: string;
+  snapshot: string;
+  items: Finding[];
+  drafts?: Finding[];
+}
+export interface FindingsError { kind: string; message: string }
+
+// Two independently mixed words plus length. These fingerprints are identity
+// guards, not cryptographic signatures or authentication.
+export function fingerprint(text: string): string {
+  let a = 0xdeadbeef, b = 0x41c6ce57;
+  for (let i = 0; i < text.length; i++) {
+    a = Math.imul(a ^ text.charCodeAt(i), 2654435761);
+    b = Math.imul(b ^ text.charCodeAt(i), 1597334677);
+  }
+  a = Math.imul(a ^ (a >>> 16), 2246822507) ^ Math.imul(b ^ (b >>> 13), 3266489909);
+  b = Math.imul(b ^ (b >>> 16), 2246822507) ^ Math.imul(a ^ (a >>> 13), 3266489909);
+  return (a >>> 0).toString(16).padStart(8, "0") + (b >>> 0).toString(16).padStart(8, "0") + ":" + text.length;
+}
+
+function canonical(value: unknown): string {
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return "[" + value.map(canonical).join(",") + "]";
+  const obj = value as Record<string, unknown>;
+  return "{" + Object.keys(obj).sort().map(key => JSON.stringify(key) + ":" + canonical(obj[key])).join(",") + "}";
+}
+
+export function findingsSessionId(metadata: Record<string, unknown> | null, rawText: string): string {
+  const format = metadata?.format || "session";
+  if (metadata?.sessionId) return format + ":id:" + metadata.sessionId;
+  // Names and discovery paths are transport metadata, not session identity.
+  // JSONL's first complete source record survives append and renamed reimports.
+  // A single JSON document without an explicit ID remains snapshot-specific.
+  let source: unknown;
+  try { source = JSON.parse(rawText); }
+  catch {
+    const first = rawText.match(/^[ \t]*\S[^\r\n]*/m)?.[0] || "";
+    try { source = JSON.parse(first); } catch { source = rawText; }
+  }
+  return format + ":source:" + fingerprint(canonical(source));
+}
+
+function objectRecord(value: unknown): Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown> : {};
+}
+
+export function buildEventAnchors(events: Array<Record<string, unknown>>): EventAnchor[] {
+  const occurrences = new Map<string, number>();
+  let prefix = "start";
+  return events.map((event, index) => {
+    const raw = objectRecord(event.raw);
+    // Completion output, duration, usage, and inferred live metadata can change.
+    // Use source IDs/timestamps and the original action, not those aggregates.
+    const evidence = [event.t, event.agent, event.track, event.text, event.toolName, event.toolInput,
+      event.toolCallId, raw.uuid, raw.id, raw.timestamp, raw.ts, raw.type,
+      typeof event.raw === "string" ? event.raw : null,
+      raw.text, raw.thinking, raw.value, raw.content, objectRecord(raw.message).content,
+      objectRecord(raw.data).content, objectRecord(raw.payload).text,
+      objectRecord(raw.payload).message, objectRecord(raw.payload).arguments];
+    const fp = fingerprint(canonical(evidence));
+    const occurrence = occurrences.get(fp) || 0;
+    occurrences.set(fp, occurrence + 1);
+    prefix = fingerprint(prefix + "|" + fp);
+    return { index, fingerprint: fp, occurrence, prefix };
+  });
+}
+
+export function anchorId(anchor: EventAnchor): string {
+  return anchor.index + ":" + anchor.occurrence + ":" + anchor.fingerprint + ":" + anchor.prefix;
+}
+
+export function matchesAnchor(anchor: EventAnchor, anchors: EventAnchor[]): boolean {
+  const current = anchors[anchor.index];
+  return Boolean(current && anchorId(current) === anchorId(anchor));
+}
+
+export function createFinding(anchor: EventAnchor, event: Record<string, unknown>, note = ""): Finding {
+  return { id: anchorId(anchor), anchor, label: String(event.text || event.toolName || event.track || "Event").slice(0, 180), note };
+}
+
+function validateItems(value: unknown): Finding[] {
+  if (!Array.isArray(value)) throw new SyntaxError("Invalid findings");
+  const ids = new Set<string>();
+  return value.map(item => {
+    const a = item?.anchor;
+    if (!a || !Number.isSafeInteger(a.index) || a.index < 0
+      || !Number.isSafeInteger(a.occurrence) || a.occurrence < 0
+      || typeof a.fingerprint !== "string" || a.fingerprint.length > 100
+      || typeof a.prefix !== "string" || a.prefix.length > 100
+      || typeof item.label !== "string" || item.label.length > 180
+      || typeof item.note !== "string" || item.note.length > MAX_NOTE_LENGTH
+      || item.id !== anchorId(a) || ids.has(item.id)) throw new SyntaxError("Invalid finding");
+    ids.add(item.id);
+    return { id: item.id, anchor: { index: a.index, fingerprint: a.fingerprint, occurrence: a.occurrence, prefix: a.prefix },
+      label: item.label, note: item.note };
+  });
+}
+
+export function validateFindingsPayload(value: unknown, sessionId: string, rawText: string): FindingsPayload {
+  const payload = value as FindingsPayload;
+  if (!payload || payload.version !== 1 || payload.sessionId !== sessionId
+    || payload.snapshot !== fingerprint(rawText)) throw new SyntaxError("Findings do not belong to this transcript");
+  return { version: 1, sessionId, snapshot: payload.snapshot, items: validateItems(payload.items),
+    drafts: validateItems(payload.drafts || []) };
+}
+
+function getStorage(storage?: Storage): Storage {
+  if (storage) return storage;
+  if (typeof window === "undefined") throw new Error("Storage unavailable");
+  return window.localStorage;
+}
+
+export function findingsError(error: unknown): FindingsError {
+  const name = (error as Error)?.name;
+  return name === "SyntaxError"
+    ? { kind: "corrupt", message: "Saved findings are damaged or invalid. They have not been replaced." }
+    : name === "QuotaExceededError"
+      ? { kind: "quota", message: "Browser storage is full. Findings are kept in memory." }
+      : { kind: "access", message: "Browser storage could not be accessed. Findings are kept in memory." };
+}
+
+export function readFindings(sessionId: string, storage?: Storage): { items: Finding[] | null; error: FindingsError | null; exists?: boolean } {
+  try {
+    const raw = getStorage(storage).getItem(FINDINGS_PREFIX + sessionId);
+    if (raw === null) return { items: [], error: null, exists: false };
+    const data = objectRecord(JSON.parse(raw));
+    if (data.version !== 1 || data.sessionId !== sessionId) throw new SyntaxError("Invalid findings store");
+    return { items: validateItems(data.items), error: null, exists: true };
+  } catch (error) { return { items: null, error: findingsError(error) }; }
+}
+
+// Merge only edits relative to the caller's baseline. A/B copies and other tabs
+// may add different findings without losing each other's work.
+export function saveFindings(sessionId: string, items: Finding[], baseline: Finding[] | null, storage?: Storage) {
+  const latest = readFindings(sessionId, storage);
+  if (latest.error) return latest;
+  if (baseline === null && latest.items!.length) return {
+    items: null, error: { kind: "conflict", message: "Saved findings are now available. Download your edits, then reload saved findings before editing." },
+  };
+  const base = new Map((baseline || []).map(item => [item.id, item]));
+  const next = new Map(items.map(item => [item.id, item]));
+  const merged = new Map(latest.items!.map(item => [item.id, item]));
+  for (const id of new Set([...base.keys(), ...next.keys()])) {
+    if (canonical(base.get(id)) === canonical(next.get(id))) continue;
+    if (canonical(merged.get(id)) !== canonical(base.get(id)) && canonical(merged.get(id)) !== canonical(next.get(id))) {
+      return { items: null, error: { kind: "conflict", message: "This finding changed in another view or tab. Download your edits, then reload saved findings." } };
+    }
+    if (next.has(id)) merged.set(id, next.get(id)!);
+    else merged.delete(id);
+  }
+  try {
+    const saved = validateItems(Array.from(merged.values()));
+    getStorage(storage).setItem(FINDINGS_PREFIX + sessionId, JSON.stringify({ version: 1, sessionId, items: saved }));
+    return { items: saved, error: null };
+  } catch (error) { return { items: null, error: findingsError(error) }; }
+}

--- a/tests/e2e/export-portability.spec.js
+++ b/tests/e2e/export-portability.spec.js
@@ -41,6 +41,14 @@ test.beforeAll(async function ({ browser }, testInfo) {
   await page.goto(origin + "/");
   await page.locator('input[type="file"]').setInputFiles(fixturePath);
   await expect(page.getByText("Ready", { exact: true })).toBeVisible();
+  await page.getByRole("button", { name: /Investigate,/ }).click();
+  await page.locator('[data-event-index="0"]').click();
+  await page.getByRole("button", { name: "Add note", exact: true }).click();
+  await page.getByRole("textbox", { name: "Event note" }).fill("Shared note </script> & plain text");
+  await page.getByRole("button", { name: "Save note", exact: true }).click();
+  await page.locator('[data-event-index="1"]').click();
+  await page.getByRole("button", { name: "Add note", exact: true }).click();
+  await page.getByRole("textbox", { name: "Event note" }).fill("Unfinished shared draft");
 
   var downloadPromise = page.waitForEvent("download");
   await page.getByRole("button", { name: "Export", exact: true }).first().click();
@@ -56,6 +64,11 @@ test.beforeAll(async function ({ browser }, testInfo) {
     name: "comparison-b.jsonl", mimeType: "application/json", buffer: Buffer.from(secondText),
   });
   await expect(page).toHaveURL(/review$/);
+  await page.getByRole("button", { name: /Investigate,/ }).click();
+  await page.locator('[data-event-index="0"]').click();
+  await page.getByRole("button", { name: "Add note", exact: true }).click();
+  await page.getByRole("textbox", { name: "Event note" }).fill("Comparison B note");
+  await page.getByRole("button", { name: "Save note", exact: true }).click();
   await page.getByRole("button", { name: /Compare, / }).click();
   await page.getByRole("button", { name: /Can you add a hello world function/ }).click();
   await expect(page.getByRole("button", { name: "Coach session B" })).toBeVisible();
@@ -123,6 +136,9 @@ test("comparison export rehydrates both runs and opens either in Improve offline
     await expect(opened.page.getByText("Session coaching:", { exact: false })).toBeVisible();
     await opened.page.getByRole("button", { name: "Investigate, Evidence stream", exact: true }).click();
     await expect(opened.page.getByText(side === "A" ? "Review the comparison fixture" : "Can you add a hello world function to utils.js?", { exact: true })).toBeVisible();
+    await opened.page.getByRole("button", { name: "Bookmarks (1)", exact: true }).click();
+    await expect(opened.page.getByRole("region", { name: "Bookmarks" }).getByText(side === "A" ? "Comparison B note" : "Shared note </script> & plain text", { exact: true })).toBeVisible();
+    await expect(opened.page.getByText(side === "A" ? "Shared note </script> & plain text" : "Comparison B note", { exact: true })).toHaveCount(0);
     expect(opened.attempted).toEqual([]);
     expect(opened.failures).toEqual([]);
     await opened.context.close();
@@ -139,6 +155,11 @@ test("exported HTML renders the session from file:// with the network blocked", 
   await expect(
     opened.page.getByText("Can you add a hello world function to utils.js?")
   ).toBeVisible();
+  await opened.page.getByRole("button", { name: "Bookmarks (1)", exact: true }).click();
+  await expect(opened.page.getByRole("region", { name: "Bookmarks" }).getByText("Shared note </script> & plain text", { exact: true })).toBeVisible();
+  await expect(opened.page.getByRole("region", { name: "Bookmarks" }).getByText("Unfinished shared draft", { exact: true })).toBeVisible();
+  await opened.page.getByRole("button", { name: "Jump to bookmarked event 2", exact: true }).click();
+  await expect(opened.page.getByRole("textbox", { name: "Event note", exact: true })).toHaveValue("Unfinished shared draft");
   await opened.page.getByRole("button", { name: "Analyze, Deep panels", exact: true }).click();
   await opened.page.getByRole("tab", { name: "Graph", exact: true }).click();
   await expect(opened.page.getByRole("tree")).toBeVisible();

--- a/tests/e2e/findings.spec.js
+++ b/tests/e2e/findings.spec.js
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+
+var text = [
+  { type: "user", uuid: "user-one", sessionId: "findings-fixture", timestamp: "2026-01-15T10:00:00.000Z", message: { role: "user", content: "First exact event" } },
+  { type: "assistant", uuid: "assistant-two", sessionId: "findings-fixture", timestamp: "2026-01-15T10:00:00.000Z", message: { role: "assistant", content: [{ type: "text", text: "Second equal-time event" }] } },
+].map(JSON.stringify).join("\n");
+
+async function open(page) {
+  await page.route("**/api/meta", function (route) { return route.fulfill({ json: {} }); });
+  await page.route("**/api/sessions", function (route) { return route.fulfill({ json: [] }); });
+  await page.goto("/");
+  await page.locator('input[type="file"]').setInputFiles({ name: "findings.jsonl", mimeType: "application/json", buffer: Buffer.from(text) });
+  await expect(page).toHaveURL(/review$/);
+  await page.getByRole("button", { name: /Investigate,/ }).click();
+}
+
+async function note(page, index, value) {
+  await page.locator('[data-event-index="' + index + '"]').click();
+  await page.getByRole("button", { name: "Add note", exact: true }).click();
+  await page.getByRole("textbox", { name: "Event note" }).fill(value);
+  await page.getByRole("button", { name: "Save note", exact: true }).click();
+}
+
+for (let width of [1400, 600]) {
+  test("bookmarks create, edit, exact jump and reopen at " + width + "px", async function ({ page }) {
+    await page.setViewportSize({ width: width, height: 860 });
+    await open(page);
+    await note(page, 0, "Note for zero");
+    await note(page, 1, "Note for equal time");
+    await page.getByRole("button", { name: "Bookmarks (2)", exact: true }).click();
+    var panel = page.getByRole("region", { name: "Bookmarks", exact: true });
+    await expect(panel.getByText("Note for zero")).toBeVisible();
+    await panel.getByRole("button", { name: "Jump to bookmarked event 1" }).click();
+    await page.getByRole("button", { name: "Edit note", exact: true }).click();
+    await expect(page.getByRole("textbox", { name: "Event note" })).toHaveValue("Note for zero");
+    await page.getByRole("textbox", { name: "Event note" }).fill("Updated zero");
+    await page.getByRole("button", { name: "Save note", exact: true }).click();
+    await panel.getByRole("button", { name: "Jump to bookmarked event 2" }).click();
+    await page.getByRole("button", { name: "Edit note", exact: true }).click();
+    await expect(page.getByRole("textbox", { name: "Event note" })).toHaveValue("Note for equal time");
+    await page.getByRole("button", { name: "Cancel note", exact: true }).click();
+    var bounds = await panel.boundingBox();
+    expect(bounds.x).toBeGreaterThanOrEqual(0);
+    expect(bounds.x + bounds.width).toBeLessThanOrEqual(width);
+    expect(bounds.y + bounds.height).toBeLessThanOrEqual(860);
+    expect(await page.evaluate(function () { return document.documentElement.scrollWidth <= window.innerWidth; })).toBe(true);
+    await page.reload();
+    await page.getByRole("button", { name: /Find,/ }).click();
+    await page.getByRole("article", { name: "First exact event" }).getByRole("button", { name: "Open", exact: true }).click();
+    await expect(page).toHaveURL(/review$/);
+    await page.getByRole("button", { name: /Investigate,/ }).click();
+    await page.getByRole("button", { name: "Bookmarks (2)", exact: true }).click();
+    await expect(page.getByRole("region", { name: "Bookmarks" }).getByText("Updated zero")).toBeVisible();
+    await expect(page.getByRole("region", { name: "Bookmarks" }).getByText("Note for equal time")).toBeVisible();
+  });
+}
+
+test("note draft survives zones and failed save supports retry and backup restore", async function ({ page }) {
+  await open(page);
+  await page.locator('[data-event-index="0"]').click();
+  await page.getByRole("button", { name: "Add note", exact: true }).click();
+  await page.getByRole("textbox", { name: "Event note" }).fill("Draft across zones");
+  await page.getByRole("button", { name: /Analyze,/ }).click();
+  await page.getByRole("button", { name: /Investigate,/ }).click();
+  await page.getByRole("button", { name: "Bookmarks", exact: true }).click();
+  await page.getByRole("button", { name: "Jump to bookmarked event 1" }).click();
+  await expect(page.getByRole("textbox", { name: "Event note" })).toHaveValue("Draft across zones");
+  await page.evaluate(function () {
+    window.originalFindingsWrite = Storage.prototype.setItem;
+    Storage.prototype.setItem = function (key, value) {
+      if (key.startsWith("agentviz:findings:v1:")) throw new DOMException("Full", "QuotaExceededError");
+      return window.originalFindingsWrite.call(this, key, value);
+    };
+  });
+  await page.getByRole("button", { name: "Save note", exact: true }).click();
+  await expect(page.getByText(/Browser storage is full. Findings are kept in memory/).first()).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "Event note" })).toHaveValue("Draft across zones");
+  var downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Download findings", exact: true }).first().click();
+  var download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("agentviz-findings.json");
+  var chunks = [];
+  for await (var chunk of await download.createReadStream()) chunks.push(chunk);
+  var backup = Buffer.concat(chunks);
+  expect(JSON.parse(backup).items[0].note).toBe("Draft across zones");
+  await page.evaluate(function () { Storage.prototype.setItem = window.originalFindingsWrite; });
+  await page.getByRole("button", { name: "Retry findings save", exact: true }).first().click();
+  await expect(page.getByText(/Browser storage is full. Findings are kept in memory/)).toHaveCount(0);
+  await expect(page.getByRole("textbox", { name: "Event note" })).toHaveCount(0);
+  var panel = page.getByRole("region", { name: "Bookmarks" });
+  await panel.getByRole("button", { name: "Remove bookmark and note" }).click();
+  await expect(panel.getByText("No bookmarks yet.", { exact: false })).toBeVisible();
+  await panel.getByLabel("Restore findings backup").setInputFiles({ name: "backup.json", mimeType: "application/json", buffer: backup });
+  await panel.getByRole("button", { name: "Replace with backup", exact: true }).click();
+  await expect(panel.getByText("Draft across zones", { exact: true })).toBeVisible();
+  expect(await page.evaluate(function () {
+    return Object.keys(localStorage).filter(function (key) { return key.startsWith("agentviz:session-content:"); }).map(function (key) { return localStorage.getItem(key); });
+  })).toEqual([text]);
+});
+
+test("live worker reset retains unavailable bookmarks without rebinding them", async function ({ page }) {
+  await page.addInitScript(function () {
+    window.EventSource = class {
+      constructor() { window.findingsStream = this; }
+      close() {}
+    };
+  });
+  await page.route("**/api/meta", function (route) { return route.fulfill({ json: { filename: "live.jsonl", live: true } }); });
+  await page.route("**/api/file?live=1", function (route) { return route.fulfill({ contentType: "text/plain", body: text + "\n" }); });
+  await page.route("**/api/sessions", function (route) { return route.fulfill({ json: [] }); });
+  await page.goto("/");
+  await expect(page.getByRole("button", { name: "Close session", exact: true })).toBeVisible();
+  await page.getByRole("button", { name: /Investigate,/ }).click();
+  await page.locator('[data-event-index="0"]').click();
+  await page.getByRole("button", { name: "Bookmark event", exact: true }).click();
+  await page.getByRole("button", { name: "Bookmarks (1)", exact: true }).click();
+  await page.evaluate(function () { window.findingsStream.onmessage({ data: JSON.stringify({ reset: true, lines: "" }) }); });
+  var panel = page.getByRole("region", { name: "Bookmarks" });
+  await expect(panel.getByText("Unavailable in this snapshot")).toBeVisible();
+  await expect(panel.getByRole("button", { name: "Jump to bookmarked event 1" })).toBeDisabled();
+  await page.evaluate(function (replacement) { window.findingsStream.onmessage({ data: JSON.stringify({ lines: replacement }) }); },
+    text.replace("First exact event", "Different event after reset").replace("user-one", "new-user") + "\n");
+  await expect(page.getByText("Different event after reset", { exact: true }).first()).toBeVisible();
+  await expect(panel.getByRole("button", { name: "Jump to bookmarked event 1" })).toBeDisabled();
+  await page.evaluate(function (original) { window.findingsStream.onmessage({ data: JSON.stringify({ reset: true, lines: original }) }); }, text + "\n");
+  await expect(panel.getByRole("button", { name: "Jump to bookmarked event 1" })).toBeEnabled();
+  await panel.getByRole("button", { name: "Jump to bookmarked event 1" }).click();
+  await expect(page.getByRole("button", { name: "Remove bookmark", exact: true }).last()).toBeVisible();
+});


### PR DESCRIPTION
## Why

Investigating a session should produce findings that users can revisit and share, rather than lose when they leave the replay. This adds event bookmarks and plain-text notes without changing raw transcripts or tying notes to transient playback state.

## Approach

- Extend Investigate with bookmark/note actions and a paginated Bookmarks list that jumps to exact original event indices, including index zero and equal-time events.
- Keep findings and drafts with each session loader. Saved findings survive reopening; drafts survive zone changes and failed loads. Findings persistence is independent of transcript storage, with visible failure, retry, conflict recovery, and JSON backup/restore controls.
- Guard event identity using source/action fingerprints, occurrence, original index, and prefix evidence. Changed or reordered evidence remains visible as unavailable rather than being rebound by timestamp.
- Include findings and drafts in single-session and A/B HTML exports. Validate session/snapshot ownership and isolate offline-export edits from ordinary local notes. Legacy exports remain supported.

## Boundaries and trade-offs

This is event-level annotation only, not session-wide notes, tags, collaboration, or a storage-engine migration. Notes are plain text, capped at 20,000 characters. Explicit session IDs preserve identity across snapshots; inferred identities are conservative and identical copied source identities cannot be distinguished. Changes to preceding evidence may make later anchors unavailable. localStorage has no cross-tab transactions, though baseline-aware merges preserve independent edits and reject detected conflicts.

Drafts are not automatically persisted: save or download them before Close, replacement, or reload. Exports include notes and drafts, so users should review them before sharing.

## Validation

- Final full suite: 1,122 tests passed across 67 files; typecheck passed.
- Production build passed, retaining the existing bundle-size advisory.
- Final targeted browser run: 12 tests passed covering desktop/compact bookmark editing, exact navigation, reopen, failed-save recovery, backup restore, live reset, and Chromium/WebKit offline exports.
- Mechanical UI scan, documentation link checks, and diff checks passed.

README, architecture, style guide, and shared agent guidance are updated; palette tokens are unchanged. Documented screenshot regeneration is deferred pending explicit approval, so the existing Investigate screenshot does not yet show the Bookmarks control. No backlog issues are implemented or closed by reference.